### PR TITLE
add git to enable macos node build to function

### DIFF
--- a/docker/DispatcharrBase
+++ b/docker/DispatcharrBase
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libpcre3 libpcre3-dev libpq-dev procps \
     build-essential gcc pciutils \
     nginx streamlink \
+    git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # --- Create Python virtual environment ---


### PR DESCRIPTION
Without git in base image the dev build is impossible on macos due to node module sourcing files from git using the base image. I tested by writing extension dockerfile like below which proved adding GIT enabled me to continue moving forward on having a single dev process that works inclusively with apple silicon. This is first step in a few other changes that will be required.

FROM ghcr.io/dispatcharr/dispatcharr:base

RUN apt-get update && apt-get install -y git

Not sure who needs to review and test this, not trying to break anything for windows users.