### PR TITLE
Fix: Prevent memory exhaustion when extracting large compressed files

### DIFF
--- a/apps/epg/tasks.py
+++ b/apps/epg/tasks.py
@@ -645,7 +645,7 @@ def extract_compressed_file(file_path, output_path=None, delete_original=False):
                     with open(extracted_path, 'wb') as out_file:
                         while True:
                             chunk = gz_file.read(MAX_EXTRACT_CHUNK_SIZE)
-                            if not chunk:
+                            if not chunk or len(chunk) == 0:
                                 break
                             out_file.write(chunk)
             except Exception as e:
@@ -695,7 +695,7 @@ def extract_compressed_file(file_path, output_path=None, delete_original=False):
                     with zip_file.open(xml_files[0], "r") as xml_file:
                         while True:
                             chunk = xml_file.read(MAX_EXTRACT_CHUNK_SIZE)
-                            if not chunk:
+                            if not chunk or len(chunk) == 0:
                                 break
                             out_file.write(chunk)
 


### PR DESCRIPTION
I've found for some reason on the latest version of Dispatcharr the background tasks would be killed by Linux's OOM handler when Dispatcharr attempts to extract large compressed files such as https://epgshare01.online/epgshare01/epg_ripper_ALL_SOURCES1.xml.gz

I've managed to solve this by implementing a chunked extractor currently set to a max size of 64kb. Here is a graph of memory usage showing before and after. The peak of 4gb is where it tried to extract and ultimately failed, while the dip is where I stopped the services to apply this change, and where the dot is, was where the same extraction function was ran again.

<img width="984" height="333" alt="image" src="https://github.com/user-attachments/assets/79000594-af1d-4c61-846c-0495d9cf5353" />

Its a similar story over the past day too:

<img width="984" height="333" alt="image" src="https://github.com/user-attachments/assets/7222853b-3e92-43da-ae94-d402c6c067e4" />
