### PR TITLE
[Enhancement/Fix] Set logo name from url

### DIFF
--- a/frontend/src/components/forms/Logo.jsx
+++ b/frontend/src/components/forms/Logo.jsx
@@ -210,6 +210,24 @@ const LogoForm = ({ logo = null, isOpen, onClose, onSuccess }) => {
     }
   };
 
+  const handleUrlBlur = (event) => {
+    const urlValue = event.target.value;
+    if (urlValue) {
+      try {
+        const url = new URL(urlValue);
+        const pathname = url.pathname;
+        const filename = pathname.substring(pathname.lastIndexOf('/') + 1);
+        const nameWithoutExtension = filename.replace(/\.[^/.]+$/, '');
+        if (nameWithoutExtension) {
+          formik.setFieldValue('name', nameWithoutExtension);
+        }
+      } catch (error) {
+        // If the URL is invalid, do nothing.
+        // The validation schema will catch this.
+      }
+    }
+  };
+
   // Clean up object URLs when component unmounts or preview changes
   useEffect(() => {
     return () => {
@@ -322,6 +340,7 @@ const LogoForm = ({ logo = null, isOpen, onClose, onSuccess }) => {
             placeholder="https://example.com/logo.png"
             {...formik.getFieldProps('url')}
             onChange={handleUrlChange}
+            onBlur={handleUrlBlur}
             error={formik.touched.url && formik.errors.url}
             disabled={!!selectedFile} // Disable when file is selected
           />


### PR DESCRIPTION
Previously, the logo form would automatically set the logo name when a file was uploaded, using the file name without the extension. However, when adding a logo via URL, the user had to manually enter a name.

This update adds automatic naming for URL-based logos:
- When the URL input loses focus, the logo name is set based on the URL.
- If the user changes the URL, the logo name updates accordingly.
- Existing behavior for file uploads remains unchanged.