### PR TITLE
Update dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,33 @@
-Django==5.1.6
+Django==5.2.4
 psycopg2-binary==2.9.10
-redis==4.5.5
+redis==6.2.0
 celery
 celery[redis]
-djangorestframework==3.15.2
-requests==2.32.3
+djangorestframework==3.16.0
+requests==2.32.4
 psutil==7.0.0
 pillow
 drf-yasg>=1.20.0
 streamlink
 python-vlc
 yt-dlp
-gevent==24.11.1
+gevent==25.5.1
 daphne
 uwsgi
 django-cors-headers
 djangorestframework-simplejwt
 m3u8
-rapidfuzz==3.12.1
+rapidfuzz==3.13.0
 tzlocal
 
 # PyTorch dependencies (CPU only)
 --extra-index-url https://download.pytorch.org/whl/cpu/
-torch==2.6.0+cpu
+torch==2.7.1+cpu
 
 # ML/NLP dependencies
-sentence-transformers==3.4.1
+sentence-transformers==5.0.0
 channels
-channels-redis
+channels-redis==4.3.0
 django-filter
 django-celery-beat
-lxml==5.4.0
+lxml==6.0.0


### PR DESCRIPTION
This pull request updates most of the pinned dependencies in requirements.txt to their latest available versions, based on the results from pip list --outdated. The only exception is Celery, which remains at version 5.3.0 due to compatibility considerations.

The following packages were updated to their latest versions:

Django: 5.1.6 → 5.2.4
channels-redis: 4.1.0 → 4.3.0
djangorestframework: 3.15.2 → 3.16.0
gevent: 24.11.1 → 25.5.1
lxml: 5.4.0 → 6.0.0
RapidFuzz: 3.12.1 → 3.13.0
redis: 4.5.5 → 6.2.0
requests: 2.32.3 → 2.32.4
sentence-transformers: 3.4.1 → 5.0.0
torch: 2.6.0+cpu → 2.7.1+cpu
Package Not Updated
Celery: Remains at 5.3.0 (latest is 5.5.3)