### PR TITLE
Dispatcharr - v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed EPG sources that emit a UTF-8 BOM (e.g. ErsatzTV, EPGShare, WebGrab+Plus) parsing 0 channels and 0 programmes after the HTML entity fix introduced in v0.22.0. `bytes.lstrip()` only strips ASCII whitespace, leaving the three BOM bytes (`EF BB BF`) in place, so `stripped.startswith(b'<?xml')` returned `False`. The function fell through to the no-declaration branch and prepended the HTML entity DOCTYPE block _before_ the BOM and XML declaration, producing invalid XML that lxml silently discarded under `recover=True`. Fixed by stripping the BOM explicitly before the whitespace strip: `start.lstrip(b'\xef\xbb\xbf').lstrip()`. BOM-free files are unaffected. (Closes #1173) — Thanks [@dwot](https://github.com/dwot) for the fix!
+
 ## [0.22.0] - 2026-04-01
 
 ### Security

--- a/apps/epg/tasks.py
+++ b/apps/epg/tasks.py
@@ -114,7 +114,7 @@ def _open_xmltv_file(file_path: str):
         return f
 
     # Insert the DOCTYPE after the XML declaration if one is present.
-    stripped = start.lstrip()
+    stripped = start.lstrip(b'\xef\xbb\xbf').lstrip()
     if stripped.startswith(b'<?xml'):
         decl_end = start.find(b'?>')
         if decl_end >= 0:


### PR DESCRIPTION
## 🐛 Bug Fixes

### EPG Parsing

- Fixed EPG sources using UTF-8 BOM-prefixed files (e.g. ErsaTV, EPGShare, WebGrab+Plus) importing 0 channels and 0 programmes after updating to v0.22.0. These files begin with an invisible BOM marker that was not being accounted for when detecting the XML declaration, causing the entity block added in v0.22.0 to be inserted in the wrong position and producing invalid XML that was silently skipped. (Fixes #1173) — Thanks [@dwot](https://github.com/dwot) for the fix!