### PR TITLE
apps: output: views.py: exclude M3U endpointfrom CSRF protection

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -3,10 +3,12 @@ from django.urls import reverse
 from apps.channels.models import Channel, ChannelProfile
 from apps.epg.models import ProgramData
 from django.utils import timezone
+from django.views.decorators.csrf import csrf_exempt
 from datetime import datetime, timedelta
 import re
 import html  # Add this import for XML escaping
 
+@csrf_exempt
 def generate_m3u(request, profile_name=None):
     """
     Dynamically generate an M3U file from channels.


### PR DESCRIPTION
Excludes the M3U generation view from CSRF protection. This allows IPTV Smarters apps (I only tested on Android) to access the playlist. Otherwise a 403 error is returned because instead of an GET request these apps are doing a POST request with empty body to the endpoint.
