### PR TITLE
Check for "SERVER_PORT" header before falling back to 9191

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -2645,12 +2645,17 @@ def get_host_and_port(request):
     if port:
         return host, port
 
-    # 4. Dev fallback: guess port
+    # 4. Try SERVER_PORT from META
+    port = request.META.get("SERVER_PORT")
+    if port:
+        return host, port
+
+    # 5. Dev fallback: guess port
     if os.environ.get("DISPATCHARR_ENV") == "dev" or host in ("localhost", "127.0.0.1"):
        guess = "5656"
        return host, guess
 
-    # 5. Fallback to scheme default
+    # 6. Fallback to scheme default
     port = "443" if request.is_secure() else "9191"
     return host, port
 


### PR DESCRIPTION
I moved on to LXC install on PVE. The x-tvg-url defaults back to 9191 port whilst in reality the port is defined as :80, therefore this obviously brakes this functionality. 

Check request.META.get("SERVER_PORT") before falling back to defaults. This should capture the actual server port from the request.