### PR TITLE
fix: add /data/backups to init script DATA_DIRS

### DIFF
--- a/docker/init/03-init-dispatcharr.sh
+++ b/docker/init/03-init-dispatcharr.sh
@@ -2,6 +2,7 @@
 
 # Define directories that need to exist and be owned by PUID:PGID
 DATA_DIRS=(
+    "/data/backups"
     "/data/logos"
     "/data/recordings"
     "/data/uploads/m3us"


### PR DESCRIPTION
Corrects issue with user ownership migration on previous installations with /data/backups in-use

## Description

<!-- What does this PR do? Be specific. -->

`/data/backups` was missing from the `DATA_DIRS` array in `docker/init/03-init-dispatcharr.sh`.
On upgrade from pre-PUID images (or when a user changes PUID/PGID), the directory retains its
old ownership while Django now runs as the new PUID — causing `[Errno 13] Permission denied`
when creating backup files.

Every other `/data/` subdirectory the application writes to was already listed in `DATA_DIRS`.
`/data/backups` was simply missed.

The fix adds `"/data/backups"` to the array, ensuring the directory is created and its ownership
is reconciled to `PUID:PGID` on every container startup — matching the existing pattern for all
other data directories.

## Related Issue

<!-- Non-trivial changes should have a linked issue. If this is a small/obvious fix, you may leave this blank. -->

Reported by user after upgrading to a version containing the PUID/PGID ownership changes.

## How was it tested?

<!-- What did you actually run to verify this works? Be specific — "it works" is not sufficient. -->

**Reproduction (unpatched code):**
- Created volume with `/data/backups` owned by UID 102 (old postgres user)
- Started container with PUID=1000 → backup failed: `Permission denied: '/data/backups/...'`

**After fix:**
- Upgrade scenario (UID 102 → PUID 1000): directory chowned, backup created successfully
- PUID change scenario (1000 → 2000): directory chowned, new backup created, old backup preserved
- Fresh install: directory created with correct ownership, backup succeeded
- No negative side effects: backup listing, download token, nginx protected-backups serving (HTTP 200), process ownership all verified
- Django unit tests: 26/26 passed

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [X] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [X] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [X] I understand — line by line — every change in this PR and can explain it if asked
- [X] This PR targets the `dev` branch
- [X] Backend: migrations are included if any models were changed
- [X] Backend: new API endpoints appear correctly in the OpenAPI schema
- [X] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [X] Tests are included for new functionality
- [X] Existing tests still pass
- [X] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [X] I have not reformatted or refactored code outside the scope of this change
