### PR TITLE
fix(frontend): prevent infinite re-renders (React error #185)

### DIFF
--- a/frontend/src/components/tables/CustomTable/index.jsx
+++ b/frontend/src/components/tables/CustomTable/index.jsx
@@ -18,7 +18,7 @@ const useTable = ({
   expandedRowRenderer = () => <></>,
   onRowSelectionChange = null,
   getExpandedRowHeight = null,
-  state = [],
+  state = {},
   columnSizing,
   setColumnSizing,
   onColumnVisibilityChange,
@@ -103,6 +103,11 @@ const useTable = ({
       selectedTableIds,
       ...(columnSizing && { columnSizing }),
     },
+    // Add these lines to prevent infinite loops during data updates
+    autoResetPageIndex: false,
+    autoResetExpanded: false,
+    autoResetRowSelection: false,
+
     onStateChange: options.onStateChange,
     ...(setColumnSizing && { onColumnSizingChange: setColumnSizing }),
     ...(onColumnVisibilityChange && { onColumnVisibilityChange }),

--- a/frontend/src/components/tables/M3UsTable.jsx
+++ b/frontend/src/components/tables/M3UsTable.jsx
@@ -139,6 +139,21 @@ const M3UTable = () => {
   const setRefreshProgress = usePlaylistsStore((s) => s.setRefreshProgress);
   const editPlaylistId = usePlaylistsStore((s) => s.editPlaylistId);
   const setEditPlaylistId = usePlaylistsStore((s) => s.setEditPlaylistId);
+
+  // Memoize data to prevent unnecessary re-renders during progress updates
+  const processedData = useMemo(() => {
+    return playlists
+      .filter((playlist) => playlist.locked === false)
+      .sort((a, b) => {
+        // First sort by active status (active items first)
+        if (a.is_active !== b.is_active) {
+          return a.is_active ? -1 : 1;
+        }
+        // Then sort by name (case-insensitive)
+        return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+      });
+  }, [playlists]);
+
   const isWarningSuppressed = useWarningsStore((s) => s.isWarningSuppressed);
   const suppressWarning = useWarningsStore((s) => s.suppressWarning);
 
@@ -640,18 +655,7 @@ const M3UTable = () => {
 
   // Listen for edit playlist requests from notifications
   useEffect(() => {
-    setData(
-      playlists
-        .filter((playlist) => playlist.locked === false)
-        .sort((a, b) => {
-          // First sort by active status (active items first)
-          if (a.is_active !== b.is_active) {
-            return a.is_active ? -1 : 1;
-          }
-          // Then sort by name (case-insensitive)
-          return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
-        })
-    );
+    setData(processedData);
 
     if (editPlaylistId) {
       const playlistToEdit = playlists.find((p) => p.id === editPlaylistId);
@@ -661,7 +665,7 @@ const M3UTable = () => {
         setEditPlaylistId(null);
       }
     }
-  }, [editPlaylistId, playlists]);
+  }, [editPlaylistId, processedData, playlists, setEditPlaylistId]);
 
   const onSortingChange = (column) => {
     console.log(column);


### PR DESCRIPTION
## Summary
This PR fixes the "Minified React error #185" (Maximum update depth exceeded) that occurs in the frontend, particularly during M3U imports or when background tasks update the playlist status.

## Changes
- **CustomTable**: Disabled `autoResetPageIndex`, `autoResetExpanded`, and `autoResetRowSelection` to prevent the table from resetting its state during data updates, which caused infinite re-render loops.
- **CustomTable**: Fixed default state initialization (changed `[]` to `{}`) to match TanStack Table's expected state object structure.
- **M3UsTable**: Memoized the `processedData` to ensure stable references during progress updates from the backend.

## Test plan
1. Start an M3U import.
2. Observe the M3U table while progress messages are received via WebSockets.
3. Verify that the table no longer crashes with a "Maximum update depth exceeded" error.

Made with [Cursor](https://cursor.com)