### PR TITLE
fix: Allow all IPv6 CIDRs by default

### DIFF
--- a/dispatcharr/utils.py
+++ b/dispatcharr/utils.py
@@ -44,7 +44,7 @@ def network_access_allowed(request, settings_key):
     cidrs = (
         network_access[settings_key].split(",")
         if settings_key in network_access
-        else ["0.0.0.0/0"]
+        else ["0.0.0.0/0", "::/0"]
     )
 
     network_allowed = False

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -278,7 +278,7 @@ const SettingsPage = () => {
   const networkAccessForm = useForm({
     mode: 'controlled',
     initialValues: Object.keys(NETWORK_ACCESS_OPTIONS).reduce((acc, key) => {
-      acc[key] = '0.0.0.0/0,::0/0';
+      acc[key] = '0.0.0.0/0,::/0';
       return acc;
     }, {}),
     validate: Object.keys(NETWORK_ACCESS_OPTIONS).reduce((acc, key) => {
@@ -358,7 +358,7 @@ const SettingsPage = () => {
       );
       networkAccessForm.setValues(
         Object.keys(NETWORK_ACCESS_OPTIONS).reduce((acc, key) => {
-          acc[key] = networkAccessSettings[key] || '0.0.0.0/0,::0/0';
+          acc[key] = networkAccessSettings[key] || '0.0.0.0/0,::/0';
           return acc;
         }, {})
       );


### PR DESCRIPTION
This change ensures that by default, IPv6 clients can
connect to the service unless explicitly denied.

Fixes #593