### PR TITLE
Support streaming ts file on currently recording video

### DIFF
--- a/apps/channels/api_views.py
+++ b/apps/channels/api_views.py
@@ -2352,8 +2352,15 @@ class RecordingViewSet(viewsets.ModelViewSet):
         file_path = cp.get("file_path")
         file_name = cp.get("file_name") or "recording"
 
-        if not file_path or not os.path.exists(file_path):
-            raise Http404("Recording file not found")
+        # For in-progress recordings, the final MKV may not exist yet or be empty.
+        # Fall back to the temporary .ts file if available.
+        if not file_path or not os.path.exists(file_path) or os.path.getsize(file_path) == 0:
+            temp_path = cp.get("_temp_file_path")
+            if temp_path and os.path.exists(temp_path) and os.path.getsize(temp_path) > 0:
+                file_path = temp_path
+                file_name = os.path.basename(temp_path)
+            elif not file_path or not os.path.exists(file_path):
+                raise Http404("Recording file not found")
 
         # Guess content type
         ext = os.path.splitext(file_path)[1].lower()
@@ -2361,6 +2368,8 @@ class RecordingViewSet(viewsets.ModelViewSet):
             content_type = "video/mp4"
         elif ext == ".mkv":
             content_type = "video/x-matroska"
+        elif ext == ".ts":
+            content_type = "video/mp2t"
         else:
             content_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
 

--- a/apps/channels/tests/test_recording_file.py
+++ b/apps/channels/tests/test_recording_file.py
@@ -1,0 +1,195 @@
+"""Tests for the recording file streaming endpoint.
+
+Covers:
+  - Fallback from missing/empty main file to _temp_file_path (.ts)
+  - Content-type detection for .mp4, .mkv, .ts, and unknown extensions
+  - 404 when neither main file nor temp file exists
+  - Full file response headers
+  - Range request (HTTP 206) response
+"""
+import os
+import tempfile
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.channels.models import Channel, Recording
+from apps.channels.api_views import RecordingViewSet
+
+
+def _make_admin():
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    u, _ = User.objects.get_or_create(
+        username="file_test_admin",
+        defaults={"user_level": User.UserLevel.ADMIN},
+    )
+    u.set_password("pass")
+    u.save()
+    return u
+
+
+class RecordingFileEndpointTests(TestCase):
+    """Tests for GET /api/channels/recordings/{id}/file/"""
+
+    def setUp(self):
+        self.channel = Channel.objects.create(
+            channel_number=77, name="File Test Channel"
+        )
+        self.user = _make_admin()
+        self.factory = APIRequestFactory()
+        # Create real temp files for testing
+        self._temp_files = []
+
+    def tearDown(self):
+        for f in self._temp_files:
+            try:
+                os.unlink(f)
+            except OSError:
+                pass
+
+    def _create_temp_file(self, suffix=".mkv", content=b"fake video data"):
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        os.write(fd, content)
+        os.close(fd)
+        self._temp_files.append(path)
+        return path
+
+    def _make_rec(self, custom_properties=None):
+        now = timezone.now()
+        return Recording.objects.create(
+            channel=self.channel,
+            start_time=now - timedelta(hours=1),
+            end_time=now + timedelta(hours=1),
+            custom_properties=custom_properties or {},
+        )
+
+    def _get_file(self, rec, **extra):
+        request = self.factory.get(
+            f"/api/channels/recordings/{rec.id}/file/", **extra
+        )
+        force_authenticate(request, user=self.user)
+        view = RecordingViewSet.as_view({"get": "file"})
+        return view(request, pk=rec.id)
+
+    # ── 404 cases ──────────────────────────────────────────────
+
+    def test_404_when_no_file_path(self):
+        rec = self._make_rec({"status": "completed"})
+        response = self._get_file(rec)
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_when_file_does_not_exist(self):
+        rec = self._make_rec({"file_path": "/nonexistent/video.mkv"})
+        response = self._get_file(rec)
+        self.assertEqual(response.status_code, 404)
+
+    def test_serves_empty_main_file_when_no_temp(self):
+        """An empty main file is still served if no temp fallback exists."""
+        empty_file = self._create_temp_file(content=b"")
+        rec = self._make_rec({"file_path": empty_file})
+        response = self._get_file(rec)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Length"], "0")
+
+    # ── Temp file fallback ─────────────────────────────────────
+
+    def test_falls_back_to_temp_ts_when_main_missing(self):
+        ts_file = self._create_temp_file(suffix=".ts", content=b"ts stream data")
+        rec = self._make_rec({
+            "file_path": "/nonexistent/video.mkv",
+            "_temp_file_path": ts_file,
+        })
+        response = self._get_file(rec)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "video/mp2t")
+
+    def test_falls_back_to_temp_ts_when_main_empty(self):
+        empty_mkv = self._create_temp_file(suffix=".mkv", content=b"")
+        ts_file = self._create_temp_file(suffix=".ts", content=b"ts stream data")
+        rec = self._make_rec({
+            "file_path": empty_mkv,
+            "_temp_file_path": ts_file,
+        })
+        response = self._get_file(rec)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "video/mp2t")
+
+    def test_serves_main_file_when_it_exists_and_nonempty(self):
+        mkv_file = self._create_temp_file(suffix=".mkv", content=b"real mkv data")
+        ts_file = self._create_temp_file(suffix=".ts", content=b"ts stream data")
+        rec = self._make_rec({
+            "file_path": mkv_file,
+            "_temp_file_path": ts_file,
+            "file_name": "show.mkv",
+        })
+        response = self._get_file(rec)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "video/x-matroska")
+
+    # ── Content-type detection ─────────────────────────────────
+
+    def test_content_type_mp4(self):
+        mp4_file = self._create_temp_file(suffix=".mp4", content=b"mp4 data")
+        rec = self._make_rec({"file_path": mp4_file})
+        response = self._get_file(rec)
+        self.assertEqual(response["Content-Type"], "video/mp4")
+
+    def test_content_type_mkv(self):
+        mkv_file = self._create_temp_file(suffix=".mkv", content=b"mkv data")
+        rec = self._make_rec({"file_path": mkv_file})
+        response = self._get_file(rec)
+        self.assertEqual(response["Content-Type"], "video/x-matroska")
+
+    def test_content_type_ts(self):
+        ts_file = self._create_temp_file(suffix=".ts", content=b"ts data")
+        rec = self._make_rec({"file_path": ts_file})
+        response = self._get_file(rec)
+        self.assertEqual(response["Content-Type"], "video/mp2t")
+
+    # ── Response headers ───────────────────────────────────────
+
+    def test_full_response_headers(self):
+        mkv_file = self._create_temp_file(suffix=".mkv", content=b"12345678")
+        rec = self._make_rec({"file_path": mkv_file, "file_name": "episode.mkv"})
+        response = self._get_file(rec)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Length"], "8")
+        self.assertEqual(response["Accept-Ranges"], "bytes")
+        self.assertIn("episode.mkv", response["Content-Disposition"])
+
+    def test_fallback_file_name_uses_temp_basename(self):
+        ts_file = self._create_temp_file(suffix=".ts", content=b"data")
+        rec = self._make_rec({
+            "file_path": "/nonexistent/video.mkv",
+            "_temp_file_path": ts_file,
+        })
+        response = self._get_file(rec)
+        expected_name = os.path.basename(ts_file)
+        self.assertIn(expected_name, response["Content-Disposition"])
+
+    # ── Range requests ─────────────────────────────────────────
+
+    def test_range_request_returns_206(self):
+        content = b"0123456789abcdef"
+        mkv_file = self._create_temp_file(suffix=".mkv", content=content)
+        rec = self._make_rec({"file_path": mkv_file, "file_name": "video.mkv"})
+        response = self._get_file(rec, HTTP_RANGE="bytes=0-7")
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response["Content-Length"], "8")
+        self.assertIn("bytes 0-7/16", response["Content-Range"])
+        body = b"".join(response.streaming_content)
+        self.assertEqual(body, b"01234567")
+
+    def test_range_request_mid_file(self):
+        content = b"0123456789abcdef"
+        mkv_file = self._create_temp_file(suffix=".mkv", content=content)
+        rec = self._make_rec({"file_path": mkv_file})
+        response = self._get_file(rec, HTTP_RANGE="bytes=4-11")
+        self.assertEqual(response.status_code, 206)
+        body = b"".join(response.streaming_content)
+        self.assertEqual(body, b"456789ab")


### PR DESCRIPTION
## Description

The `/api/channels/recordings/{id}/file/` endpoint return nothing on a recording in progress. To be able to watch an in-progress recording from beginning this endpoint should use the temporary `.ts` file since the final `.mkv` file is created at the end of the recording.

## Related Issue
Closes #1123

## How was it tested?
Clone my fork/branch on a Proxmox LXC. Copy the `dispatcharr_data` from my real Dispatcharr server.
```
cd Dispatcharr
git checkout feature/watch-live-recording-from-start
docker/build-dev.sh

docker run \
  -p 9191:9191 \
  --name dispatcharr-dev \
  -v /root/dispatcharr_data:/data \
  dispatcharr:dev 
```

- Using my app StreamClient with branch https://github.com/Drvolks/NexusPVR/tree/feature/dispatcharr/play-from-beginning 
- start a recording
- wait a minute or so and try to play the recording from beginning (invokes `/api/channels/recordings/{id}/file/`)
- With this patch, it works. With v0.21.1 the player fails to start because the stream is empty.

### Unit testing
Inside the docker container I execute
`python manage.py test apps.channels.tests.test_recording_file -v 2`

```
test_404_when_file_does_not_exist (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_404_when_file_does_not_exist) ... 2026-03-20 15:13:27,386 INFO apps.channels.signals Recording 1: start_time in past but end_time still future, scheduling immediately
Celery configuring loggers with level: INFO
ok
test_404_when_no_file_path (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_404_when_no_file_path) ... 2026-03-20 15:13:27,632 INFO apps.channels.signals Recording 2: start_time in past but end_time still future, scheduling immediately
ok
test_content_type_mkv (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_content_type_mkv) ... 2026-03-20 15:13:27,953 INFO apps.channels.signals Recording 3: start_time in past but end_time still future, scheduling immediately
ok
test_content_type_mp4 (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_content_type_mp4) ... 2026-03-20 15:13:28,245 INFO apps.channels.signals Recording 4: start_time in past but end_time still future, scheduling immediately
ok
test_content_type_ts (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_content_type_ts) ... 2026-03-20 15:13:28,466 INFO apps.channels.signals Recording 5: start_time in past but end_time still future, scheduling immediately
ok
test_fallback_file_name_uses_temp_basename (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_fallback_file_name_uses_temp_basename) ... 2026-03-20 15:13:28,696 INFO apps.channels.signals Recording 6: start_time in past but end_time still future, scheduling immediately
ok
test_falls_back_to_temp_ts_when_main_empty (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_falls_back_to_temp_ts_when_main_empty) ... 2026-03-20 15:13:29,020 INFO apps.channels.signals Recording 7: start_time in past but end_time still future, scheduling immediately
ok
test_falls_back_to_temp_ts_when_main_missing (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_falls_back_to_temp_ts_when_main_missing) ... 2026-03-20 15:13:29,253 INFO apps.channels.signals Recording 8: start_time in past but end_time still future, scheduling immediately
ok
test_full_response_headers (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_full_response_headers) ... 2026-03-20 15:13:29,466 INFO apps.channels.signals Recording 9: start_time in past but end_time still future, scheduling immediately
ok
test_range_request_mid_file (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_range_request_mid_file) ... 2026-03-20 15:13:29,684 INFO apps.channels.signals Recording 10: start_time in past but end_time still future, scheduling immediately
ok
test_range_request_returns_206 (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_range_request_returns_206) ... 2026-03-20 15:13:29,929 INFO apps.channels.signals Recording 11: start_time in past but end_time still future, scheduling immediately
ok
test_serves_empty_main_file_when_no_temp (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_serves_empty_main_file_when_no_temp)
An empty main file is still served if no temp fallback exists. ... 2026-03-20 15:13:30,200 INFO apps.channels.signals Recording 12: start_time in past but end_time still future, scheduling immediately
ok
test_serves_main_file_when_it_exists_and_nonempty (apps.channels.tests.test_recording_file.RecordingFileEndpointTests.test_serves_main_file_when_it_exists_and_nonempty) ... 2026-03-20 15:13:30,417 INFO apps.channels.signals Recording 13: start_time in past but end_time still future, scheduling immediately
ok

----------------------------------------------------------------------
Ran 13 tests in 3.250s

OK
```

Running all tests
`python manage.py test`

```
System check identified no issues (0 silenced).
..............2026-03-20 15:18:01,557 WARNING django.request Bad Request: /api/accounts/users/me/
...2026-03-20 15:18:02,564 WARNING django.request Unauthorized: /api/accounts/users/me/
....2026-03-20 15:18:03,595 INFO wait_for_redis Waiting for Redis at localhost:6379/0...
2026-03-20 15:18:03,596 INFO wait_for_redis Flushed Redis database
2026-03-20 15:18:03,596 INFO wait_for_redis ✅ Redis at localhost:6379/0 is now available!
.2026-03-20 15:18:03,597 INFO wait_for_redis Waiting for Redis at localhost:6379/0...
2026-03-20 15:18:03,597 INFO wait_for_redis ✅ Redis at localhost:6379/0 is now available!
.2026-03-20 15:18:03,598 INFO wait_for_redis Waiting for Redis at localhost:6379/0...
2026-03-20 15:18:03,598 INFO wait_for_redis ⏳ Redis not available yet, retrying in 0s... (1/5)
2026-03-20 15:18:03,598 INFO wait_for_redis ⏳ Redis not available yet, retrying in 0s... (2/5)
2026-03-20 15:18:03,599 INFO wait_for_redis Flushed Redis database
2026-03-20 15:18:03,599 INFO wait_for_redis ✅ Redis at localhost:6379/0 is now available!
.2026-03-20 15:18:03,599 INFO wait_for_redis Waiting for Redis at localhost:6379/0...
2026-03-20 15:18:03,599 INFO wait_for_redis ⏳ Redis not available yet, retrying in 0s... (1/2)
2026-03-20 15:18:03,599 ERROR wait_for_redis ❌ Failed to connect to Redis after 2 attempts: refused
.2026-03-20 15:18:03,600 INFO wait_for_redis Waiting for Redis at localhost:6379/0...
2026-03-20 15:18:03,601 ERROR wait_for_redis ❌ Unexpected error connecting to Redis: unexpected
.
----------------------------------------------------------------------
Ran 26 tests in 2.751s

OK
```

### More validation
Using this python script that I put in /app inside the docker image:
```
import os
import sys
import django
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'dispatcharr.settings')
django.setup()

from apps.channels.models import Recording

if len(sys.argv) < 2:
    print(f'Usage: {sys.argv[0]} <recording_id>')
    sys.exit(1)

r = Recording.objects.get(pk=int(sys.argv[1]))
cp = r.custom_properties or {}
print('file_path:', cp.get('file_path'))
print('_temp_file_path:', cp.get('_temp_file_path'))

fp = cp.get('file_path')
tp = cp.get('_temp_file_path')
if fp:
    print('file exists:', os.path.exists(fp), 'size:', os.path.getsize(fp) if os.path.exists(fp) else 'N/A')
if tp:
    print('temp exists:', os.path.exists(tp), 'size:', os.path.getsize(tp) if os.path.exists(tp) else 'N/A')
```

I execute `python check_recording.py 12` to confirm we have access to the temp `.ts` file and the `.mkv` file is empty.

```
file_path: /data/recordings/TV_Shows/MotoGP ᴺᵉʷ
Brazilian Grand Prix Free Practice 1/20260320_141834.mkv
_temp_file_path: /data/recordings/TV_Shows/MotoGP ᴺᵉʷ
Brazilian Grand Prix Free Practice 1/20260320_141834.ts
file exists: True size: 0
temp exists: True size: 63455232
```

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
