### PR TITLE
Fix f-string formatting

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -266,11 +266,11 @@ def generate_dummy_epg(
 
         # Create program entry with escaped channel name
         xml_lines.append(
-            f'  <programme start="{start_str}" stop="{stop_str}" channel="{program["channel_id"]}">'
+            f"""  <programme start="{start_str}" stop="{stop_str}" channel="{program['channel_id']}">"""
         )
         xml_lines.append(f"    <title>{html.escape(program['title'])}</title>")
         xml_lines.append(f"    <desc>{html.escape(program['description'])}</desc>")
-        xml_lines.append(f"  </programme>")
+        xml_lines.append("  </programme>")
 
     return xml_lines
 


### PR DESCRIPTION
I've noticed on a few occasions now the f-string formatting causes celery to crash with the following:

```
Aug 08 23:09:05 threadfin celery[10257]:   File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
Aug 08 23:09:05 threadfin celery[10257]:   File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
Aug 08 23:09:05 threadfin celery[10257]:   File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
Aug 08 23:09:05 threadfin celery[10257]:   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
Aug 08 23:09:05 threadfin celery[10257]:   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
Aug 08 23:09:05 threadfin celery[10257]:   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
Aug 08 23:09:05 threadfin celery[10257]:   File "/opt/dispatcharr/dispatcharr/urls.py", line 10, in <module>
Aug 08 23:09:05 threadfin celery[10257]:     from apps.output.views import xc_player_api, xc_panel_api, xc_get, xc_xmltv
Aug 08 23:09:05 threadfin celery[10257]:   File "/opt/dispatcharr/apps/output/views.py", line 269
Aug 08 23:09:05 threadfin celery[10257]:     f'  <programme start="{start_str}" stop="{stop_str}" channel="{program['channel_id']}">'
Aug 08 23:09:05 threadfin celery[10257]:                                                                             ^^^^^^^^^^
Aug 08 23:09:05 threadfin celery[10257]: SyntaxError: f-string: unmatched '['
```

This PR fixes the formatting of f-strings, using a triple quote as the boundary allows us to "register" apos and quotes within the string itself without f-string "thinking" that the string has ended prematurely.