### PR TITLE
Add select_related to Channel queries in output views

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -138,7 +138,7 @@ def generate_m3u(request, profile_name=None, user=None):
                 # Hide adult content if user preference is set
                 if (user.custom_properties or {}).get('hide_adult_content', False):
                     filters["is_adult"] = False
-                channels = Channel.objects.filter(**filters).order_by("channel_number")
+                channels = Channel.objects.filter(**filters).select_related('channel_group', 'logo').order_by("channel_number")
             else:
                 # User has specific limited profiles assigned
                 filters = {
@@ -149,9 +149,9 @@ def generate_m3u(request, profile_name=None, user=None):
                 # Hide adult content if user preference is set
                 if (user.custom_properties or {}).get('hide_adult_content', False):
                     filters["is_adult"] = False
-                channels = Channel.objects.filter(**filters).distinct().order_by("channel_number")
+                channels = Channel.objects.filter(**filters).select_related('channel_group', 'logo').distinct().order_by("channel_number")
         else:
-            channels = Channel.objects.filter(user_level__lte=user.user_level).order_by(
+            channels = Channel.objects.filter(user_level__lte=user.user_level).select_related('channel_group', 'logo').order_by(
                 "channel_number"
             )
 
@@ -165,9 +165,9 @@ def generate_m3u(request, profile_name=None, user=None):
             channels = Channel.objects.filter(
                 channelprofilemembership__channel_profile=channel_profile,
                 channelprofilemembership__enabled=True
-            ).order_by('channel_number')
+            ).select_related('channel_group', 'logo').order_by('channel_number')
         else:
-            channels = Channel.objects.order_by("channel_number")
+            channels = Channel.objects.select_related('channel_group', 'logo').order_by("channel_number")
 
     # Check if the request wants to use direct logo URLs instead of cache
     use_cached_logos = request.GET.get('cachedlogos', 'true').lower() != 'false'
@@ -1301,7 +1301,7 @@ def generate_epg(request, profile_name=None, user=None):
                     # Hide adult content if user preference is set
                     if (user.custom_properties or {}).get('hide_adult_content', False):
                         filters["is_adult"] = False
-                    channels = Channel.objects.filter(**filters).order_by("channel_number")
+                    channels = Channel.objects.filter(**filters).select_related('logo').order_by("channel_number")
                 else:
                     # User has specific limited profiles assigned
                     filters = {
@@ -1312,9 +1312,9 @@ def generate_epg(request, profile_name=None, user=None):
                     # Hide adult content if user preference is set
                     if (user.custom_properties or {}).get('hide_adult_content', False):
                         filters["is_adult"] = False
-                    channels = Channel.objects.filter(**filters).distinct().order_by("channel_number")
+                    channels = Channel.objects.filter(**filters).select_related('logo').distinct().order_by("channel_number")
             else:
-                channels = Channel.objects.filter(user_level__lte=user.user_level).order_by(
+                channels = Channel.objects.filter(user_level__lte=user.user_level).select_related('logo').order_by(
                     "channel_number"
                 )
         else:
@@ -1327,9 +1327,9 @@ def generate_epg(request, profile_name=None, user=None):
                 channels = Channel.objects.filter(
                     channelprofilemembership__channel_profile=channel_profile,
                     channelprofilemembership__enabled=True,
-                ).order_by("channel_number")
+                ).select_related('logo').order_by("channel_number")
             else:
-                channels = Channel.objects.all().order_by("channel_number")
+                channels = Channel.objects.all().select_related('logo').order_by("channel_number")
 
         # Check if the request wants to use direct logo URLs instead of cache
         use_cached_logos = request.GET.get('cachedlogos', 'true').lower() != 'false'
@@ -2181,7 +2181,7 @@ def xc_get_live_streams(request, user, category_id=None):
             # Hide adult content if user preference is set
             if (user.custom_properties or {}).get('hide_adult_content', False):
                 filters["is_adult"] = False
-            channels = Channel.objects.filter(**filters).order_by("channel_number")
+            channels = Channel.objects.filter(**filters).select_related('channel_group', 'logo').order_by("channel_number")
         else:
             # User has specific limited profiles assigned
             filters = {
@@ -2194,14 +2194,14 @@ def xc_get_live_streams(request, user, category_id=None):
             # Hide adult content if user preference is set
             if (user.custom_properties or {}).get('hide_adult_content', False):
                 filters["is_adult"] = False
-            channels = Channel.objects.filter(**filters).distinct().order_by("channel_number")
+            channels = Channel.objects.filter(**filters).select_related('channel_group', 'logo').distinct().order_by("channel_number")
     else:
         if not category_id:
-            channels = Channel.objects.filter(user_level__lte=user.user_level).order_by("channel_number")
+            channels = Channel.objects.filter(user_level__lte=user.user_level).select_related('channel_group', 'logo').order_by("channel_number")
         else:
             channels = Channel.objects.filter(
                 channel_group__id=category_id, user_level__lte=user.user_level
-            ).order_by("channel_number")
+            ).select_related('channel_group', 'logo').order_by("channel_number")
 
     # Build collision-free mapping for XC clients (which require integers)
     # This ensures channels with float numbers don't conflict with existing integers


### PR DESCRIPTION
## Description

`generate_m3u`, `generate_epg`, and `xc_get_live_streams` iterate over all channels and access `channel.logo` and/or `channel.channel_group` on every row. Without `select_related`, each access fires a separate query — producing 2N extra queries for N channels.

This adds `select_related('channel_group', 'logo')` (or just `'logo'` where `channel_group` isn't accessed) to all 14 Channel query paths in these three functions. `xc_get_epg` queries were intentionally left unchanged as they fetch single objects (`.first()` / `get_object_or_404`) where `select_related` provides no benefit.

## Related Issue

Closes #1127

## How was it tested?

Built a full Docker image from the branch, restored a production `pg_dump` (10,878 channels, 356 groups, 13 users), and tested against localhost:

**Response times with production data (10,878 channels):**
- `get_live_streams`: **1.1s** (3.8 MB, all 10,878 streams with logos and category IDs populated)
- `generate_m3u`: **1.1s** (2.6 MB)
- `generate_epg` (XMLTV): **56s** cold generation (259 MB)
- `get_live_categories`: **31ms** (183 categories)

**Edge cases tested:**
- Channel with `logo=NULL` and `channel_group=NULL` — `get_live_streams` returns the channel correctly (stream_icon=None, category_id falls back to Default Group via `get_or_create`)
- User with zero profile memberships — returns all 10,878 streams
- Anonymous M3U request (no user, no profile) — 200 OK

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change