### PR TITLE
Enhancement: Allow multiple channel numbering modes for auto channel sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Channel numbering modes for auto channel sync: Added three channel numbering modes when auto-syncing channels from M3U groups:
+  - **Fixed Start Number** (default): Start at a specified number and increment sequentially
+  - **Use Provider Number**: Use channel numbers from the M3U source (tvg-chno), with configurable fallback if provider number is missing
+  - **Next Available**: Auto-assign starting from 1, skipping all used channel numbers
+    Each mode includes its own configuration options accessible via the "Channel Numbering Mode" dropdown in auto sync settings. (Closes #956, #433)
+
 ### Fixed
 
+- Auto channel sync duplicate channel numbers across groups: Fixed issue where multiple auto-sync groups starting at the same number would create duplicate channel numbers. The used channel number tracking now persists across all groups in a single sync operation, ensuring each assigned channel number is globally unique.
 - Modular mode PostgreSQL/Redis connection checks: Replaced raw Python socket checks with native tools (`pg_isready` for PostgreSQL and `socket.create_connection` for Redis) in modular deployment mode to prevent indefinite hangs in Docker environments with non-standard networking or DNS configurations. Now properly supports IPv4 and IPv6 configurations. (Fixes #952) - Thanks [@CodeBormen](https://github.com/CodeBormen)
 
 ## [0.19.0] - 2026-02-10

--- a/apps/m3u/tasks.py
+++ b/apps/m3u/tasks.py
@@ -1648,6 +1648,13 @@ def sync_auto_channels(account_id, scan_start_time=None):
         channels_updated = 0
         channels_deleted = 0
 
+        # Get all channel numbers that are already in use by other channels (not auto-created by this account)
+        used_numbers = set(
+            Channel.objects.exclude(
+                auto_created=True, auto_created_by=account
+            ).values_list("channel_number", flat=True)
+        )
+
         for group_relation in auto_sync_groups:
             channel_group = group_relation.channel_group
             start_number = group_relation.auto_sync_channel_start or 1.0
@@ -1840,13 +1847,6 @@ def sync_auto_channels(account_id, scan_start_time=None):
             # This ensures channels are always in the correct sequence
             channels_to_renumber = []
             temp_channel_number = start_number
-
-            # Get all channel numbers that are already in use by other channels (not auto-created by this account)
-            used_numbers = set(
-                Channel.objects.exclude(
-                    auto_created=True, auto_created_by=account
-                ).values_list("channel_number", flat=True)
-            )
 
             for stream in current_streams:
                 if stream.id in existing_channel_map:

--- a/frontend/src/components/forms/LiveGroupFilter.jsx
+++ b/frontend/src/components/forms/LiveGroupFilter.jsx
@@ -314,17 +314,119 @@ const LiveGroupFilter = ({
 
                   {group.auto_channel_sync && group.enabled && (
                     <>
-                      <NumberInput
-                        label="Start Channel #"
-                        value={group.auto_sync_channel_start}
-                        onChange={(value) =>
-                          updateChannelStart(group.channel_group, value)
+                      <Tooltip
+                        label={
+                          <div>
+                            <div>
+                              <strong>Fixed:</strong> Start at a specific number
+                              and increment
+                            </div>
+                            <div>
+                              <strong>Provider:</strong> Use channel numbers
+                              from the M3U source
+                            </div>
+                            <div>
+                              <strong>Next Available:</strong> Auto-assign
+                              starting from 1, skipping used numbers
+                            </div>
+                          </div>
                         }
-                        min={1}
-                        step={1}
-                        size="xs"
-                        precision={1}
-                      />
+                        withArrow
+                        multiline
+                        w={280}
+                        openDelay={500}
+                      >
+                        <Select
+                          label="Channel Numbering Mode"
+                          placeholder="Select mode..."
+                          value={
+                            group.custom_properties?.channel_numbering_mode ||
+                            'fixed'
+                          }
+                          onChange={(value) => {
+                            setGroupStates(
+                              groupStates.map((state) => {
+                                if (
+                                  state.channel_group === group.channel_group
+                                ) {
+                                  return {
+                                    ...state,
+                                    custom_properties: {
+                                      ...state.custom_properties,
+                                      channel_numbering_mode: value || 'fixed',
+                                    },
+                                  };
+                                }
+                                return state;
+                              })
+                            );
+                          }}
+                          data={[
+                            {
+                              value: 'fixed',
+                              label: 'Fixed Start Number',
+                            },
+                            {
+                              value: 'provider',
+                              label: 'Use Provider Number',
+                            },
+                            {
+                              value: 'next_available',
+                              label: 'Next Available',
+                            },
+                          ]}
+                          size="xs"
+                        />
+                      </Tooltip>
+
+                      {(!group.custom_properties?.channel_numbering_mode ||
+                        group.custom_properties?.channel_numbering_mode ===
+                          'fixed') && (
+                        <NumberInput
+                          label="Start Channel #"
+                          value={group.auto_sync_channel_start}
+                          onChange={(value) =>
+                            updateChannelStart(group.channel_group, value)
+                          }
+                          min={1}
+                          step={1}
+                          size="xs"
+                          precision={0}
+                        />
+                      )}
+
+                      {group.custom_properties?.channel_numbering_mode ===
+                        'provider' && (
+                        <NumberInput
+                          label="Fallback Channel # (if provider # missing)"
+                          value={
+                            group.custom_properties
+                              ?.channel_numbering_fallback || 1
+                          }
+                          onChange={(value) => {
+                            setGroupStates(
+                              groupStates.map((state) => {
+                                if (
+                                  state.channel_group === group.channel_group
+                                ) {
+                                  return {
+                                    ...state,
+                                    custom_properties: {
+                                      ...state.custom_properties,
+                                      channel_numbering_fallback: value || 1,
+                                    },
+                                  };
+                                }
+                                return state;
+                              })
+                            );
+                          }}
+                          min={1}
+                          step={1}
+                          size="xs"
+                          precision={0}
+                        />
+                      )}
 
                       {/* Auto Channel Sync Options Multi-Select */}
                       <MultiSelect


### PR DESCRIPTION
This update introduces three channel numbering modes for the auto channel sync feature: Fixed Start Number, Use Provider Number, and Next Available. The default mode is Fixed Start Number, which allows users to specify a starting number and increment sequentially. The Use Provider Number mode utilizes channel numbers from the M3U source, with a configurable fallback option if the provider number is missing. The Next Available mode auto-assigns starting from 1, skipping any used channel numbers. Additionally, a bug was fixed to prevent duplicate channel numbers across overlapping groups.

Closes #956, #433