### PR TITLE
Fix bulk_create and bulk_update errors for VOD content refresh

### DIFF
--- a/apps/vod/tasks.py
+++ b/apps/vod/tasks.py
@@ -654,12 +654,26 @@ def process_movie_batch(account, batch, categories, relations, scan_start_time=N
                 if id(relation.movie) in created_movies:
                     relation.movie = created_movies[id(relation.movie)]
 
-            # Handle relations
-            if relations_to_create:
-                M3UMovieRelation.objects.bulk_create(relations_to_create, ignore_conflicts=True)
+            # Also update relations_to_update to reference saved movies
+            for relation in relations_to_update:
+                if id(relation.movie) in created_movies:
+                    relation.movie = created_movies[id(relation.movie)]
 
-            if relations_to_update:
-                M3UMovieRelation.objects.bulk_update(relations_to_update, [
+            # Filter out relations with unsaved movies (no PK)
+            valid_relations_to_create = [r for r in relations_to_create if r.movie.pk is not None]
+            valid_relations_to_update = [r for r in relations_to_update if r.movie.pk is not None]
+
+            if len(valid_relations_to_create) < len(relations_to_create):
+                logger.warning(f"Skipping {len(relations_to_create) - len(valid_relations_to_create)} movie relations with unsaved movies")
+            if len(valid_relations_to_update) < len(relations_to_update):
+                logger.warning(f"Skipping {len(relations_to_update) - len(valid_relations_to_update)} movie relation updates with unsaved movies")
+
+            # Handle relations
+            if valid_relations_to_create:
+                M3UMovieRelation.objects.bulk_create(valid_relations_to_create, ignore_conflicts=True)
+
+            if valid_relations_to_update:
+                M3UMovieRelation.objects.bulk_update(valid_relations_to_update, [
                     'movie', 'category', 'container_extension', 'custom_properties', 'last_seen'
                 ])
 
@@ -985,12 +999,26 @@ def process_series_batch(account, batch, categories, relations, scan_start_time=
                 if id(relation.series) in created_series:
                     relation.series = created_series[id(relation.series)]
 
-            # Handle relations
-            if relations_to_create:
-                M3USeriesRelation.objects.bulk_create(relations_to_create, ignore_conflicts=True)
+            # Also update relations_to_update to reference saved series
+            for relation in relations_to_update:
+                if id(relation.series) in created_series:
+                    relation.series = created_series[id(relation.series)]
 
-            if relations_to_update:
-                M3USeriesRelation.objects.bulk_update(relations_to_update, [
+            # Filter out relations with unsaved series (no PK)
+            valid_relations_to_create = [r for r in relations_to_create if r.series.pk is not None]
+            valid_relations_to_update = [r for r in relations_to_update if r.series.pk is not None]
+
+            if len(valid_relations_to_create) < len(relations_to_create):
+                logger.warning(f"Skipping {len(relations_to_create) - len(valid_relations_to_create)} series relations with unsaved series")
+            if len(valid_relations_to_update) < len(relations_to_update):
+                logger.warning(f"Skipping {len(relations_to_update) - len(valid_relations_to_update)} series relation updates with unsaved series")
+
+            # Handle relations
+            if valid_relations_to_create:
+                M3USeriesRelation.objects.bulk_create(valid_relations_to_create, ignore_conflicts=True)
+
+            if valid_relations_to_update:
+                M3USeriesRelation.objects.bulk_update(valid_relations_to_update, [
                     'series', 'category', 'custom_properties', 'last_seen'
                 ])
 


### PR DESCRIPTION
This commit addresses the issues described in GitHub issue #813 where bulk_create and bulk_update operations were failing with errors like:

- "bulk_update() prohibited to prevent data loss due to unsaved related object 'movie'"
- "bulk_create() prohibited to prevent data loss due to unsaved related object 'series'"

The changes include:

1. Fixed movie batch processing (lines 652-678):
   - Properly handle relations_to_update to reference saved movies
   - Filter out relations with unsaved movies (no PK) before bulk operations
   - Add warning logs when relations are skipped due to unsaved movies

2. Fixed series batch processing (lines 1007-1023):
   - Properly handle relations_to_update to reference saved series
   - Filter out relations with unsaved series (no PK) before bulk operations
   - Add warning logs when relations are skipped due to unsaved series

3. Root cause resolution:
   - The errors occurred because bulk_create doesn't immediately set primary keys on created objects in all cases
   - Relations were being created with references to objects that didn't have PKs yet
   - When bulk_update was called on relations, Django detected that the related objects (movies/series) didn't have primary keys

4. Solution implementation:
   - All relations now reference objects that have been successfully saved to the database
   - Relations with unsaved objects are filtered out before bulk operations
   - Proper warnings are logged when relations are skipped
   - The transaction ensures atomicity of the operations

These changes ensure data integrity while maintaining performance during VOD content refresh operations.