### PR TITLE
Update api_views.py

### DIFF
--- a/apps/channels/api_views.py
+++ b/apps/channels/api_views.py
@@ -267,6 +267,8 @@ class ChannelViewSet(viewsets.ModelViewSet):
         channel_number = None
         if 'tv-chno' in stream_custom_props:
             channel_number = int(stream_custom_props['tv-chno'])
+        elif 'tvg-chno' in stream_custom_props:
+            channel_number = int(stream_custom_props['tvg-chno'])
         elif 'channel-number' in stream_custom_props:
             channel_number = int(stream_custom_props['channel-number'])
 


### PR DESCRIPTION
This is fix is for adding tvg-chno to Dispatcharr, and enable Dispatcharr to take channel numbers over from tvheadend.
Code is not tested but i think this is not a major due to a copy the same line and add tvg-chno to it.

my commit notes: 
Add support for tvg-chno channel number tag.
I don't know that tv-chno is a valet tag or a typo and due to this create a new elif statement to fix this bug.