### PR TITLE
Add option to add a logo by a URL in Channel editor/creator

### DIFF
--- a/frontend/src/components/forms/Channel.jsx
+++ b/frontend/src/components/forms/Channel.jsx
@@ -11,6 +11,7 @@ import logo from '../../images/logo.png';
 import { useChannelLogoSelection } from '../../hooks/useSmartLogos';
 import useLogosStore from '../../store/logos';
 import LazyLogo from '../LazyLogo';
+import LogoForm from './Logo';
 import {
   Box,
   Button,
@@ -37,7 +38,7 @@ import {
 import { notifications } from '@mantine/notifications';
 import { ListOrdered, SquarePlus, SquareX, X, Zap } from 'lucide-react';
 import useEPGsStore from '../../store/epgs';
-import { Dropzone } from '@mantine/dropzone';
+
 import { FixedSizeList as List } from 'react-window';
 import { USER_LEVELS, USER_LEVEL_LABELS } from '../../constants';
 
@@ -71,7 +72,7 @@ const ChannelForm = ({ channel = null, isOpen, onClose }) => {
   const tvgs = useEPGsStore((s) => s.tvgs);
   const tvgsById = useEPGsStore((s) => s.tvgsById);
 
-  const [logoPreview, setLogoPreview] = useState(null);
+  const [logoModalOpen, setLogoModalOpen] = useState(false);
   const [channelStreams, setChannelStreams] = useState([]);
   const [channelGroupModelOpen, setChannelGroupModalOpen] = useState(false);
   const [epgPopoverOpened, setEpgPopoverOpened] = useState(false);
@@ -97,33 +98,12 @@ const ChannelForm = ({ channel = null, isOpen, onClose }) => {
     setChannelStreams(Array.from(streamSet));
   };
 
-  const handleLogoChange = async (files) => {
-    if (files.length === 1) {
-      const file = files[0];
-
-      // Validate file size on frontend first
-      if (file.size > 5 * 1024 * 1024) {
-        // 5MB
-        notifications.show({
-          title: 'Error',
-          message: 'File too large. Maximum size is 5MB.',
-          color: 'red',
-        });
-        return;
-      }
-
-      try {
-        const retval = await API.uploadLogo(file);
-        // Note: API.uploadLogo already adds the logo to the store, no need to fetch
-        setLogoPreview(retval.cache_url);
-        formik.setFieldValue('logo_id', retval.id);
-      } catch (error) {
-        console.error('Logo upload failed:', error);
-        // Error notification is already handled in API.uploadLogo
-      }
-    } else {
-      setLogoPreview(null);
+  const handleLogoSuccess = ({ logo }) => {
+    if (logo && logo.id) {
+      formik.setFieldValue('logo_id', logo.id);
+      ensureLogosLoaded(); // Refresh logos
     }
+    setLogoModalOpen(false);
   };
 
   const handleAutoMatchEpg = async () => {
@@ -809,35 +789,13 @@ const ChannelForm = ({ channel = null, isOpen, onClose }) => {
                 </Stack>
               </Group>
 
-              <Group>
-                <Divider size="xs" style={{ flex: 1 }} />
-                <Text size="xs" c="dimmed">
-                  OR
-                </Text>
-                <Divider size="xs" style={{ flex: 1 }} />
-              </Group>
-
-              <Stack>
-                <Text size="sm">Upload Logo</Text>
-                <Dropzone
-                  onDrop={handleLogoChange}
-                  onReject={(files) => console.log('rejected files', files)}
-                  maxSize={5 * 1024 ** 2}
-                >
-                  <Group
-                    justify="center"
-                    gap="xl"
-                    mih={40}
-                    style={{ pointerEvents: 'none' }}
-                  >
-                    <Text size="sm" inline>
-                      Drag images here or click to select files
-                    </Text>
-                  </Group>
-                </Dropzone>
-
-                <Center></Center>
-              </Stack>
+              <Button
+                onClick={() => setLogoModalOpen(true)}
+                fullWidth
+                variant="default"
+              >
+                Upload or Create Logo
+              </Button>
             </Stack>
 
             <Divider size="sm" orientation="vertical" />
@@ -1056,6 +1014,12 @@ const ChannelForm = ({ channel = null, isOpen, onClose }) => {
       <ChannelGroupForm
         isOpen={channelGroupModelOpen}
         onClose={handleChannelGroupModalClose}
+      />
+
+      <LogoForm
+        isOpen={logoModalOpen}
+        onClose={() => setLogoModalOpen(false)}
+        onSuccess={handleLogoSuccess}
       />
     </>
   );

--- a/frontend/src/components/forms/Logo.jsx
+++ b/frontend/src/components/forms/Logo.jsx
@@ -106,13 +106,12 @@ const LogoForm = ({ logo = null, isOpen, onClose, onSuccess }) => {
           onSuccess?.({ type: 'create', logo: newLogo }); // Call onSuccess for creates
         } else {
           // File was uploaded and logo was already created
-          // Note: API.uploadLogo already calls addLogo() in the store, so no need to call onSuccess
           notifications.show({
             title: 'Success',
             message: 'Logo uploaded successfully',
             color: 'green',
           });
-          // No onSuccess call needed - API.uploadLogo already updated the store
+          onSuccess?.({ type: 'create', logo: uploadResponse });
         }
         onClose();
       } catch (error) {


### PR DESCRIPTION
This pull request revolves around adding an option to set the logo for a channel by a url directly in the channel editor/creator Channel.jsx form.

My original proposal is to simply add textbox for the url to set the logo above the current dropzone. The logo name will be automatically set to the filename.

![](https://private-user-images.githubusercontent.com/6157937/491400176-f7ca3e11-bb38-459f-9e2d-92de0406b5c5.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTg1OTM2NjksIm5iZiI6MTc1ODU5MzM2OSwicGF0aCI6Ii82MTU3OTM3LzQ5MTQwMDE3Ni1mN2NhM2UxMS1iYjM4LTQ1OWYtOWUyZC05MmRlMDQwNmI1YzUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDkyMyUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA5MjNUMDIwOTI5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MjVlMmIzYjIyOWNhMjk4Mzk2MmRkYWIwMzFmOTdjN2I4ZWJlMmUzNGFkYmUyOTQyM2RjNjc0NDU2ZjU3YzYwZCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.lkTXRkDfxhHKVGXRNu6YhR8rRVyDcb04mb6qMpf6ZaM)

A second option would be to have a separate button that then links to the Logo.jsx form to set the logo.

<img width="994" height="359" alt="image" src="https://github.com/user-attachments/assets/2448c92b-073a-471a-80af-a809e5a98471" />
<img width="998" height="532" alt="image" src="https://github.com/user-attachments/assets/f928c6c6-a0f0-452f-abea-013d5e3baa5a" />

A third option would be to remove the logo portion entirely and have a separate button to bring up the Logo.jsx form. This would require probably creating a second version of this form that includes the existing logo selector so as to not alter the original form for the Logo Manager.

<img width="994" height="356" alt="image" src="https://github.com/user-attachments/assets/c561fae9-fa72-4045-8a88-547759f8c8e9" />