### PR TITLE
Add 'UK' region

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -303,6 +303,7 @@ export const REGION_CHOICES = [
   { value: 'tz', label: 'TZ' },
   { value: 'ua', label: 'UA' },
   { value: 'ug', label: 'UG' },
+  { value: 'uk', label: 'UK' },
   { value: 'um', label: 'UM' },
   { value: 'us', label: 'US' },
   { value: 'uy', label: 'UY' },


### PR DESCRIPTION
I'm not sure if this was intentional, but the UK seems to be missing from the region list.