### PR TITLE
fix: Don't serialize custom_properties for m3u filters

### DIFF
--- a/frontend/src/components/forms/M3UFilter.jsx
+++ b/frontend/src/components/forms/M3UFilter.jsx
@@ -52,7 +52,7 @@ const M3UFilter = ({ filter = null, m3u, isOpen, onClose }) => {
       filter ? filter.custom_properties : {},
       'case_sensitive',
       values.case_sensitive,
-      true
+      false
     );
 
     delete values.case_sensitive;


### PR DESCRIPTION
Serialising results in text strings being stored in the backend database, and then errors like this on sync:

`Error in XC thread batch 0: 'str' object has no attribute 'get'`