### PR TITLE
Honor  PORT defiitions in K8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - nginx now gracefully handles hosts without IPv6 support by automatically disabling IPv6 binding at startup (Fixes #744)
 - XtreamCodes EPG API now returns correct date/time format for start/end fields and proper string types for timestamps and channel_id
 - XtreamCodes EPG API now handles None values for title and description fields to prevent AttributeError
+- Update init to work with port definitions in Kubernetes. [@jdblack](https://g
+ithub.com/jdblack)
 
 ## [0.14.0] - 2025-12-09
 

--- a/docker/init/03-init-dispatcharr.sh
+++ b/docker/init/03-init-dispatcharr.sh
@@ -30,7 +30,9 @@ if [ "$(id -u)" = "0" ] && [ -d "/app" ]; then
     fi
 fi
 # Configure nginx port
-sed -i "s/NGINX_PORT/${DISPATCHARR_PORT}/g" /etc/nginx/sites-enabled/default
+NGINX_PORT=${DISPATCHER_SERVICE_PORT:-${DISPATCHER_PORT:-80}}
+sed -i "s|NGINX_PORT|${NGINX_PORT}|g" /etc/nginx/sites-enabled/default
+
 
 # Configure nginx based on IPv6 availability
 if ip -6 addr show | grep -q "inet6"; then


### PR DESCRIPTION
Kuberntes exposes port numbers via environmental variables in a slightly different way than docker,  to wit:
```
DISPATCHARR_PORT=tcp://10.98.37.10:80
DISPATCHARR_PORT_80_TCP_ADDR=10.98.37.10
DISPATCHARR_PORT_80_TCP_PROTO=tcp
DISPATCHARR_PORT_80_TCP_PORT=80
DISPATCHARR_SERVICE_PORT=80
DISPATCHARR_PORT_80_TCP=tcp://10.98.37.10:80
DISPATCHARR_PORT is tcp://10.98.37.10:80
```

This patch uses DISPATCHARR_SERVICE_PORT first,  then falls back to DISPATCHARR_PORT, and finally, defaults to
port 80.
