### PR TITLE
Remove Redundant Issue Form Labels | Triage Feature Requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: I have an issue with Dispatcharr
 title: "[Bug]: "
-labels: ["Bug", "Triage"]
+labels: ["Triage"]
 type: "Bug"
 projects: []
 assignees: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: I want to suggest a new feature for Dispatcharr
 title: "[Feature]: "
-labels: ["Feature Request"]
+labels: ["Feature Request", "Triage"]
 type: "Feature"
 projects: []
 assignees: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: I want to suggest a new feature for Dispatcharr
 title: "[Feature]: "
-labels: ["Feature Request", "Triage"]
+labels: ["Triage"]
 type: "Feature"
 projects: []
 assignees: []


### PR DESCRIPTION
2 Small changes 

 - Now that we have types fully setup and the new bot can use them, there is no need for the redundant feature request and bug labels, so they have been removed from the form templates
 - Feature requests could also benefit from being triaged , so added the triage tag to that form template as well