### PR TITLE
Fix stream_view returning None due to indentation error

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -184,7 +184,7 @@ def stream_view(request, channel_uuid):
             persistent_lock.release()
             logger.debug("Persistent lock released for channel ID=%s", channel.id)
 
-        return StreamingHttpResponse(
-            stream_generator(process, stream, persistent_lock),
-            content_type="video/MP2T"
-        )
+    return StreamingHttpResponse(
+        stream_generator(process, stream, persistent_lock),
+        content_type="video/MP2T"
+    )


### PR DESCRIPTION
## Summary
- The `return StreamingHttpResponse(...)` in `core/views.py` was indented inside the `stream_generator` inner function instead of in `stream_view`
- Since `stream_generator` is a generator (uses `yield`), the `return` after `finally` was unreachable
- `stream_view` fell through without returning a response, causing Django to raise:
  `ValueError: The view core.views.stream_view didn't return an HttpResponse object. It returned None instead.`
- This also caused stale Redis profile locks (the lock acquired before `stream_generator` was never released on the successful path), blocking all subsequent stream requests with "No available profiles for the stream"

## Fix
Dedent `return StreamingHttpResponse(...)` by one level (lines 187-190) so it belongs to `stream_view` instead of `stream_generator`.

## Test plan
- [x] Stream a channel via `/output/stream/<uuid>` — previously returned HTTP 500 with "No available streams for this channel", now returns video data (29MB in 10s, 1080p60 h264)
- [x] No stale Redis locks after streaming
- [x] Lock is properly released when client disconnects (via `stream_generator`'s `finally` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)