### PR TITLE
tweak: only show sidebar when logged in

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -102,15 +102,17 @@ const App = () => {
               height: 0,
             }}
             navbar={{
-              width: open ? drawerWidth : miniDrawerWidth,
+              width: isAuthenticated ? (open ? drawerWidth : miniDrawerWidth) : 0,
             }}
           >
-            <Sidebar
-              drawerWidth
-              miniDrawerWidth
-              collapsed={!open}
-              toggleDrawer={toggleDrawer}
-            />
+            {isAuthenticated && (
+              <Sidebar
+                drawerWidth
+                miniDrawerWidth
+                collapsed={!open}
+                toggleDrawer={toggleDrawer}
+              />
+            )}
 
             <AppShell.Main>
               <Box


### PR DESCRIPTION
It's a bit confusing when the sidebar and its items are shown but navigating to them leads to the login screen being shown anyway, so hiding them is ideal.

