### PR TITLE
feat: add logo to login form

### DIFF
--- a/frontend/src/components/Logo.jsx
+++ b/frontend/src/components/Logo.jsx
@@ -1,0 +1,25 @@
+import logo from '../images/logo.png';
+
+function Logo({ width = 30, showText = true }) {
+  return (
+    <>
+      <img width={width} src={logo} />
+      {showText && (
+        <Text
+          sx={{
+            opacity: showText ? 1 : 0,
+            transition: 'opacity 0.2s ease-in-out',
+            whiteSpace: 'nowrap', // Ensures text never wraps
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            minWidth: showText ? 150 : 0, // Prevents reflow
+          }}
+        >
+          Dispatcharr
+        </Text>
+      )}
+    </>
+  )
+}
+
+export default Logo

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -22,7 +22,6 @@ import {
   TextInput,
   ActionIcon,
 } from '@mantine/core';
-import logo from '../images/logo.png';
 import useChannelsStore from '../store/channels';
 import './sidebar.css';
 import useSettingsStore from '../store/settings';
@@ -166,21 +165,7 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
         }}
       >
         {/* <ListOrdered size={24} /> */}
-        <img width={30} src={logo} />
-        {!collapsed && (
-          <Text
-            sx={{
-              opacity: collapsed ? 0 : 1,
-              transition: 'opacity 0.2s ease-in-out',
-              whiteSpace: 'nowrap', // Ensures text never wraps
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              minWidth: collapsed ? 0 : 150, // Prevents reflow
-            }}
-          >
-            Dispatcharr
-          </Text>
-        )}
+        <Logo showText={!collapsed} />
       </Group>
 
       {/* Navigation Links */}

--- a/frontend/src/components/forms/LoginForm.jsx
+++ b/frontend/src/components/forms/LoginForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useAuthStore from '../../store/auth';
 import { Paper, Title, TextInput, Button, Center, Stack } from '@mantine/core';
+import Logo from "../Logo";
 
 const LoginForm = () => {
   const login = useAuthStore((s) => s.login);
@@ -34,9 +35,15 @@ const LoginForm = () => {
   return (
     <Center
       style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        rowGap: 32,
+
         height: '100vh',
       }}
     >
+      <Logo />
       <Paper
         elevation={3}
         style={{ padding: 30, width: '100%', maxWidth: 400 }}


### PR DESCRIPTION
This is meant to be used alongside the [other PR](https://github.com/Dispatcharr/Dispatcharr/pull/120) I've made featuring the sidebar change.

Key changes:
- Added a centralized `Logo` component
- Migrated the logo displayed in the sidebar to the new component
- Added the logo to the login form

The new Logo component accepts two props, one for the logo width, and one for showing/hiding the logo text. This will make it easier to change the logo (and its text) throughout the app in future changes as we won't have to comb through the app and update every instance of it.

I didn't want to update other instances of logo usage as to prevent merge conflicts so I've left them be for now.

