### PR TITLE
Add per-user credential rewrite for redirect responses

### DIFF
--- a/apps/proxy/ts_proxy/views.py
+++ b/apps/proxy/ts_proxy/views.py
@@ -595,7 +595,28 @@ def stream_xc(request, username, password, channel_id):
         channel = get_object_or_404(Channel, id=channel_id)
 
     # @TODO: we've got the  file 'type' via extension, support this when we support multiple outputs
-    return stream_ts(request._request, str(channel.uuid), user)
+    response = stream_ts(request._request, str(channel.uuid), user)
+
+    # For redirect responses, rewrite provider credentials in the Location URL
+    # so each XC user connects with their own provider account instead of sharing
+    # the master account's connection pool.
+    if (
+        isinstance(response, HttpResponseRedirect)
+        and user.user_level < 10
+        and custom_properties.get("provider_username")
+        and custom_properties.get("provider_password")
+    ):
+        location = response["Location"]
+        rewritten = re.sub(
+            r"/live/[^/]+/[^/]+/",
+            f"/live/{custom_properties['provider_username']}/{custom_properties['provider_password']}/",
+            location,
+            count=1,
+        )
+        if rewritten != location:
+            response["Location"] = rewritten
+
+    return response
 
 
 @csrf_exempt


### PR DESCRIPTION
## Description

When multiple XC users share the same provider through Dispatcharr, redirect mode (302) sends all users to the same provider URL with the master account's credentials. This means all users share one connection pool at the provider, which can cause stream limits to be hit prematurely.

This adds a per-user credential rewrite in `stream_xc()`: after `stream_ts()` returns a redirect response, the `/live/{user}/{pass}/` segment of the Location URL is rewritten to use the authenticated user's own provider credentials from `custom_properties`. The rewrite only fires when all four guards pass:

1. Response is `HttpResponseRedirect`
2. `user.user_level < 10` (admins skipped)
3. `custom_properties.get("provider_username")` is non-empty
4. `custom_properties.get("provider_password")` is non-empty

Admin users and users without provider credentials configured are completely unaffected.

## Related Issue

N/A — new feature for multi-user redirect deployments.

## How was it tested?

Built a full Docker image from the branch, restored a production `pg_dump` (10,878 channels, 356 groups, 13 users), and tested against localhost:

**Credential rewrite verified across 3 user types:**
- User with `provider_username`/`provider_password` set — Location rewritten from `/live/master/pass/` to `/live/testuser/testpass/`
- Admin user (level 10) — Location unchanged, original provider credentials preserved
- User without provider credentials — Location unchanged, original provider credentials preserved

**Edge cases tested (6 cases):**
- Regex special characters in password (`p@ss+word$`) — correctly rewritten, no regex crash
- Empty `provider_username` string (`""`) — rewrite skipped (`.get()` returns falsy empty string), original URL preserved
- Stream URL without `/live/x/y/` pattern (e.g. `https://example.com/stream/12345.m3u8`) — URL passed through unchanged, regex doesn't match
- `custom_properties=NULL` on user — returns 401 (auth check rejects before rewrite code)
- URL containing `/live/x/y/` twice — `count=1` ensures only the first occurrence is replaced
- Extreme special characters in replacement (`p@$$w0rd!#%^&*()`) — `re.sub` handles replacement strings correctly

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change