### PR TITLE
Switch to api calls instead of celery beat for stats

### DIFF
--- a/apps/proxy/ts_proxy/views.py
+++ b/apps/proxy/ts_proxy/views.py
@@ -28,6 +28,7 @@ from apps.accounts.permissions import (
 from .constants import ChannelState, EventType, StreamType, ChannelMetadataField
 from .config_helper import ConfigHelper
 from .services.channel_service import ChannelService
+from core.utils import send_websocket_update
 from .url_utils import (
     generate_stream_url,
     transform_url,
@@ -632,6 +633,18 @@ def channel_status(request, channel_id=None):
 
                 if cursor == 0:
                     break
+
+            # Send WebSocket update with the stats
+            # Format it the same way the original Celery task did
+            send_websocket_update(
+                "updates",
+                "update",
+                {
+                    "success": True,
+                    "type": "channel_stats",
+                    "stats": json.dumps({'channels': all_channels, 'count': len(all_channels)})
+                }
+            )
 
             return JsonResponse({"channels": all_channels, "count": len(all_channels)})
 

--- a/dispatcharr/settings.py
+++ b/dispatcharr/settings.py
@@ -198,10 +198,8 @@ CELERY_TASK_SERIALIZER = "json"
 
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"
 CELERY_BEAT_SCHEDULE = {
-    "fetch-channel-statuses": {
-        "task": "apps.proxy.tasks.fetch_channel_stats",  # Direct task call
-        "schedule": 2.0,  # Every 2 seconds
-    },
+    # Remove the frequent fetch-channel-statuses task
+    # Stats are now fetched via API calls from the frontend
     "scan-files": {
         "task": "core.tasks.scan_and_process_files",  # Direct task call
         "schedule": 20.0,  # Every 20 seconds

--- a/dispatcharr/settings.py
+++ b/dispatcharr/settings.py
@@ -198,8 +198,14 @@ CELERY_TASK_SERIALIZER = "json"
 
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"
 CELERY_BEAT_SCHEDULE = {
-    # Remove the frequent fetch-channel-statuses task
-    # Stats are now fetched via API calls from the frontend
+    # Explicitly disable the old fetch-channel-statuses task
+    # This ensures it gets disabled when DatabaseScheduler syncs
+    "fetch-channel-statuses": {
+        "task": "apps.proxy.tasks.fetch_channel_stats",
+        "schedule": 2.0,  # Original schedule (doesn't matter since disabled)
+        "enabled": False,  # Explicitly disabled
+    },
+    # Keep the file scanning task
     "scan-files": {
         "task": "core.tasks.scan_and_process_files",  # Direct task call
         "schedule": 20.0,  # Every 20 seconds

--- a/frontend/src/WebSocket.jsx
+++ b/frontend/src/WebSocket.jsx
@@ -194,7 +194,9 @@ export const WebsocketProvider = ({ children }) => {
                   loading: false,
                   autoClose: 4000,
                 });
-                try { await useChannelsStore.getState().fetchRecordings(); } catch {}
+                try {
+                  await useChannelsStore.getState().fetchRecordings();
+                } catch {}
               } else if (status === 'skipped') {
                 notifications.update({
                   id,
@@ -204,7 +206,9 @@ export const WebsocketProvider = ({ children }) => {
                   loading: false,
                   autoClose: 3000,
                 });
-                try { await useChannelsStore.getState().fetchRecordings(); } catch {}
+                try {
+                  await useChannelsStore.getState().fetchRecordings();
+                } catch {}
               } else if (status === 'error') {
                 notifications.update({
                   id,
@@ -214,7 +218,9 @@ export const WebsocketProvider = ({ children }) => {
                   loading: false,
                   autoClose: 6000,
                 });
-                try { await useChannelsStore.getState().fetchRecordings(); } catch {}
+                try {
+                  await useChannelsStore.getState().fetchRecordings();
+                } catch {}
               }
               break;
             }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1319,7 +1319,7 @@ export default class API {
 
   static async fetchActiveChannelStats() {
     try {
-      const response = await request(`${host}/proxy/ts/status/`);
+      const response = await request(`${host}/proxy/ts/status`);
       return response;
     } catch (e) {
       errorNotification('Failed to fetch active channel stats', e);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1317,6 +1317,16 @@ export default class API {
     }
   }
 
+  static async fetchActiveChannelStats() {
+    try {
+      const response = await request(`${host}/proxy/ts/status/`);
+      return response;
+    } catch (e) {
+      errorNotification('Failed to fetch active channel stats', e);
+      throw e;
+    }
+  }
+
   static async getLogos(params = {}) {
     try {
       const queryParams = new URLSearchParams(params);

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -429,10 +429,18 @@ const SettingsPage = () => {
                     <Stack gap="sm">
                       <Switch
                         label="Enable Comskip (remove commercials after recording)"
-                        {...form.getInputProps('dvr-comskip-enabled', { type: 'checkbox' })}
+                        {...form.getInputProps('dvr-comskip-enabled', {
+                          type: 'checkbox',
+                        })}
                         key={form.key('dvr-comskip-enabled')}
-                        id={settings['dvr-comskip-enabled']?.id || 'dvr-comskip-enabled'}
-                        name={settings['dvr-comskip-enabled']?.key || 'dvr-comskip-enabled'}
+                        id={
+                          settings['dvr-comskip-enabled']?.id ||
+                          'dvr-comskip-enabled'
+                        }
+                        name={
+                          settings['dvr-comskip-enabled']?.key ||
+                          'dvr-comskip-enabled'
+                        }
                       />
                       <TextInput
                         label="TV Path Template"
@@ -440,8 +448,12 @@ const SettingsPage = () => {
                         placeholder="Recordings/TV_Shows/{show}/S{season:02d}E{episode:02d}.mkv"
                         {...form.getInputProps('dvr-tv-template')}
                         key={form.key('dvr-tv-template')}
-                        id={settings['dvr-tv-template']?.id || 'dvr-tv-template'}
-                        name={settings['dvr-tv-template']?.key || 'dvr-tv-template'}
+                        id={
+                          settings['dvr-tv-template']?.id || 'dvr-tv-template'
+                        }
+                        name={
+                          settings['dvr-tv-template']?.key || 'dvr-tv-template'
+                        }
                       />
                       <TextInput
                         label="TV Fallback Template"
@@ -449,8 +461,14 @@ const SettingsPage = () => {
                         placeholder="Recordings/TV_Shows/{show}/{start}.mkv"
                         {...form.getInputProps('dvr-tv-fallback-template')}
                         key={form.key('dvr-tv-fallback-template')}
-                        id={settings['dvr-tv-fallback-template']?.id || 'dvr-tv-fallback-template'}
-                        name={settings['dvr-tv-fallback-template']?.key || 'dvr-tv-fallback-template'}
+                        id={
+                          settings['dvr-tv-fallback-template']?.id ||
+                          'dvr-tv-fallback-template'
+                        }
+                        name={
+                          settings['dvr-tv-fallback-template']?.key ||
+                          'dvr-tv-fallback-template'
+                        }
                       />
                       <TextInput
                         label="Movie Path Template"
@@ -458,8 +476,14 @@ const SettingsPage = () => {
                         placeholder="Recordings/Movies/{title} ({year}).mkv"
                         {...form.getInputProps('dvr-movie-template')}
                         key={form.key('dvr-movie-template')}
-                        id={settings['dvr-movie-template']?.id || 'dvr-movie-template'}
-                        name={settings['dvr-movie-template']?.key || 'dvr-movie-template'}
+                        id={
+                          settings['dvr-movie-template']?.id ||
+                          'dvr-movie-template'
+                        }
+                        name={
+                          settings['dvr-movie-template']?.key ||
+                          'dvr-movie-template'
+                        }
                       />
                       <TextInput
                         label="Movie Fallback Template"
@@ -467,11 +491,24 @@ const SettingsPage = () => {
                         placeholder="Recordings/Movies/{start}.mkv"
                         {...form.getInputProps('dvr-movie-fallback-template')}
                         key={form.key('dvr-movie-fallback-template')}
-                        id={settings['dvr-movie-fallback-template']?.id || 'dvr-movie-fallback-template'}
-                        name={settings['dvr-movie-fallback-template']?.key || 'dvr-movie-fallback-template'}
+                        id={
+                          settings['dvr-movie-fallback-template']?.id ||
+                          'dvr-movie-fallback-template'
+                        }
+                        name={
+                          settings['dvr-movie-fallback-template']?.key ||
+                          'dvr-movie-fallback-template'
+                        }
                       />
-                      <Flex mih={50} gap="xs" justify="flex-end" align="flex-end">
-                        <Button type="submit" variant="default">Save</Button>
+                      <Flex
+                        mih={50}
+                        gap="xs"
+                        justify="flex-end"
+                        align="flex-end"
+                      >
+                        <Button type="submit" variant="default">
+                          Save
+                        </Button>
                       </Flex>
                     </Stack>
                   </form>

--- a/frontend/src/pages/Stats.jsx
+++ b/frontend/src/pages/Stats.jsx
@@ -831,9 +831,16 @@ const ChannelsPage = () => {
       const response = await API.fetchActiveChannelStats();
       if (response) {
         setChannelStats(response);
+      } else {
+        console.log('API response was empty or null');
       }
     } catch (error) {
       console.error('Error fetching channel stats:', error);
+      console.error('Error details:', {
+        message: error.message,
+        status: error.status,
+        body: error.body,
+      });
     }
   }, [setChannelStats]);
 
@@ -868,6 +875,7 @@ const ChannelsPage = () => {
   }, [fetchChannelStats]);
 
   useEffect(() => {
+    console.log('Processing channel stats:', channelStats);
     if (
       !channelStats ||
       !channelStats.channels ||
@@ -934,7 +942,7 @@ const ChannelsPage = () => {
       });
 
       console.log('Processed active channels:', stats);
-      
+
       // Update clients based on new stats
       const clientStats = Object.values(stats).reduce((acc, ch) => {
         if (ch.clients && Array.isArray(ch.clients)) {
@@ -948,7 +956,7 @@ const ChannelsPage = () => {
         return acc;
       }, []);
       setClients(clientStats);
-      
+
       return stats;
     });
   }, [channelStats, channels, channelsByUUID, streamProfiles]);


### PR DESCRIPTION
This removes our celery beat for channel stats and switches to using direct api calls instead. This also allows for the user to select their refresh time and will only pull new stats when viewing the stats page.

This will reduce CPU and RAM usage while Dispatcharr is idle.