### PR TITLE
Update README with DISPATCHARR_PORT note

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ docker run -d \
 ```
 
 > Customize ports and volumes to fit your setup.
+> Note: certain environments require you to set the `DISPATCHARR_PORT` environment variable to match your port or the docker startup scripts will fail.
 
 ---
 


### PR DESCRIPTION
Added note about DISPATCHARR_PORT requirement for Docker.

I found that while running the AIO container in Kubernetes, the docker/init/03-init-dispatcharr.sh script would fail on the line 32: 

`sed -i "s/NGINX_PORT/${DISPATCHARR_PORT}/g" /etc/nginx/sites-enabled/default`

The `sed` command would attempt to replace `${DISPATCHARR_PORT}` with `tcp://[ip address]:[port]`, which breaks on the `/` in the replacement value, given that the delimiter is also `/`.

The specific error is:

`sed: -e expression #1, char 19: unknown option to s'`

Simply ensuring that you have the environmental variable set fixes this. I attempted to simply change the delimiter but it obviously still fails as the script is not expecting a full url in here. I think some additional error messaging as to why the script fails would be great, but in the short term I think adding to the documentation would be a good start.