### PR TITLE
fix: stabilize build-dev paths and push behavior

### DIFF
--- a/docker/build-dev.sh
+++ b/docker/build-dev.sh
@@ -1,65 +1,69 @@
-#!/bin/bash 
+#!/bin/bash
 set -e
 
 # Default values
-VERSION=$(python3 -c "import sys; sys.path.append('..'); import version; print(version.__version__)")
-REGISTRY="dispatcharr"        # Registry or private repo to push to
-IMAGE="dispatcharr"           # Image that we're building
-BRANCH="dev" 
-ARCH=""                      # Architectures to build for, e.g. linux/amd64,linux/arm64
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VERSION=$(python3 -c "import sys; sys.path.append('${ROOT_DIR}'); import version; print(version.__version__)")
+REGISTRY="dispatcharr" # Registry or private repo to push to
+IMAGE="dispatcharr"    # Image that we're building
+BRANCH="dev"
+ARCH="" # Architectures to build for, e.g. linux/amd64,linux/arm64
 PUSH=false
 
 usage() {
-  cat <<- EOF
-    To test locally:
-      ./build-dev.sh 
+	cat <<-EOF
+	To test locally:
+	  ./build-dev.sh
 
-    To build and push to registry:
-      ./build-dev.sh -p
+	To build and push to registry:
+	  ./build-dev.sh -p
 
-    To build and push to a private registry:
-      ./build-dev.sh -p -r myregistry:5000
+	To build and push to a private registry:
+	  ./build-dev.sh -p -r myregistry:5000
 
-    To build for -both-  x86_64 and arm_64:
-      ./build-dev.sh -p -a linux/amd64,linux/arm64
+	To build for -both-  x86_64 and arm_64:
+	  ./build-dev.sh -p -a linux/amd64,linux/arm64
 
-    Do it all:
-      ./build-dev.sh -p -r myregistry:5000 -a linux/amd64,linux/arm64
-EOF
-exit 0
+	Do it all:
+	  ./build-dev.sh -p -r myregistry:5000 -a linux/amd64,linux/arm64
+	EOF
+	exit 0
 }
 
 # Parse options
 while getopts "pr:a:b:i:h" opt; do
-  case $opt in
-    r) REGISTRY="$OPTARG" ;;
-    a) ARCH="--platform $OPTARG" ;;
-    b) BRANCH="$OPTARG" ;;
-    i) IMAGE="$OPTARG" ;;
-    p) PUSH=true ;;
-    h) usage ;;
-    \?) echo "Invalid option: -$OPTARG" >&2; exit 1 ;;
-  esac
+	case $opt in
+	r) REGISTRY="$OPTARG" ;;
+	a) ARCH="$OPTARG" ;;
+	b) BRANCH="$OPTARG" ;;
+	i) IMAGE="$OPTARG" ;;
+	p) PUSH=true ;;
+	h) usage ;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		exit 1
+		;;
+	esac
 done
 
 BUILD_ARGS="BRANCH=$BRANCH"
-
-echo docker build --build-arg $BUILD_ARGS $ARCH -t $IMAGE
-docker build -f Dockerfile --build-arg $BUILD_ARGS $ARCH -t $IMAGE ..
-docker tag $IMAGE $IMAGE:$BRANCH
-docker tag $IMAGE $IMAGE:$VERSION
-
-if [ -z "$PUSH" ]; then
-  echo "Please run 'docker push -t $IMAGE:dev -t $IMAGE:${VERSION}' when ready"
-else
-  for TAG in latest "$VERSION" "$BRANCH"; do
-    docker tag "$IMAGE" "$REGISTRY/$IMAGE:$TAG"
-    docker push -q "$REGISTRY/$IMAGE:$TAG"
-  done
-  echo "Images pushed successfully."
+ARCH_ARGS=()
+if [ -n "$ARCH" ]; then
+	ARCH_ARGS=(--platform "$ARCH")
 fi
 
+echo docker build --build-arg "$BUILD_ARGS" "${ARCH_ARGS[@]}" -t "$IMAGE"
+docker build -f "${SCRIPT_DIR}/Dockerfile" --build-arg "$BUILD_ARGS" "${ARCH_ARGS[@]}" -t "$IMAGE" "$ROOT_DIR"
+docker tag "$IMAGE" "$IMAGE":"$BRANCH"
+docker tag "$IMAGE" "$IMAGE":"$VERSION"
 
-
-
-
+if [ "$PUSH" = "true" ]; then
+	for TAG in latest "$VERSION" "$BRANCH"; do
+		docker tag "$IMAGE" "$REGISTRY/$IMAGE:$TAG"
+		docker push -q "$REGISTRY/$IMAGE:$TAG"
+	done
+	echo "Images pushed successfully."
+else
+	echo "Please run 'docker push $IMAGE:$BRANCH' and 'docker push $IMAGE:${VERSION}' when ready"
+fi


### PR DESCRIPTION
### Description:
This updates `docker/build-dev.sh` so it works from any cwd by anchoring paths to the script and repo root, builds with explicit --platform args when provided, and fixes push behavior and messaging. Also normalizes formatting and quoting to avoid word-splitting issues.

### Changes:

  - Resolve Dockerfile and build context relative to the script location.
  - Convert -a to --platform args safely.
  - Fix push logic to honor -p and correct push hints.