### PR TITLE
Bind nginx to both IPv4 and IPv6 protocol stacks

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -2,7 +2,8 @@ proxy_cache_path /app/logo_cache levels=1:2 keys_zone=logo_cache:10m
                  inactive=24h use_temp_path=off;
 
 server {
-    listen NGINX_PORT;
+    # Bind to all available IP's in both IPv4 and IPv6 stacks
+    listen [::]:NGINX_PORT ipv6only=off;
 
     proxy_connect_timeout 75;
     proxy_send_timeout 300;


### PR DESCRIPTION
This is a simple nginx.conf fix that enables the nginx port bind to both ip protocol stacks