### PR TITLE
fix(accounts): allow passwords with leading/trailing spaces

### DIFF
--- a/apps/accounts/api_views.py
+++ b/apps/accounts/api_views.py
@@ -16,11 +16,22 @@ from dispatcharr.utils import network_access_allowed
 from .models import User
 from .serializers import UserSerializer, GroupSerializer, PermissionSerializer
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 logger = logging.getLogger(__name__)
 
 
+class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Ensure password is not trimmed to allow passwords with leading/trailing spaces
+        if 'password' in self.fields:
+            self.fields['password'].trim_whitespace = False
+
+
 class TokenObtainPairView(TokenObtainPairView):
+    serializer_class = CustomTokenObtainPairSerializer
+
     def post(self, request, *args, **kwargs):
         # Custom logic here
         if not network_access_allowed(request, "UI"):

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -24,7 +24,7 @@ class GroupSerializer(serializers.ModelSerializer):
 
 # 🔹 Fix for User serialization
 class UserSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(write_only=True)
+    password = serializers.CharField(write_only=True, trim_whitespace=False)
     channel_profiles = serializers.PrimaryKeyRelatedField(
         queryset=ChannelProfile.objects.all(), many=True, required=False
     )


### PR DESCRIPTION
## Summary
This PR fixes an issue where users were unable to log in if their password contained leading or trailing spaces. This occurred because Django Rest Framework's `CharField` trims whitespace by default.

## Changes
- **TokenObtainPairView**: Introduced `CustomTokenObtainPairSerializer` which explicitly sets `trim_whitespace=False` for the password field.
- **UserSerializer**: Updated the password field to set `trim_whitespace=False`.

This ensures that the password provided during login exactly matches the one stored in the database, even if it contains spaces that would normally be trimmed.

## Test plan
1. Create a user with a password that has a trailing space (e.g., `secret `).
2. Attempt to log in with that exact password.
3. Verify that login succeeds.

Made with [Cursor](https://cursor.com)