### PR TITLE
Fix: add tmdb_id and imdb_id to Xtream get_series response

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -2523,6 +2523,8 @@ def xc_get_series(request, user, category_id=None):
             "episode_run_time": series.custom_properties.get('episode_run_time', '') if series.custom_properties else "",
             "category_id": str(relation.category.id) if relation.category else "0",
             "category_ids": [int(relation.category.id)] if relation.category else [],
+            "tmdb_id": series.tmdb_id or "",
+            "imdb_id": series.imdb_id or "",
         })
 
     return series_list


### PR DESCRIPTION
## Summary

- `get_series` Xtream endpoint was missing `tmdb_id` and `imdb_id` fields
- These fields are already stored on the `Series` model and already included in `get_vod_streams` (movies) — this was a simple omission
- Xtream clients (e.g. Chillio) use these IDs to fetch proper metadata from TMDB, including sanitized series titles and poster images

## Impact

Without `tmdb_id`/`imdb_id` in the `get_series` response, clients that do TMDB enrichment fall back to:
- The raw provider series name, which may include provider prefixes (e.g. `┃NL┃ Lieve Mama` instead of `Lieve Mama`)
- The proxied cover URL instead of TMDB's poster image

## Change

```python
# apps/output/views.py — xc_get_series()
"tmdb_id": series.tmdb_id or "",
"imdb_id": series.imdb_id or "",
```

Two lines, matching exactly what `get_vod_streams` already does for movies.

## Test plan

- [ ] Connect an Xtream client that uses TMDB enrichment (e.g. Chillio) via Dispatcharr
- [ ] Verify series names are resolved to clean TMDB titles
- [ ] Verify series poster images load from TMDB instead of the proxied cover URL
- [ ] Verify clients that don't use TMDB enrichment are unaffected (extra fields are ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)