### PR TITLE
Signaling ready when no StreamTable rendered

### DIFF
--- a/frontend/src/pages/Channels.jsx
+++ b/frontend/src/pages/Channels.jsx
@@ -65,6 +65,7 @@ const PageContent = () => {
   if (!authUser.id) return <></>;
 
   if (authUser.user_level <= USER_LEVELS.STANDARD) {
+    handleStreamsReady();
     return (
       <Box style={{ padding: 10 }}>
         <ChannelsTable onReady={handleChannelsReady} />


### PR DESCRIPTION
With the logo signaling changes introduced in https://github.com/Dispatcharr/Dispatcharr/commit/f5c6d2b576f0b6c050b704ef63cc38bbac406215 Standard Users don't see logos on the Channels page because StreamsTable doesn't get rendered.

This change signals ready for the StreamsTable within the conditional render block.