### PR TITLE
Fix backup scheduler test to match actual defaults

### DIFF
--- a/apps/backups/tests.py
+++ b/apps/backups/tests.py
@@ -765,11 +765,12 @@ class BackupSchedulerTestCase(TestCase):
 
         settings = scheduler.get_schedule_settings()
 
-        self.assertEqual(settings['enabled'], False)
+        # These should match the DEFAULTS in scheduler.py
+        self.assertEqual(settings['enabled'], True)
         self.assertEqual(settings['frequency'], 'daily')
         self.assertEqual(settings['time'], '03:00')
         self.assertEqual(settings['day_of_week'], 0)
-        self.assertEqual(settings['retention_count'], 0)
+        self.assertEqual(settings['retention_count'], 3)
         self.assertEqual(settings['cron_expression'], '')
 
     def test_update_schedule_settings_stores_values(self):


### PR DESCRIPTION
## Summary
- Fix `test_get_schedule_settings_defaults` to match the actual default values in `scheduler.py`

## Context
Commit [5371519d](https://github.com/Dispatcharr/Dispatcharr/commit/5371519d8a2abca3be8c26918f9e49df7edb25c9) ("Enhancement: Update default backup settings to enable backups and set retention count to 3") changed the defaults in [`scheduler.py` lines 12-17](https://github.com/Dispatcharr/Dispatcharr/blob/5371519d8a2abca3be8c26918f9e49df7edb25c9/apps/backups/scheduler.py#L12-L17) but didn't update the corresponding test.

The test expected:
- `enabled`: False
- `retention_count`: 0

But the actual (intended) defaults are:
- `enabled`: True
- `retention_count`: 3

## Test plan
- [x] `python manage.py test apps.backups.tests` passes

🤖 Generated with [Claude Code](https://claude.ai/code)