### PR TITLE
Add Support for Github Organization Issue Type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug Report
 description: I have an issue with Dispatcharr
 title: "[Bug]: "
 labels: ["Bug", "Triage"]
+type: "Bug"
 projects: []
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature request
 description: I want to suggest a new feature for Dispatcharr
 title: "[Feature]: "
 labels: ["Feature Request"]
+type: "Feature"
 projects: []
 assignees: []
 body:


### PR DESCRIPTION
I did not see these during my testing as my testing repo was not a part of an Organization. 

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax

An example of the types in use is available here: 
![image](https://github.com/user-attachments/assets/40336de8-a400-4a12-a2b9-ba9e29040727)
