### PR TITLE
Fix/graceful chown + external mounts

### DIFF
--- a/docker/init/01-user-setup.sh
+++ b/docker/init/01-user-setup.sh
@@ -6,24 +6,11 @@
 # runtime behavior since all postgres operations run as $POSTGRES_USER
 # rather than the postgres system user.
 
-# Auto-detect PUID/PGID from existing data when not explicitly set.
-# Avoids a cross-UID chown on upgrade, which would fail on restricted
-# filesystems (NFS root_squash, CIFS). UID/GID 0 is excluded — PostgreSQL
-# refuses to run as root. Falls through to default 1000 for new installs.
-if [ -z "${PUID+x}" ] && [ -f "${POSTGRES_DIR}/PG_VERSION" ]; then
-    _data_uid=$(stat -c '%u' "${POSTGRES_DIR}/PG_VERSION")
-    if [ "$_data_uid" -ne 0 ] 2>/dev/null; then
-        export PUID=$_data_uid
-        echo "PUID not set — defaulting to existing data owner UID: $PUID"
-    fi
-fi
-if [ -z "${PGID+x}" ] && [ -f "${POSTGRES_DIR}/PG_VERSION" ]; then
-    _data_gid=$(stat -c '%g' "${POSTGRES_DIR}/PG_VERSION")
-    if [ "$_data_gid" -ne 0 ] 2>/dev/null; then
-        export PGID=$_data_gid
-        echo "PGID not set — defaulting to existing data owner GID: $PGID"
-    fi
-fi
+# Default PUID/PGID to 1000 when not explicitly set.
+# The old image ran Django as UID 1000 and PostgreSQL as UID 102. Since
+# DATA_DIRS and host-side files are owned by 1000, defaulting to 1000
+# preserves access for upgrading users without requiring configuration.
+# The DB ownership migration (102 → 1000) is handled by 02-postgres.sh.
 export PUID=${PUID:-1000}
 export PGID=${PGID:-1000}
 

--- a/docker/init/03-init-dispatcharr.sh
+++ b/docker/init/03-init-dispatcharr.sh
@@ -31,6 +31,7 @@ done
 
 # Create data directories, tolerating failures on external mounts
 _failed_mkdir=()
+_failed_chown=()
 for dir in "${DATA_DIRS[@]}"; do
     _mkdir_err=$(mkdir -p "$dir" 2>&1) || _failed_mkdir+=("$dir ($_mkdir_err)")
 done
@@ -63,7 +64,6 @@ if [ "$(id -u)" = "0" ]; then
     # Fix data directories (non-recursive to avoid touching user files).
     # Failures are collected rather than fatal — directories may be on
     # external mounts (NFS, SMB/CIFS, FUSE) that reject chown.
-    _failed_chown=()
     for dir in "${DATA_DIRS[@]}"; do
         if [ -d "$dir" ] && [ "$(stat -c '%u:%g' "$dir" 2>/dev/null)" != "$PUID:$PGID" ]; then
             _chown_err=$(chown "$PUID:$PGID" "$dir" 2>&1) || {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Be specific. -->

Two related fixes for the PUID/PGID ownership changes:

The auto-detect read PUID/PGID from `/data/db` ownership, which was UID 102 in pre-PUID images. This caused all upgrading users (who didn't set PUID) to run as UID 102 instead of the expected 1000. 

Effects:
- Host-side access broken (SSH, WinSCP — host user is typically UID 1000)
- Existing DATA_DIR files unwritable (owned by 1000, process running as 102)
- Comskip failures on recordings created before the UID switch

Now defaults to 1000 when not explicitly set. The DB ownership migration (102 → 1000) is already handled by `02-postgres.sh` on local volumes.

**2. Graceful chown failures on external mounts (03-init-dispatcharr.sh)**

DATA_DIRS chown failures (NFS root_squash, SMB/CIFS, FUSE) crashed the container under `set -e`. The old image never chowned these directories, so users with external mounts had a working setup that broke on upgrade.

- `mkdir` and `chown` failures collected per-directory instead of crashing
- Single consolidated warning listing affected paths, current ownership, OS-level error, and three remediation options
- Container continues to start normally
- Also adds `/data/backups` to DATA_DIRS (was missing, caused backup permission denied errors after upgrade)

## Related Issue

<!-- Non-trivial changes should have a linked issue. If this is a small/obvious fix, you may leave this blank. -->

Reported by users after upgrading to the version containing the PUID/PGID ownership changes: backup permission denied, SSH/WinSCP access loss, comskip failures, NFS/SMB mount crashes.

## How was it tested?

<!-- What did you actually run to verify this works? Be specific — "it works" is not sufficient. -->

**Auto-detect removal:**
- Upgrade from pre-PUID image (DB owned by UID 102): PUID defaults to 1000, DB migrated 102→1000, DATA_DIRS untouched (already 1000).
- Fresh install: all owned by 1000.
- Explicit PUID=1500: all owned by 1500.
- Edge cases: need to document that when changing PUID:PGID, ownership must manually be changed for files within Dispatcharr-owned file mounts. The current migration own chowns the directory. This is intentional as to not break permissions on shared directories.

**Graceful chown:**
- NFS simulation (chown returns EPERM): container starts, consolidated warning lists both dirs with ownership + error reason.
- Local volume mismatch: chown succeeds silently, no warning.
- PUID change (1000→2000): directories reconciled.
- Backup create/list/download: all operations succeed.

**Regression:**
- Django unit tests: 26/26 passed

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [X] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [X] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [X] I understand — line by line — every change in this PR and can explain it if asked
- [X] This PR targets the `dev` branch
- [X] Backend: migrations are included if any models were changed
- [X] Backend: new API endpoints appear correctly in the OpenAPI schema
- [X] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [X] Tests are included for new functionality
- [X] Existing tests still pass
- [X] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [X] I have not reformatted or refactored code outside the scope of this change
