### PR TITLE
fix(ts-proxy): eliminate TOCTOU race condition and connection leaks

### DIFF
--- a/apps/proxy/ts_proxy/server.py
+++ b/apps/proxy/ts_proxy/server.py
@@ -784,12 +784,16 @@ class ProxyServer:
             # Force release resources in the Channel model
             try:
                 channel = Channel.objects.get(uuid=channel_id)
-                channel.release_stream()
+                success = channel.release_stream()
+                if not success:
+                    logger.info(f"Failed to release stream for channel {channel_id}")
                 logger.info(f"Released stream allocation for zombie channel {channel_id}")
             except Exception as e:
                 try:
                     stream = Stream.objects.get(stream_hash=channel_id)
-                    stream.release_stream()
+                    success = stream.release_stream()
+                    if not success:
+                        logger.info(f"Failed to release stream for channel {channel_id}")
                     logger.info(f"Released stream allocation for zombie channel {channel_id}")
                 except Exception as e:
                     logger.error(f"Error releasing stream for zombie channel {channel_id}: {e}")
@@ -1335,10 +1339,14 @@ class ProxyServer:
         # Release the channel, stream, and profile keys from the channel
         try:
             channel = Channel.objects.get(uuid=channel_id)
-            channel.release_stream()
+            success = channel.release_stream()
+            if not success:
+                logger.info(f"Failed to release stream for channel {channel_id}")
         except:
             stream = Stream.objects.get(stream_hash=channel_id)
-            stream.release_stream()
+            success = stream.release_stream()
+            if not success:
+                logger.info(f"Failed to release stream for channel {channel_id}")
 
         if not self.redis_client:
             return 0

--- a/apps/proxy/ts_proxy/services/channel_service.py
+++ b/apps/proxy/ts_proxy/services/channel_service.py
@@ -265,13 +265,17 @@ class ChannelService:
         # Release the channel in the channel model if applicable
         try:
             channel = Channel.objects.get(uuid=channel_id)
-            channel.release_stream()
+            success = channel.release_stream()
+            if not success:
+                logger.info(f"Failed to release stream for channel {channel_id}")
             logger.info(f"Released channel {channel_id} stream allocation")
             model_released = True
         except Channel.DoesNotExist:
             logger.warning(f"Could not find Channel model for UUID {channel_id}, attempting stream hash")
             stream = Stream.objects.get(stream_hash=channel_id)
-            stream.release_stream()
+            success = stream.release_stream()
+            if not success:
+                logger.info(f"Failed to release stream for channel {channel_id}")
             logger.info(f"Released stream {channel_id} stream allocation")
             model_released = True
         except Exception as e:

--- a/apps/proxy/ts_proxy/stream_generator.py
+++ b/apps/proxy/ts_proxy/stream_generator.py
@@ -441,7 +441,9 @@ class StreamGenerator:
                                 try:
                                     # Get the channel by UUID
                                     channel = Channel.objects.get(uuid=self.channel_id)
-                                    channel.release_stream()
+                                    success = channel.release_stream()
+                                    if not success:
+                                        logger.warning(f"[{self.client_id}] Failed to properly release stream for channel {self.channel_id} - connection counter may have leaked")
                                     stream_released = True
                                     logger.debug(f"[{self.client_id}] Released stream for channel {self.channel_id}")
                                 except Exception as e:

--- a/apps/proxy/ts_proxy/views.py
+++ b/apps/proxy/ts_proxy/views.py
@@ -308,7 +308,9 @@ def stream_ts(request, channel_id):
                                 f"[{client_id}] Alternate stream #{alt['stream_id']} failed validation: {message}"
                             )
                 # Release stream lock before redirecting
-                channel.release_stream()
+                success = channel.release_stream()
+                if not success:
+                    logger.info(f"Failed to release stream for channel {channel_id}")
                 # Final decision based on validation results
                 if is_valid:
                     logger.info(


### PR DESCRIPTION
This PR fixes two critical issues in the TS proxy connection management that caused false positive "at capacity" errors under high concurrency and connection counter leaks during cleanup.

## Problems Fixed

### 1. TOCTOU Race Condition (Time-Of-Check to Time-Of-Use) The original code checked profile capacity and then incremented the counter in two separate Redis operations. Under high concurrency, multiple requests could pass the capacity check simultaneously, leading to:
- False positive "All active M3U profiles have reached maximum connection limits"
- Actual connections exceeding profile limits

### 2. Connection Counter Leaks
The release_stream() method had no fallback mechanism when Redis keys were missing. If cleanup happened in an unexpected order, the profile connection counter would never be decremented, causing permanent "at capacity" errors.

## Solution

### Part 1: Atomic Slot Reservation
- Added _check_and_reserve_profile_slot() using a Lua script
- Check and increment happen in a single atomic Redis operation
- Eliminates the TOCTOU race condition entirely

### Part 2: Defensive Release Stream
- Channel.release_stream() now has metadata hash fallbacks
- Returns bool for success/failure tracking
- Detailed logging for debugging
- All 7 call sites now log failures for monitoring

### Part 3: Consistency & Logging Improvements
- Fixed Stream.release_stream() to return bool (was returning None)
- Standardized all logs to use channel UUID instead of database ID
- Downgraded expected cleanup messages from WARNING to INFO (prevents log spam during normal disconnect flow)

## Changes
- apps/channels/models.py: Atomic Lua reservation, defensive release, bool returns
- apps/proxy/ts_proxy/server.py: Return value checking
- apps/proxy/ts_proxy/services/channel_service.py: Return value checking
- apps/proxy/ts_proxy/stream_generator.py: Return value checking
- apps/proxy/ts_proxy/views.py: Return value checking

## Testing
- Tested under high concurrency - no more false positive errors
- Verified connection counters decrement correctly in all scenarios
- Logs are cleaner and easier to correlate across components