### PR TITLE
Fix "Invalid page" error when filtering empty channels

### DIFF
--- a/frontend/src/components/tables/ChannelsTable.jsx
+++ b/frontend/src/components/tables/ChannelsTable.jsx
@@ -1413,6 +1413,8 @@ const ChannelsTable = ({ onReady }) => {
             setShowDisabled={setShowDisabled}
             showOnlyStreamlessChannels={showOnlyStreamlessChannels}
             setShowOnlyStreamlessChannels={setShowOnlyStreamlessChannels}
+            pagination={pagination}
+            setPagination={setPagination}
           />
 
           {/* Table or ghost empty state inside Paper */}

--- a/frontend/src/components/tables/ChannelsTable/ChannelTableHeader.jsx
+++ b/frontend/src/components/tables/ChannelsTable/ChannelTableHeader.jsx
@@ -109,6 +109,8 @@ const ChannelTableHeader = ({
   setShowDisabled,
   showOnlyStreamlessChannels,
   setShowOnlyStreamlessChannels,
+  pagination,
+  setPagination,
 }) => {
   const theme = useMantineTheme();
 
@@ -226,6 +228,7 @@ const ChannelTableHeader = ({
   };
 
   const toggleShowOnlyStreamlessChannels = () => {
+    setPagination({ ...pagination, pageIndex: 0 });
     setShowOnlyStreamlessChannels(!showOnlyStreamlessChannels);
   };
 


### PR DESCRIPTION
Reset pagination to page 1 when toggling "Only Empty Channels" filter to prevent requesting non-existent pages after filtering reduces results.

Fixes #864