### PR TITLE
UI now reflects date and time formats chosen by user

### DIFF
--- a/frontend/src/pages/DVR.jsx
+++ b/frontend/src/pages/DVR.jsx
@@ -102,6 +102,16 @@ const RECURRING_DAY_OPTIONS = [
   { value: 5, label: 'Sat' },
 ];
 
+const useDateTimeFormat = () => {
+  const [timeFormatSetting] = useLocalStorage('time-format', '12h');
+  const [dateFormatSetting] = useLocalStorage('date-format', 'mdy');
+  // Use user preference for time format
+  const timeFormat = timeFormatSetting === '12h' ? 'h:mma' : 'HH:mm';
+  const dateFormat = dateFormatSetting === 'mdy' ? 'MMM D' : 'D MMM';
+
+  return [timeFormat, dateFormat]
+};
+
 // Short preview that triggers the details modal when clicked
 const RecordingSynopsis = ({ description, onOpen }) => {
   const truncated = description?.length > 140;
@@ -139,6 +149,7 @@ const RecordingDetailsModal = ({
   const { toUserTime, userNow } = useTimeHelpers();
   const [childOpen, setChildOpen] = React.useState(false);
   const [childRec, setChildRec] = React.useState(null);
+  const [timeformat, dateformat] = useDateTimeFormat();
 
   const safeRecording = recording || {};
   const customProps = safeRecording.custom_properties || {};
@@ -320,7 +331,7 @@ const RecordingDetailsModal = ({
               )}
             </Group>
             <Text size="xs">
-              {start.format('MMM D, YYYY h:mma')} – {end.format('h:mma')}
+              {start.format(`${dateformat}, YYYY ${timeformat}`)} – {end.format(timeformat)}
             </Text>
           </Stack>
           <Group gap={6}>
@@ -498,7 +509,7 @@ const RecordingDetailsModal = ({
               </Group>
             </Group>
             <Text size="sm">
-              {start.format('MMM D, YYYY h:mma')} – {end.format('h:mma')}
+              {start.format(`${dateformat}, YYYY ${timeformat}`)} – {end.format(timeformat)}
             </Text>
             {rating && (
               <Group gap={8}>
@@ -558,6 +569,7 @@ const RecurringRuleModal = ({ opened, onClose, ruleId, onEditOccurrence }) => {
   const fetchRecordings = useChannelsStore((s) => s.fetchRecordings);
   const recordings = useChannelsStore((s) => s.recordings);
   const { toUserTime, userNow } = useTimeHelpers();
+  const [timeformat, dateformat] = useDateTimeFormat();
 
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -892,10 +904,10 @@ const RecurringRuleModal = ({ opened, onClose, ruleId, onEditOccurrence }) => {
                     <Group justify="space-between" align="center">
                       <Stack gap={2} style={{ flex: 1 }}>
                         <Text fw={600} size="sm">
-                          {occStart.format('MMM D, YYYY')}
+                          {occStart.format(`${dateformat}, YYYY`)}
                         </Text>
                         <Text size="xs" c="dimmed">
-                          {occStart.format('h:mma')} – {occEnd.format('h:mma')}
+                          {occStart.format(timeformat)} – {occEnd.format(timeformat)}
                         </Text>
                       </Stack>
                       <Group gap={6}>
@@ -937,6 +949,7 @@ const RecordingCard = ({ recording, onOpenDetails, onOpenRecurring }) => {
   const showVideo = useVideoStore((s) => s.showVideo);
   const fetchRecordings = useChannelsStore((s) => s.fetchRecordings);
   const { toUserTime, userNow } = useTimeHelpers();
+  const [timeformat, dateformat] = useDateTimeFormat();
 
   const channel = channels?.[recording.channel];
 
@@ -1221,7 +1234,7 @@ const RecordingCard = ({ recording, onOpenDetails, onOpenRecurring }) => {
               {isSeriesGroup ? 'Next recording' : 'Time'}
             </Text>
             <Text size="sm">
-              {start.format('MMM D, YYYY h:mma')} – {end.format('h:mma')}
+              {start.format(`${dateformat}, YYYY ${timeformat}`)} – {end.format(timeformat)}
             </Text>
           </Group>
 


### PR DESCRIPTION
This is a reworked version of #425 using the same approach as #322
Info-cards and Info-modulars in the DVR page now use the date and time formats chosen by the user in settings.

<img width="400" height="621" alt="bild" src="https://github.com/user-attachments/assets/bd4cc876-2a54-4c8d-979d-d3f644a005eb" />
<img width="400" height="451" alt="bild" src="https://github.com/user-attachments/assets/96f472c5-bf48-49e5-9eea-15f4c426c117" />

I found a bug in the existing code where pressing "New recording" (always) shows US datetime for one-time recordings but only US date format with international time for Recurring recordings.
This is OOS for this PR though. Let me know if I should open a issue for that bug.

<img width="400" height="596" alt="bild" src="https://github.com/user-attachments/assets/f96a7ca6-d936-41f5-86ce-f5387096847b" />
<img width="400" height="830" alt="bild" src="https://github.com/user-attachments/assets/0ae19d06-b9a9-43cd-a462-40c2985e03c3" />
