### PR TITLE
feat: Add `XC_AUTH_DELAY` to prevent XtreamCodes rate limiting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- XtreamCodes rate limiting protection: Added `XC_AUTH_DELAY` environment variable to configure delay after authentication before making first API request (e.g., `get_live_categories`). Some XC servers enforce strict rate limiting and block rapid successive requests with error 844. Default value is 0 (disabled) to maintain current behavior. Users experiencing rate limiting can set this to 2.5 or higher via environment variable. This is separate from the existing `XC_PROFILE_REFRESH_DELAY` which controls delays between multiple profile authentications.
+
 ## [0.18.1] - 2026-01-27
 
 ### Fixed

--- a/apps/m3u/tasks.py
+++ b/apps/m3u/tasks.py
@@ -1271,6 +1271,12 @@ def refresh_m3u_groups(account_id, use_cache=False, full_refresh=False, scan_sta
                         auth_result = xc_client.authenticate()
                         logger.debug(f"Authentication response: {auth_result}")
 
+                        # Add delay after authentication to prevent rate limiting
+                        # Some XC servers block rapid successive requests (error 844)
+                        auth_delay = getattr(settings, 'XC_AUTH_DELAY', 0)
+                        logger.info(f"Waiting {auth_delay}s after authentication to avoid rate limiting")
+                        time.sleep(auth_delay)
+
                         # Queue async profile refresh task to run in background
                         # This prevents any delay in the main refresh process
                         try:

--- a/dispatcharr/settings.py
+++ b/dispatcharr/settings.py
@@ -57,6 +57,11 @@ EPG_ENABLE_MEMORY_MONITORING = True  # Whether to monitor memory usage during pr
 # This prevents providers from temporarily banning users with many profiles
 XC_PROFILE_REFRESH_DELAY = float(os.environ.get('XC_PROFILE_REFRESH_DELAY', '2.5'))  # seconds between profile refreshes
 
+# Delay after authentication before making first API request (e.g., get_live_categories)
+# Some XC servers enforce strict rate limiting and block rapid successive requests
+# Set to 0 by default (disabled). Increase if you experience rate limiting errors (e.g., error 844)
+XC_AUTH_DELAY = float(os.environ.get('XC_AUTH_DELAY', '0'))  # seconds after authentication
+
 # Database optimization settings
 DATABASE_STATEMENT_TIMEOUT = 300  # Seconds before timing out long-running queries
 DATABASE_CONN_MAX_AGE = (


### PR DESCRIPTION
## Add XC_AUTH_DELAY setting to prevent rate limiting errors

### 📝 Description
This PR introduces a new configurable delay that occurs immediately after XtreamCodes authentication and before the first resource request (like fetching categories).

### ❌ The Problem
Some XtreamCodes providers implement very aggressive rate limiting. When Dispatcharr authenticates and then immediately requests the live categories list, these servers return an **Error 844 (Rate Limit Exceeded)** or block the connection. This prevents the M3U playlist from being refreshed correctly.

### ✅ The Solution
Added a new setting `XC_AUTH_DELAY` that allows users to specify a sleep interval (in seconds) between the authentication phase and the first API call.

### 🛠 Changes
- **[dispatcharr/settings.py](cci:7://file:///Users/jrberenguer/repos/Dispatcharr/dispatcharr/settings.py:0:0-0:0)**: Added `XC_AUTH_DELAY` environment variable (defaults to `0`).
- **[apps/m3u/tasks.py](cci:7://file:///Users/jrberenguer/repos/Dispatcharr/apps/m3u/tasks.py:0:0-0:0)**: Implemented the delay logic in the [refresh_m3u_groups](cci:1://file:///Users/jrberenguer/repos/Dispatcharr/apps/m3u/tasks.py:1138:0-1498:30) task.
- **[CHANGELOG.md](cci:7://file:///Users/jrberenguer/repos/Dispatcharr/CHANGELOG.md:0:0-0:0)**: Added a description of the new feature under the `[Unreleased]` section.

### ⚙️ Configuration
By default, the delay is **0** (disabled) to maintain existing behavior for most users. Users experiencing rate limiting can enable it via environment variables:

```yaml
# In your docker-compose.yml
environment:
  - XC_AUTH_DELAY=2.5  # Recommended value for strict servers