### PR TITLE
Skip stream validation for redirect profiles

### DIFF
--- a/apps/proxy/ts_proxy/views.py
+++ b/apps/proxy/ts_proxy/views.py
@@ -274,93 +274,24 @@ def stream_ts(request, channel_id, user=None):
             # Generate transcode command if needed
             stream_profile = channel.get_stream_profile()
             if stream_profile.is_redirect():
-                # Validate the stream URL before redirecting
-                from .url_utils import (
-                    validate_stream_url,
-                    get_alternate_streams,
-                    get_stream_info_for_switch,
-                )
-
-                # Try initial URL
-                logger.info(f"[{client_id}] Validating redirect URL: {stream_url}")
-                is_valid, final_url, status_code, message = validate_stream_url(
-                    stream_url, user_agent=stream_user_agent, timeout=(5, 5)
-                )
-
-                # If first URL doesn't validate, try alternates
-                if not is_valid:
-                    logger.warning(
-                        f"[{client_id}] Primary stream URL failed validation: {message}"
-                    )
-
-                    # Track tried streams to avoid loops
-                    tried_streams = {stream_id}
-
-                    # Get alternate streams
-                    alternates = get_alternate_streams(channel_id, stream_id)
-
-                    # Try each alternate until one works
-                    for alt in alternates:
-                        if alt["stream_id"] in tried_streams:
-                            continue
-
-                        tried_streams.add(alt["stream_id"])
-
-                        # Get stream info
-                        alt_info = get_stream_info_for_switch(
-                            channel_id, alt["stream_id"]
-                        )
-                        if "error" in alt_info:
-                            logger.warning(
-                                f"[{client_id}] Error getting alternate stream info: {alt_info['error']}"
-                            )
-                            continue
-
-                        # Validate the alternate URL
-                        logger.info(
-                            f"[{client_id}] Trying alternate stream #{alt['stream_id']}: {alt_info['url']}"
-                        )
-                        is_valid, final_url, status_code, message = validate_stream_url(
-                            alt_info["url"],
-                            user_agent=alt_info["user_agent"],
-                            timeout=(5, 5),
-                        )
-
-                        if is_valid:
-                            logger.info(
-                                f"[{client_id}] Alternate stream #{alt['stream_id']} validated successfully"
-                            )
-                            break
-                        else:
-                            logger.warning(
-                                f"[{client_id}] Alternate stream #{alt['stream_id']} failed validation: {message}"
-                            )
                 # Release stream lock before redirecting
                 if not channel.release_stream():
                     logger.warning(f"[{client_id}] Failed to release stream before redirect")
                 connection_allocated = False
-                # Final decision based on validation results
-                if is_valid:
-                    logger.info(
-                        f"[{client_id}] Redirecting to validated URL: {final_url} ({message})"
-                    )
 
-                    # For non-HTTP protocols (RTSP/RTP/UDP), we need to manually create the redirect
-                    # because Django's HttpResponseRedirect blocks them for security
-                    if final_url.startswith(('rtsp://', 'rtp://', 'udp://')):
-                        logger.info(f"[{client_id}] Using manual redirect for non-HTTP protocol")
-                        response = HttpResponse(status=301)
-                        response['Location'] = final_url
-                        return response
+                logger.info(
+                    f"[{client_id}] Redirecting to: {stream_url}"
+                )
 
-                    return HttpResponseRedirect(final_url)
-                else:
-                    logger.error(
-                        f"[{client_id}] All available redirect URLs failed validation"
-                    )
-                    return JsonResponse(
-                        {"error": "All available streams failed validation"}, status=502
-                    )  # 502 Bad Gateway
+                # For non-HTTP protocols (RTSP/RTP/UDP), we need to manually create the redirect
+                # because Django's HttpResponseRedirect blocks them for security
+                if stream_url.startswith(('rtsp://', 'rtp://', 'udp://')):
+                    logger.info(f"[{client_id}] Using manual redirect for non-HTTP protocol")
+                    response = HttpResponse(status=301)
+                    response['Location'] = stream_url
+                    return response
+
+                return HttpResponseRedirect(stream_url)
 
             # Initialize channel with the stream's user agent (not the client's)
             success = ChannelService.initialize_channel(


### PR DESCRIPTION
## Description

Redirect profiles (HTTP 302) hand the stream URL directly to the client — the client validates it by attempting to play. The server-side `validate_stream_url` probe adds 160-900ms of latency per channel switch with no benefit in this mode, since the server never touches the stream data.

This removes the validation call and alternate-stream failover loop from the redirect path. Stream lock release and non-HTTP protocol handling (RTSP/RTP/UDP) are preserved. Proxy and transcode profile paths are completely untouched.

## Related Issue

N/A — performance improvement for redirect mode users.

## How was it tested?

Built a full Docker image from the branch, restored a production `pg_dump` (10,878 channels, 356 groups, 13 users), and tested against localhost:

**Redirect timing:**
- Channel switch via `/live/{user}/{pass}/{id}.ts`: **31ms** to return 302 with correct Location header
- Location header correctly points to the upstream provider URL
- Non-HTTP protocol redirect path preserved (manual `HttpResponse(status=301)` for rtsp/rtp/udp)

**Edge cases tested:**
- Channel with no streams assigned — returns 503 (graceful, upstream `generate_stream_url` handles this before the redirect path)
- Stream with empty URL — upstream code errors before reaching redirect path (not a regression)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change