### PR TITLE
Fix: Preserve stream order in ChannelSerializer PATCH/PUT responses

### DIFF
--- a/apps/channels/serializers.py
+++ b/apps/channels/serializers.py
@@ -348,8 +348,17 @@ class ChannelSerializer(serializers.ModelSerializer):
 
         if include_streams:
             self.fields["streams"] = serializers.SerializerMethodField()
-
-        return super().to_representation(instance)
+            return super().to_representation(instance)
+        else:
+            # Fix: For PATCH/PUT responses, ensure streams are ordered
+            representation = super().to_representation(instance)
+            if "streams" in representation:
+                representation["streams"] = list(
+                    instance.streams.all()
+                    .order_by("channelstream__order")
+                    .values_list("id", flat=True)
+                )
+            return representation
 
     def get_logo(self, obj):
         return LogoSerializer(obj.logo).data


### PR DESCRIPTION
## Problem
The `ChannelSerializer.to_representation()` method was not respecting the `ChannelStream.order` field when serializing PATCH/PUT responses. This caused streams to be returned in an arbitrary order rather than the order specified in the request.

While the `update()` method correctly saves the stream order to the database using the `ChannelStream.order` field, and GET requests (with `include_streams=True`) correctly return ordered streams via `get_streams()`, standard PATCH/PUT responses were using `PrimaryKeyRelatedField` which doesn't respect the ordering.

## Solution
This PR modifies the `to_representation()` method to ensure that all API responses (GET, PATCH, PUT) return streams ordered by the `channelstream__order` field.

## Changes
- Modified `ChannelSerializer.to_representation()` to query streams with `.order_by('channelstream__order')` for standard responses
- Preserved existing behavior for `include_streams=True` cases

## Impact
- PATCH/PUT responses now correctly reflect the stream order as saved
- Clients can trust the response data without needing a follow-up GET request
- No breaking changes - only fixes inconsistent behavior

## Testing
Tested with:
- PATCH request with ordered stream IDs
- Verified response matches request order
- Verified GET request confirms order persisted to database
- Production testing with StreamFlow integration confirms fix works correctly