### PR TITLE
Fix streams requery to respect table filters

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -715,6 +715,7 @@ export default class API {
   static async queryStreamsTable(params) {
     try {
       API.lastStreamQueryParams = params;
+      useStreamsTableStore.getState().setLastQueryParams(params);
 
       const response = await request(
         `${host}/api/channels/streams/?${params.toString()}`
@@ -729,21 +730,24 @@ export default class API {
   }
 
   static async requeryStreams() {
-    if (!API.lastStreamQueryParams) {
+    const params =
+      useStreamsTableStore.getState().lastQueryParams ||
+      API.lastStreamQueryParams;
+    if (!params) {
       return null;
     }
 
     try {
       const [response, ids] = await Promise.all([
         request(
-          `${host}/api/channels/streams/?${API.lastStreamQueryParams.toString()}`
+          `${host}/api/channels/streams/?${params.toString()}`
         ),
-        API.getAllStreamIds(API.lastStreamQueryParams),
+        API.getAllStreamIds(params),
       ]);
 
       useStreamsTableStore
         .getState()
-        .queryStreams(response, API.lastStreamQueryParams);
+        .queryStreams(response, params);
       useStreamsTableStore.getState().setAllQueryIds(ids);
 
       return response;

--- a/frontend/src/store/streamsTable.jsx
+++ b/frontend/src/store/streamsTable.jsx
@@ -12,6 +12,7 @@ const useStreamsTableStore = create((set) => ({
   },
   selectedStreamIds: [],
   allQueryIds: [],
+  lastQueryParams: null,
 
   queryStreams: ({ results, count }, params) => {
     set(() => ({
@@ -42,6 +43,12 @@ const useStreamsTableStore = create((set) => ({
   setSorting: (sorting) => {
     set(() => ({
       sorting,
+    }));
+  },
+
+  setLastQueryParams: (lastQueryParams) => {
+    set(() => ({
+      lastQueryParams,
     }));
   },
 }));


### PR DESCRIPTION
### Bug Description:
Removing streams with “Only Unassociated” on left deleted rows visible, pointing to a stale query cache.

### Changes: 
  - Fix stale Streams table results by requerying with the table’s latest query params.
  - Store the last streams table params in the streams table store and reuse them in API.requeryStreams().
  - Ensures deletes and websocket refreshes reflect active filters like “Only Unassociated.”