### PR TITLE
fix(accounts): allow passwords with leading/trailing spaces

### DIFF
--- a/apps/accounts/api_views.py
+++ b/apps/accounts/api_views.py
@@ -16,11 +16,22 @@ from dispatcharr.utils import network_access_allowed
 from .models import User
 from .serializers import UserSerializer, GroupSerializer, PermissionSerializer
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 logger = logging.getLogger(__name__)
 
 
+class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Ensure password is not trimmed to allow passwords with leading/trailing spaces
+        if 'password' in self.fields:
+            self.fields['password'].trim_whitespace = False
+
+
 class TokenObtainPairView(TokenObtainPairView):
+    serializer_class = CustomTokenObtainPairSerializer
+
     def post(self, request, *args, **kwargs):
         # Custom logic here
         if not network_access_allowed(request, "UI"):

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -47,7 +47,9 @@ class GroupSerializer(serializers.ModelSerializer):
 
 # 🔹 Fix for User serialization
 class UserSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(write_only=True, required=False)
+    password = serializers.CharField(
+        write_only=True, required=False, trim_whitespace=False
+    )
     channel_profiles = serializers.PrimaryKeyRelatedField(
         queryset=ChannelProfile.objects.all(), many=True, required=False
     )


### PR DESCRIPTION
## Description
Users could get locked out when their password had leading or trailing spaces. Django REST Framework’s `CharField` trims whitespace by default, so the submitted password no longer matched what was stored.

**Changes:**
- **`CustomTokenObtainPairSerializer`** —  sets `trim_whitespace=False` on the login password field (JWT token view).
- **`UserSerializer`** —  sets `trim_whitespace=False` on the password field for create/update, and keeps `required=False` from `dev` after rebase.
Passwords are now handled exactly as sent/stored, including surrounding spaces.
## Related Issue
N/A
## How was it tested?
- Fresh **Debian** installs in **LXC**: one checkout on upstream `dev`, one on this branch.
- Ran **`debian_install.sh`** on both with the same flow.
- Created a user / used a password with **trailing spaces** and attempted login.
- **Before:** login failed; **after (this PR):** login succeeded.
## Checklist
- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed (N/A — no model changes)
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema (N/A — no new endpoints)
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`) (N/A — no frontend changes)
- [ ] Tests are included for new functionality
- [ ] Existing tests still pass (not run locally; relying on CI)
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change