### PR TITLE
Add update UI and help resources

### DIFF
--- a/core/api_urls.py
+++ b/core/api_urls.py
@@ -2,7 +2,14 @@
 
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .api_views import UserAgentViewSet, StreamProfileViewSet, CoreSettingsViewSet, environment, version
+from .api_views import (
+    UserAgentViewSet,
+    StreamProfileViewSet,
+    CoreSettingsViewSet,
+    environment,
+    version,
+    check_update,
+)
 
 router = DefaultRouter()
 router.register(r'useragents', UserAgentViewSet, basename='useragent')
@@ -12,5 +19,6 @@ router.register(r'settings', CoreSettingsViewSet, basename='settings')
 urlpatterns = [
     path('settings/env/', environment, name='token_refresh'),
     path('version/', version, name='version'),
+    path('check_update/', check_update, name='check_update'),
     path('', include(router.urls)),
 ]

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -114,3 +114,28 @@ def version(request):
         'update_version': update_version,
         'update_url': update_url,
     })
+
+
+@swagger_auto_schema(
+    method='post',
+    operation_description="Manually check for available updates",
+    responses={200: "Version information"},
+)
+@api_view(['POST'])
+def check_update(request):
+    """Trigger an update check and return version info."""
+    from version import __version__, __timestamp__
+    from core.tasks import check_for_update
+
+    # Run the check synchronously to immediately update DB values
+    check_for_update()
+
+    update_version = CoreSettings.get_available_update_version()
+    update_url = CoreSettings.get_available_update_url()
+
+    return Response({
+        'version': __version__,
+        'timestamp': __timestamp__,
+        'update_version': update_version,
+        'update_url': update_url,
+    })

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import Guide from './pages/Guide';
 import Stats from './pages/Stats';
 import DVR from './pages/DVR';
 import Settings from './pages/Settings';
+import Help from './pages/Help';
 import useAuthStore from './store/auth';
 import FloatingVideo from './components/FloatingVideo';
 import { WebsocketProvider } from './WebSocket';
@@ -138,6 +139,7 @@ const App = () => {
                     ) : (
                       <Route path="/login" element={<Login needsSuperuser />} />
                     )}
+                    <Route path="/help" element={<Help />} />
                     <Route
                       path="*"
                       element={

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1084,6 +1084,19 @@ export default class API {
     }
   }
 
+  static async checkForUpdate() {
+    try {
+      const response = await request(`${host}/api/core/check_update/`, {
+        method: 'POST',
+        auth: false,
+      });
+
+      return response;
+    } catch (e) {
+      errorNotification('Failed to check for updates', e);
+    }
+  }
+
   static async updateSetting(values) {
     const { id, ...payload } = values;
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -10,6 +10,7 @@ import {
   Copy,
   ChartLine,
   Video,
+  HelpCircle,
 } from 'lucide-react';
 import {
   Avatar,
@@ -115,6 +116,11 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
       label: 'Settings',
       icon: <LucideSettings size={20} />,
       path: '/settings',
+    },
+    {
+      label: 'Help',
+      icon: <HelpCircle size={20} />,
+      path: '/help',
     },
   ];
 

--- a/frontend/src/components/forms/LoginForm.jsx
+++ b/frontend/src/components/forms/LoginForm.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useAuthStore from '../../store/auth';
-import { Paper, Title, TextInput, Button, Center, Stack } from '@mantine/core';
+import API from '../../api';
+import { Paper, Title, TextInput, Button, Center, Stack, Text } from '@mantine/core';
 
 const LoginForm = () => {
   const login = useAuthStore((s) => s.login);
@@ -10,12 +11,28 @@ const LoginForm = () => {
 
   const navigate = useNavigate(); // Hook to navigate to other routes
   const [formData, setFormData] = useState({ username: '', password: '' });
+  const [version, setVersion] = useState('');
+  const [timestamp, setTimestamp] = useState(null);
 
   useEffect(() => {
     if (isAuthenticated) {
       navigate('/channels');
     }
   }, [isAuthenticated, navigate]);
+
+  useEffect(() => {
+    const fetchVersion = async () => {
+      try {
+        const data = await API.getVersion();
+        setVersion(data.version || '');
+        setTimestamp(data.timestamp || null);
+      } catch (e) {
+        console.error('Failed to fetch version info:', e);
+      }
+    };
+
+    fetchVersion();
+  }, []);
 
   const handleInputChange = (e) => {
     setFormData({
@@ -66,6 +83,9 @@ const LoginForm = () => {
             <Button type="submit" mt="sm">
               Login
             </Button>
+            <Text size="xs" ta="right" c="dimmed">
+              v{version || '0.0.0'}{timestamp ? `-${timestamp}` : ''}
+            </Text>
           </Stack>
         </form>
       </Paper>

--- a/frontend/src/pages/Help.jsx
+++ b/frontend/src/pages/Help.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Box, Title, Stack, Anchor, Text } from '@mantine/core';
+import useSettingsStore from '../store/settings';
+
+const Help = () => {
+  const environment = useSettingsStore((s) => s.environment);
+  const swaggerUrl = `${window.location.origin}/swagger/`;
+
+  return (
+    <Box p="md">
+      <Title order={3} mb="md">
+        Help & Resources
+      </Title>
+      <Stack gap={8}>
+        <Text>
+          <Anchor href={swaggerUrl} target="_blank" rel="noopener noreferrer">
+            API Swagger Documentation
+          </Anchor>
+        </Text>
+        <Text>
+          <Anchor href="https://dispatcharr.github.io/Dispatcharr-Docs/" target="_blank" rel="noopener noreferrer">
+            Dispatcharr Documentation
+          </Anchor>
+        </Text>
+        <Text>
+          <Anchor href="https://discord.gg/aMqkWsydMH" target="_blank" rel="noopener noreferrer">
+            Discord
+          </Anchor>
+        </Text>
+      </Stack>
+    </Box>
+  );
+};
+
+export default Help;


### PR DESCRIPTION
## Summary
- expose `check_update` endpoint and wire it up
- show version details with update section in Settings
- add help page with links to docs, swagger, and Discord
- show running version on login form
- add Help entry to sidebar navigation

