### PR TITLE
feat: user_hidden and user_locked per-channel flags for auto-sync

### DIFF
--- a/apps/channels/api_views.py
+++ b/apps/channels/api_views.py
@@ -586,6 +586,7 @@ class ChannelViewSet(viewsets.ModelViewSet):
         show_disabled_param = self.request.query_params.get("show_disabled", None)
         only_streamless = self.request.query_params.get("only_streamless", None)
         only_stale = self.request.query_params.get("only_stale", None)
+        visibility_filter = self.request.query_params.get("visibility_filter", "active")
 
         if channel_profile_id:
             try:
@@ -608,6 +609,15 @@ class ChannelViewSet(viewsets.ModelViewSet):
         if only_stale:
             # Filter channels that have at least one related stream marked as stale
             q_filters &= Q(streams__is_stale=True)
+
+        # Only apply visibility filtering to list-style reads. Retrieve/update/
+        # delete actions must still be able to reach a hidden channel by id so
+        # the frontend can PATCH user_hidden=False to unhide it.
+        if self.action in ("list", "get_ids", "summary"):
+            if visibility_filter == "hidden":
+                q_filters &= Q(user_hidden=True)
+            elif visibility_filter != "all":
+                q_filters &= Q(user_hidden=False)
 
         if self.request.user.user_level < 10:
             filters["user_level__lte"] = self.request.user.user_level

--- a/apps/channels/migrations/0035_channel_user_hidden_channel_user_locked.py
+++ b/apps/channels/migrations/0035_channel_user_hidden_channel_user_locked.py
@@ -1,0 +1,23 @@
+# Generated for FR #1196 (per-channel lock and hide flags for auto-sync'd channels)
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dispatcharr_channels', '0034_remove_stream_dispatcharr_stream_id_idx_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='channel',
+            name='user_hidden',
+            field=models.BooleanField(db_index=True, default=False, help_text='When True, the channel is excluded from HDHR, M3U, and EPG output and preserved across auto-sync refreshes.'),
+        ),
+        migrations.AddField(
+            model_name='channel',
+            name='user_locked',
+            field=models.BooleanField(default=False, help_text='When True, auto-sync preserves user-set name, number, and group but continues updating EPG data, tvg_id, logo, and tvc_guide_stationid.'),
+        ),
+    ]

--- a/apps/channels/migrations/0036_channel_user_hidden_channel_user_locked.py
+++ b/apps/channels/migrations/0036_channel_user_hidden_channel_user_locked.py
@@ -1,12 +1,10 @@
-# Generated for FR #1196 (per-channel lock and hide flags for auto-sync'd channels)
-
 from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dispatcharr_channels', '0034_remove_stream_dispatcharr_stream_id_idx_and_more'),
+        ('dispatcharr_channels', '0035_alter_channel_name_alter_stream_name'),
     ]
 
     operations = [

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -360,6 +360,16 @@ class Channel(models.Model):
         help_text="The M3U account that auto-created this channel"
     )
 
+    user_hidden = models.BooleanField(
+        default=False,
+        db_index=True,
+        help_text="When True, the channel is excluded from HDHR, M3U, and EPG output and preserved across auto-sync refreshes."
+    )
+    user_locked = models.BooleanField(
+        default=False,
+        help_text="When True, auto-sync preserves user-set name, number, and group but continues updating EPG data, tvg_id, logo, and tvc_guide_stationid."
+    )
+
     created_at = models.DateTimeField(
         auto_now_add=True,
         help_text="Timestamp when this channel was created"

--- a/apps/channels/serializers.py
+++ b/apps/channels/serializers.py
@@ -300,6 +300,8 @@ class ChannelSerializer(serializers.ModelSerializer):
             "auto_created",
             "auto_created_by",
             "auto_created_by_name",
+            "user_hidden",
+            "user_locked",
         ]
 
     def to_representation(self, instance):

--- a/apps/channels/tests/test_user_channel_overrides.py
+++ b/apps/channels/tests/test_user_channel_overrides.py
@@ -1,0 +1,368 @@
+"""
+Tests for per-channel user_hidden and user_locked flags (FR #1196).
+
+Covers:
+  - Model defaults and serializer round-trip.
+  - Output filtering (HDHR lineup, M3U, EPG, XC) excludes hidden channels.
+  - sync_auto_channels:
+      * preserves hidden channels (no update, no delete, no recreate)
+      * reserves hidden channels' numbers in used_numbers
+      * preserves locked channels' name / channel_number / channel_group
+      * still flows provider metadata (tvg_id, logo, epg_data) to locked channels
+      * skips locked and hidden channels in renumber and stale-delete passes
+      * skips locked and hidden channels in orphan cleanup pass
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.channels.models import (
+    Channel,
+    ChannelGroup,
+    ChannelGroupM3UAccount,
+    ChannelStream,
+    Stream,
+)
+from apps.m3u.models import M3UAccount
+
+User = get_user_model()
+
+
+def _run_sync(account):
+    """Call sync_auto_channels synchronously with a fresh scan_start_time."""
+    from apps.m3u.tasks import sync_auto_channels
+
+    # Set scan_start_time slightly in the past so any streams with last_seen=now() pass.
+    start = timezone.now() - timezone.timedelta(seconds=1)
+    return sync_auto_channels(account.id, scan_start_time=start)
+
+
+class UserHiddenUserLockedModelTests(TestCase):
+    """Field defaults and Channel serializer round-trip."""
+
+    def setUp(self):
+        self.group = ChannelGroup.objects.create(name="Test Group")
+        self.channel = Channel.objects.create(
+            channel_number=1.0,
+            name="Test Channel",
+            channel_group=self.group,
+        )
+
+    def test_defaults_are_false(self):
+        self.assertFalse(self.channel.user_hidden)
+        self.assertFalse(self.channel.user_locked)
+
+    def test_serializer_includes_both_fields(self):
+        user = User.objects.create_user(username="admin", password="pw", user_level=10)
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(f"/api/channels/channels/{self.channel.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("user_hidden", response.data)
+        self.assertIn("user_locked", response.data)
+        self.assertFalse(response.data["user_hidden"])
+        self.assertFalse(response.data["user_locked"])
+
+    def test_patch_can_set_both_fields(self):
+        user = User.objects.create_user(username="admin", password="pw", user_level=10)
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.patch(
+            f"/api/channels/channels/{self.channel.id}/",
+            {"user_hidden": True, "user_locked": True},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.channel.refresh_from_db()
+        self.assertTrue(self.channel.user_hidden)
+        self.assertTrue(self.channel.user_locked)
+
+
+class HiddenChannelOutputFilteringTests(TestCase):
+    """Hidden channels must not appear in HDHR, M3U, or EPG output."""
+
+    def setUp(self):
+        self.group = ChannelGroup.objects.create(name="Test Group")
+        self.visible = Channel.objects.create(
+            channel_number=10.0,
+            name="Visible Channel",
+            channel_group=self.group,
+            tvg_id="visible",
+        )
+        self.hidden = Channel.objects.create(
+            channel_number=11.0,
+            name="Hidden Channel",
+            channel_group=self.group,
+            tvg_id="hidden",
+            user_hidden=True,
+        )
+        self.client = APIClient()
+
+    def test_hdhr_api_lineup_excludes_hidden(self):
+        response = self.client.get("/hdhr/lineup.json")
+        self.assertEqual(response.status_code, 200)
+        names = [entry["GuideName"] for entry in response.json()]
+        self.assertIn("Visible Channel", names)
+        self.assertNotIn("Hidden Channel", names)
+
+    def test_m3u_output_excludes_hidden(self):
+        response = self.client.get("/output/m3u")
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode()
+        self.assertIn("Visible Channel", body)
+        self.assertNotIn("Hidden Channel", body)
+
+    def test_epg_output_excludes_hidden(self):
+        response = self.client.get("/output/epg")
+        self.assertEqual(response.status_code, 200)
+        # EPG is streamed; join the chunks to assert on the full body.
+        body = b"".join(response.streaming_content).decode()
+        self.assertIn("Visible Channel", body)
+        self.assertNotIn("Hidden Channel", body)
+
+
+class SyncAutoChannelsUserHiddenTests(TestCase):
+    """Verify sync_auto_channels respects user_hidden across passes."""
+
+    def setUp(self):
+        self.account = M3UAccount.objects.create(
+            name="Test Provider",
+            server_url="http://example.test/get.php",
+        )
+        self.group = ChannelGroup.objects.create(name="HIDDEN TEST GROUP")
+        ChannelGroupM3UAccount.objects.create(
+            channel_group=self.group,
+            m3u_account=self.account,
+            enabled=True,
+            auto_channel_sync=True,
+            auto_sync_channel_start=100.0,
+        )
+        self.stream = Stream.objects.create(
+            name="Keeper Stream",
+            url="http://example.test/keeper.ts",
+            m3u_account=self.account,
+            channel_group=self.group,
+            tvg_id="keeper",
+            last_seen=timezone.now(),
+        )
+
+    def _create_auto_channel(self, stream, channel_number, **extra):
+        defaults = {
+            "name": stream.name,
+            "channel_group": self.group,
+            "tvg_id": stream.tvg_id,
+            "auto_created": True,
+            "auto_created_by": self.account,
+        }
+        defaults.update(extra)
+        channel = Channel.objects.create(
+            channel_number=channel_number,
+            **defaults,
+        )
+        ChannelStream.objects.create(channel=channel, stream=stream, order=0)
+        return channel
+
+    def test_hidden_channel_receives_provider_metadata_updates_on_sync(self):
+        """
+        Option B semantic: hide is an output-visibility flag, not a sync-freeze.
+        Hidden channels still receive provider metadata (name, tvg_id, logo,
+        etc.) from their linked stream on each sync.
+        """
+        hidden = self._create_auto_channel(
+            self.stream,
+            channel_number=105.0,
+            name="Stale Name",
+            tvg_id="stale_tvg",
+            user_hidden=True,
+        )
+
+        # Provider updates the stream's metadata.
+        self.stream.name = "Fresh Provider Name"
+        self.stream.tvg_id = "fresh_tvg"
+        self.stream.save()
+
+        _run_sync(self.account)
+
+        hidden.refresh_from_db()
+        self.assertEqual(hidden.name, "Fresh Provider Name")
+        self.assertEqual(hidden.tvg_id, "fresh_tvg")
+
+    def test_hidden_channel_preserves_user_hidden_flag_on_sync(self):
+        """
+        Critical invariant: sync must never clear a channel's user_hidden
+        flag. Even though hidden channels receive metadata updates (Option B),
+        their hidden status is orthogonal to any provider field and must
+        remain True until the user explicitly unhides.
+        """
+        hidden = self._create_auto_channel(
+            self.stream,
+            channel_number=105.0,
+            user_hidden=True,
+        )
+        self.stream.name = "New Name That Triggers An Update"
+        self.stream.save()
+
+        _run_sync(self.account)
+
+        hidden.refresh_from_db()
+        self.assertTrue(
+            hidden.user_hidden,
+            "user_hidden must NOT be cleared by sync_auto_channels under any condition",
+        )
+
+    def test_hidden_channel_does_not_block_another_channels_number(self):
+        """
+        Under Option B, hidden channels renumber like normal channels
+        (they are not reserved as a special number-blocker). New channels
+        still get unique numbers; there are no collisions even when a hidden
+        channel exists at the same number a new channel might otherwise claim.
+        """
+        self._create_auto_channel(
+            self.stream,
+            channel_number=105.0,
+            user_hidden=True,
+        )
+        Stream.objects.create(
+            name="New Stream",
+            url="http://example.test/new.ts",
+            m3u_account=self.account,
+            channel_group=self.group,
+            tvg_id="new",
+            last_seen=timezone.now(),
+        )
+
+        _run_sync(self.account)
+
+        # Every auto-created channel from this account must have a unique number.
+        numbers = list(
+            Channel.objects.filter(
+                auto_created=True, auto_created_by=self.account
+            ).values_list("channel_number", flat=True)
+        )
+        self.assertEqual(len(numbers), len(set(numbers)), f"duplicate channel_numbers: {numbers}")
+
+    def test_hidden_channel_survives_stream_removal(self):
+        """If the underlying stream disappears, a hidden channel still persists."""
+        hidden = self._create_auto_channel(
+            self.stream,
+            channel_number=106.0,
+            user_hidden=True,
+        )
+        # Remove the stream so it's not present in any group any more.
+        self.stream.delete()
+
+        _run_sync(self.account)
+
+        self.assertTrue(Channel.objects.filter(pk=hidden.pk).exists())
+
+
+class SyncAutoChannelsUserLockedTests(TestCase):
+    """Verify sync_auto_channels respects user_locked across passes."""
+
+    def setUp(self):
+        self.account = M3UAccount.objects.create(
+            name="Test Provider",
+            server_url="http://example.test/get.php",
+        )
+        self.group = ChannelGroup.objects.create(name="LOCK TEST GROUP")
+        ChannelGroupM3UAccount.objects.create(
+            channel_group=self.group,
+            m3u_account=self.account,
+            enabled=True,
+            auto_channel_sync=True,
+            auto_sync_channel_start=200.0,
+        )
+        self.stream = Stream.objects.create(
+            name="Provider Stream Name",
+            url="http://example.test/locked.ts",
+            m3u_account=self.account,
+            channel_group=self.group,
+            tvg_id="provider_tvg",
+            last_seen=timezone.now(),
+        )
+
+    def _create_auto_channel(self, stream, channel_number, **extra):
+        defaults = {
+            "name": stream.name,
+            "channel_group": self.group,
+            "tvg_id": stream.tvg_id,
+            "auto_created": True,
+            "auto_created_by": self.account,
+        }
+        defaults.update(extra)
+        channel = Channel.objects.create(
+            channel_number=channel_number,
+            **defaults,
+        )
+        ChannelStream.objects.create(channel=channel, stream=stream, order=0)
+        return channel
+
+    def test_locked_channel_preserves_identity(self):
+        """Locked channel keeps user-set name and channel_number across sync."""
+        locked = self._create_auto_channel(
+            self.stream,
+            channel_number=250.0,
+            name="User Custom Name",
+            user_locked=True,
+        )
+
+        # Provider changes name on stream side.
+        self.stream.name = "Provider Renamed"
+        self.stream.save()
+
+        _run_sync(self.account)
+
+        locked.refresh_from_db()
+        self.assertEqual(locked.name, "User Custom Name")
+        self.assertEqual(locked.channel_number, 250.0)
+
+    def test_locked_channel_still_flows_tvg_id(self):
+        """Locked channel's tvg_id updates when the provider changes it."""
+        locked = self._create_auto_channel(
+            self.stream,
+            channel_number=251.0,
+            name="User Custom Name",
+            user_locked=True,
+        )
+
+        self.stream.tvg_id = "updated_tvg"
+        self.stream.save()
+
+        _run_sync(self.account)
+
+        locked.refresh_from_db()
+        self.assertEqual(locked.tvg_id, "updated_tvg")
+        # Identity still preserved.
+        self.assertEqual(locked.name, "User Custom Name")
+
+    def test_locked_channel_survives_stream_removal(self):
+        """Locked channel persists even when provider drops the stream."""
+        locked = self._create_auto_channel(
+            self.stream,
+            channel_number=252.0,
+            name="User Custom",
+            user_locked=True,
+        )
+        self.stream.delete()
+
+        _run_sync(self.account)
+
+        self.assertTrue(Channel.objects.filter(pk=locked.pk).exists())
+
+    def test_unlocked_channel_gets_provider_name_back(self):
+        """Control: without user_locked, sync overwrites with stream name."""
+        unlocked = self._create_auto_channel(
+            self.stream,
+            channel_number=253.0,
+            name="User Custom Name",
+            user_locked=False,
+        )
+
+        _run_sync(self.account)
+
+        unlocked.refresh_from_db()
+        self.assertEqual(unlocked.name, "Provider Stream Name")

--- a/apps/hdhr/api_views.py
+++ b/apps/hdhr/api_views.py
@@ -111,9 +111,9 @@ class LineupAPIView(APIView):
             channels = Channel.objects.filter(
                 channelprofilemembership__channel_profile=channel_profile,
                 channelprofilemembership__enabled=True,
-            ).order_by("channel_number")
+            ).exclude(user_hidden=True).order_by("channel_number")
         else:
-            channels = Channel.objects.all().order_by("channel_number")
+            channels = Channel.objects.exclude(user_hidden=True).order_by("channel_number")
 
         lineup = []
         for ch in channels:

--- a/apps/hdhr/views.py
+++ b/apps/hdhr/views.py
@@ -84,7 +84,7 @@ class LineupAPIView(APIView):
         description="Retrieve the available channel lineup",
     )
     def get(self, request):
-        channels = Channel.objects.all().order_by("channel_number")
+        channels = Channel.objects.exclude(user_hidden=True).order_by("channel_number")
         lineup = [
             {
                 "GuideNumber": str(ch.channel_number),

--- a/apps/m3u/tasks.py
+++ b/apps/m3u/tasks.py
@@ -1686,6 +1686,13 @@ def delete_m3u_refresh_task_by_id(account_id):
         return False
 
 
+def _channel_is_frozen(channel):
+    # True when sync must never delete this channel. Both flags imply the
+    # user explicitly wants the row preserved. Does NOT gate metadata
+    # updates; hidden channels still receive provider tvg_id/logo/epg_data.
+    return channel.user_locked or channel.user_hidden
+
+
 @shared_task
 def sync_auto_channels(account_id, scan_start_time=None):
     """
@@ -1868,8 +1875,10 @@ def sync_auto_channels(account_id, scan_start_time=None):
 
             if not has_streams:
                 logger.debug(f"No streams found in group {channel_group.name}")
-                # Delete all existing auto channels if no streams
-                channels_to_delete = [ch for ch in existing_channel_map.values()]
+                channels_to_delete = [
+                    ch for ch in existing_channel_map.values()
+                    if not _channel_is_frozen(ch)
+                ]
                 if channels_to_delete:
                     deleted_count = len(channels_to_delete)
                     Channel.objects.filter(
@@ -1926,6 +1935,13 @@ def sync_auto_channels(account_id, scan_start_time=None):
             for stream in current_streams:
                 if stream.id in existing_channel_map:
                     channel = existing_channel_map[stream.id]
+
+                    # Protected channels keep their user-chosen number.
+                    # Reserve it so the renumber pass doesn't hand it out again.
+                    if channel.user_locked:
+                        if channel.channel_number is not None:
+                            used_numbers.add(channel.channel_number)
+                        continue
 
                     # Determine target number based on numbering mode
                     if channel_numbering_mode == "provider":
@@ -2011,14 +2027,18 @@ def sync_auto_channels(account_id, scan_start_time=None):
                     # Check if we already have a channel for this stream
                     existing_channel = existing_channel_map.get(stream.id)
 
+                    # Hidden channels flow through the normal update path; only
+                    # downstream output queryset filters exclude them.
                     if existing_channel:
                         # Update existing channel if needed (channel number already handled above)
                         channel_updated = False
 
-                        # Use new_name instead of stream.name
-                        if existing_channel.name != new_name:
-                            existing_channel.name = new_name
-                            channel_updated = True
+                        # Locked channels keep their user-chosen identity;
+                        # provider metadata below still flows through.
+                        if not existing_channel.user_locked:
+                            if existing_channel.name != new_name:
+                                existing_channel.name = new_name
+                                channel_updated = True
 
                         if existing_channel.tvg_id != stream.tvg_id:
                             existing_channel.tvg_id = stream.tvg_id
@@ -2028,8 +2048,11 @@ def sync_auto_channels(account_id, scan_start_time=None):
                             existing_channel.tvc_guide_stationid = tvc_guide_stationid
                             channel_updated = True
 
-                        # Check if channel group needs to be updated (in case override was added/changed)
-                        if existing_channel.channel_group != target_group:
+                        # Locked channels keep their user-chosen group.
+                        if (
+                            not existing_channel.user_locked
+                            and existing_channel.channel_group != target_group
+                        ):
                             existing_channel.channel_group = target_group
                             channel_updated = True
                             logger.info(
@@ -2325,11 +2348,12 @@ def sync_auto_channels(account_id, scan_start_time=None):
                     )
                     continue
 
-            # Delete channels for streams that no longer exist
+            # Delete channels for streams that no longer exist.
             channels_to_delete = []
             for stream_id, channel in existing_channel_map.items():
                 if stream_id not in processed_stream_ids:
-                    channels_to_delete.append(channel)
+                    if not _channel_is_frozen(channel):
+                        channels_to_delete.append(channel)
 
             if channels_to_delete:
                 deleted_count = len(channels_to_delete)
@@ -2342,10 +2366,12 @@ def sync_auto_channels(account_id, scan_start_time=None):
                 )
 
         # Additional cleanup: Remove auto-created channels that no longer have any valid streams
-        # This handles the case where streams were deleted due to stale retention policy
+        # This handles the case where streams were deleted due to stale retention policy.
         orphaned_channels = Channel.objects.filter(
             auto_created=True,
-            auto_created_by=account
+            auto_created_by=account,
+            user_locked=False,
+            user_hidden=False,
         ).exclude(
             # Exclude channels that still have valid stream associations
             id__in=ChannelStream.objects.filter(

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -168,6 +168,8 @@ def generate_m3u(request, profile_name=None, user=None):
         else:
             channels = Channel.objects.select_related('channel_group', 'logo').order_by("channel_number")
 
+    channels = channels.exclude(user_hidden=True)
+
     # Check if the request wants to use direct logo URLs instead of cache
     use_cached_logos = request.GET.get('cachedlogos', 'true').lower() != 'false'
 
@@ -1357,6 +1359,7 @@ def generate_epg(request, profile_name=None, user=None):
             else:
                 channels = Channel.objects.all().select_related('logo', 'epg_data__epg_source').order_by("channel_number")
 
+        channels = channels.exclude(user_hidden=True)
 
         # For dummy EPG, use either the specified value or default to 3 days
         dummy_days = num_days if num_days > 0 else 3
@@ -2173,6 +2176,8 @@ def xc_get_live_streams(request, user, category_id=None):
                 channel_group__id=category_id, user_level__lte=user.user_level
             ).select_related('channel_group', 'logo').order_by("channel_number")
 
+    channels = channels.exclude(user_hidden=True)
+
     # Resolve the fallback group ID once to avoid a get_or_create query per null-group channel
     _default_group_id = None
 
@@ -2259,7 +2264,7 @@ def xc_get_epg(request, user, short=False):
             # Hide adult content if user preference is set
             if (user.custom_properties or {}).get('hide_adult_content', False):
                 filters["is_adult"] = False
-            channel = Channel.objects.filter(**filters).select_related('epg_data__epg_source').first()
+            channel = Channel.objects.filter(**filters).exclude(user_hidden=True).select_related('epg_data__epg_source').first()
         else:
             # User has specific limited profiles assigned
             filters = {
@@ -2271,22 +2276,25 @@ def xc_get_epg(request, user, short=False):
             # Hide adult content if user preference is set
             if (user.custom_properties or {}).get('hide_adult_content', False):
                 filters["is_adult"] = False
-            channel = Channel.objects.filter(**filters).select_related('epg_data__epg_source').distinct().first()
+            channel = Channel.objects.filter(**filters).exclude(user_hidden=True).select_related('epg_data__epg_source').distinct().first()
 
         if not channel:
             raise Http404()
     else:
-        channel = get_object_or_404(Channel.objects.select_related('epg_data__epg_source'), id=channel_id)
+        channel = get_object_or_404(
+            Channel.objects.exclude(user_hidden=True).select_related('epg_data__epg_source'),
+            id=channel_id,
+        )
 
     if not channel:
         raise Http404()
 
-    # Calculate the collision-free integer channel number for this channel
-    # This must match the logic in xc_get_live_streams to ensure consistency
-    # Get all channels in the same category for collision detection
+    # Calculate the collision-free integer channel number for this channel.
+    # Must match xc_get_live_streams (which also excludes user_hidden) so the
+    # number mapping stays consistent.
     category_channels = Channel.objects.filter(
         channel_group=channel.channel_group
-    ).order_by("channel_number")
+    ).exclude(user_hidden=True).order_by("channel_number")
 
     channel_num_map = {}
     used_numbers = set()

--- a/frontend/src/components/forms/Channel.jsx
+++ b/frontend/src/components/forms/Channel.jsx
@@ -43,6 +43,7 @@ import {
 } from '../../utils/notificationUtils.js';
 import {
   addChannel,
+  applyAutoProtect,
   createLogo,
   getChannelFormDefaultValues,
   getFormattedValues,
@@ -314,6 +315,7 @@ const ChannelForm = ({ channel = null, isOpen, onClose }) => {
       const formattedValues = getFormattedValues(values);
 
       if (channel) {
+        applyAutoProtect(channel, values, formattedValues);
         await handleEpgUpdate(channel, values, formattedValues, channelStreams);
       } else {
         // New channel creation - use the standard method
@@ -738,6 +740,43 @@ const ChannelForm = ({ channel = null, isOpen, onClose }) => {
                   />
                 </Box>
               </Tooltip>
+
+              {channel && (
+                <Stack gap="xs" mt={4}>
+                  {channel.auto_created && (
+                    <Tooltip
+                      label="Protected from auto-sync. Channel name, channel number, and group will not be overwritten on M3U refresh."
+                      withArrow
+                    >
+                      <Box>
+                        <Switch
+                          label="Protect from Auto-Sync"
+                          checked={watch('user_locked')}
+                          onChange={(event) =>
+                            setValue('user_locked', event.currentTarget.checked)
+                          }
+                          size="md"
+                        />
+                      </Box>
+                    </Tooltip>
+                  )}
+                  <Tooltip
+                    label="Hidden from HDHR, M3U, and EPG output to clients."
+                    withArrow
+                  >
+                    <Box>
+                      <Switch
+                        label="Hide from Clients"
+                        checked={watch('user_hidden')}
+                        onChange={(event) =>
+                          setValue('user_hidden', event.currentTarget.checked)
+                        }
+                        size="md"
+                      />
+                    </Box>
+                  </Tooltip>
+                </Stack>
+              )}
             </Stack>
 
             <Divider size="sm" orientation="vertical" />

--- a/frontend/src/components/forms/ChannelBatch.jsx
+++ b/frontend/src/components/forms/ChannelBatch.jsx
@@ -36,7 +36,10 @@ import logo from '../../images/logo.png';
 import ConfirmationDialog from '../ConfirmationDialog';
 import useWarningsStore from '../../store/warnings';
 import { showNotification } from '../../utils/notificationUtils.js';
-import { requeryChannels } from '../../utils/forms/ChannelUtils.js';
+import {
+  requeryChannels,
+  selectAutoCreatedInSelection,
+} from '../../utils/forms/ChannelUtils.js';
 import {
   batchSetEPG,
   buildEpgAssociations,
@@ -49,7 +52,9 @@ import {
   getMatureContentChange,
   getRegexNameChange,
   getStreamProfileChange,
+  getUserHiddenChange,
   getUserLevelChange,
+  getUserLockedChange,
   setChannelLogosFromEpg,
   setChannelNamesFromEpg,
   setChannelTvgIdsFromEpg,
@@ -123,8 +128,20 @@ const ChannelBatchForm = ({ channelIds, isOpen, onClose }) => {
       stream_profile_id: '-1',
       user_level: '-1',
       is_adult: '-1',
+      user_hidden: '-1',
+      user_locked: '-1',
     },
   });
+
+  // Auto-created subset of the selection. The Protect flag only applies to
+  // auto-created rows; tracking both ids and count here lets the submit path
+  // reuse the filter without recomputing.
+  const tableChannels = useChannelsTableStore((s) => s.channels);
+  const autoCreatedSelection = useMemo(
+    () => selectAutoCreatedInSelection(channelIds, tableChannels),
+    [channelIds, tableChannels]
+  );
+  const autoCreatedInSelectionCount = autoCreatedSelection.count;
 
   // Build confirmation message based on selected changes
   const getConfirmationMessage = () => {
@@ -137,6 +154,8 @@ const ChannelBatchForm = ({ channelIds, isOpen, onClose }) => {
       getStreamProfileChange(values.stream_profile_id, streamProfiles),
       getUserLevelChange(values.user_level, USER_LEVEL_LABELS),
       getMatureContentChange(values.is_adult),
+      getUserHiddenChange(values.user_hidden),
+      getUserLockedChange(values.user_locked, autoCreatedInSelectionCount),
       getEpgChange(selectedDummyEpgId, epgs),
     ].filter(Boolean);
   };
@@ -173,8 +192,32 @@ const ChannelBatchForm = ({ channelIds, isOpen, onClose }) => {
         selectedLogoId
       );
 
+      // Protect applies only to auto-created channels, so split user_locked
+      // out of the shared PATCH and target the auto-created subset separately.
+      const userLockedValue = Object.prototype.hasOwnProperty.call(
+        values,
+        'user_locked'
+      )
+        ? values.user_locked
+        : undefined;
+      delete values.user_locked;
+
+      const patches = [];
       if (Object.keys(values).length > 0) {
-        await updateChannels(channelIds, values);
+        patches.push(updateChannels(channelIds, values));
+      }
+      if (
+        userLockedValue !== undefined &&
+        autoCreatedSelection.ids.length > 0
+      ) {
+        patches.push(
+          updateChannels(autoCreatedSelection.ids, {
+            user_locked: userLockedValue,
+          })
+        );
+      }
+      if (patches.length > 0) {
+        await Promise.all(patches);
       }
 
       if (regexFind.trim().length > 0) {
@@ -797,6 +840,37 @@ const ChannelBatchForm = ({ channelIds, isOpen, onClose }) => {
                   { value: '-1', label: '(no change)' },
                   { value: 'true', label: 'Yes' },
                   { value: 'false', label: 'No' },
+                ]}
+              />
+
+              <Select
+                size="xs"
+                label="Hide from Clients"
+                description="Hidden channels are excluded from HDHR, M3U, and EPG output."
+                {...form.getInputProps('user_hidden')}
+                key={form.key('user_hidden')}
+                data={[
+                  { value: '-1', label: '(no change)' },
+                  { value: 'true', label: 'Hide' },
+                  { value: 'false', label: 'Unhide' },
+                ]}
+              />
+
+              <Select
+                size="xs"
+                label="Protect from Auto-Sync"
+                description={
+                  autoCreatedInSelectionCount > 0
+                    ? `Applied to ${autoCreatedInSelectionCount} auto-created channel${autoCreatedInSelectionCount === 1 ? '' : 's'} in the selection. Manual channels are skipped.`
+                    : 'No auto-created channels in the current selection; Protect has no effect here.'
+                }
+                disabled={autoCreatedInSelectionCount === 0}
+                {...form.getInputProps('user_locked')}
+                key={form.key('user_locked')}
+                data={[
+                  { value: '-1', label: '(no change)' },
+                  { value: 'true', label: 'Protect' },
+                  { value: 'false', label: 'Unprotect' },
                 ]}
               />
             </Stack>

--- a/frontend/src/components/forms/__tests__/Channel.test.jsx
+++ b/frontend/src/components/forms/__tests__/Channel.test.jsx
@@ -20,6 +20,7 @@ vi.mock('../../../utils/notificationUtils.js', () => ({
 
 vi.mock('../../../utils/forms/ChannelUtils.js', () => ({
   addChannel: vi.fn(),
+  applyAutoProtect: vi.fn(),
   createLogo: vi.fn(),
   getChannelFormDefaultValues: vi.fn(),
   getFormattedValues: vi.fn(),

--- a/frontend/src/components/forms/__tests__/ChannelBatch.test.jsx
+++ b/frontend/src/components/forms/__tests__/ChannelBatch.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../../../utils/notificationUtils.js', () => ({
 
 vi.mock('../../../utils/forms/ChannelUtils.js', () => ({
   requeryChannels: vi.fn(),
+  selectAutoCreatedInSelection: vi.fn(() => ({ ids: [], count: 0 })),
 }));
 
 vi.mock('../../../utils/forms/ChannelBatchUtils.js', () => ({
@@ -36,7 +37,9 @@ vi.mock('../../../utils/forms/ChannelBatchUtils.js', () => ({
   getMatureContentChange: vi.fn(),
   getRegexNameChange: vi.fn(),
   getStreamProfileChange: vi.fn(),
+  getUserHiddenChange: vi.fn(),
   getUserLevelChange: vi.fn(),
+  getUserLockedChange: vi.fn(),
   setChannelLogosFromEpg: vi.fn(),
   setChannelNamesFromEpg: vi.fn(),
   setChannelTvgIdsFromEpg: vi.fn(),

--- a/frontend/src/components/tables/ChannelsTable.jsx
+++ b/frontend/src/components/tables/ChannelsTable.jsx
@@ -38,6 +38,10 @@ import {
   ArrowUpDown,
   ArrowDownWideNarrow,
   Search,
+  Eye,
+  EyeOff,
+  Shield,
+  ShieldOff,
 } from 'lucide-react';
 import {
   Box,
@@ -85,6 +89,7 @@ import useWarningsStore from '../../store/warnings';
 import ConfirmationDialog from '../ConfirmationDialog';
 import useAuthStore from '../../store/auth';
 import { USER_LEVELS } from '../../constants';
+import { selectAutoCreatedInSelection } from '../../utils/forms/ChannelUtils.js';
 
 const m3uUrlBase = `${window.location.protocol}//${window.location.host}/output/m3u`;
 const epgUrlBase = `${window.location.protocol}//${window.location.host}/output/epg`;
@@ -137,10 +142,15 @@ const ChannelRowActions = React.memo(
     handleWatchStream,
     createRecording,
     getChannelURL,
+    toggleChannelHidden,
+    toggleChannelLocked,
   }) => {
     // Extract the channel ID once to ensure consistency
     const channelId = row.original.id;
     const channelUuid = row.original.uuid;
+    const isHidden = !!row.original.user_hidden;
+    const isLocked = !!row.original.user_locked;
+    const isAutoCreated = !!row.original.auto_created;
 
     const authUser = useAuthStore((s) => s.user);
 
@@ -165,6 +175,14 @@ const ChannelRowActions = React.memo(
       console.log(`Recording channel ID: ${channelId}`);
       createRecording(row.original);
     }, [channelId]);
+
+    const onToggleHidden = useCallback(() => {
+      toggleChannelHidden(channelId, !isHidden);
+    }, [channelId, isHidden, toggleChannelHidden]);
+
+    const onToggleLocked = useCallback(() => {
+      toggleChannelLocked(channelId, !isLocked);
+    }, [channelId, isLocked, toggleChannelLocked]);
 
     const tableSize = table?.tableSize ?? 'default';
     const iconSize =
@@ -235,17 +253,42 @@ const ChannelRowActions = React.memo(
               >
                 <Text size="xs">Record</Text>
               </Menu.Item>
+
+              <Menu.Divider />
+
+              <Menu.Item
+                onClick={onToggleHidden}
+                disabled={authUser.user_level != USER_LEVELS.ADMIN}
+                leftSection={
+                  isHidden ? <Eye size="14" /> : <EyeOff size="14" />
+                }
+              >
+                <Text size="xs">{isHidden ? 'Unhide' : 'Hide'}</Text>
+              </Menu.Item>
+
+              {isAutoCreated && (
+                <Menu.Item
+                  onClick={onToggleLocked}
+                  disabled={authUser.user_level != USER_LEVELS.ADMIN}
+                  leftSection={
+                    isLocked ? <ShieldOff size="14" /> : <Shield size="14" />
+                  }
+                >
+                  <Text size="xs">{isLocked ? 'Unprotect' : 'Protect'}</Text>
+                </Menu.Item>
+              )}
             </Menu.Dropdown>
           </Menu>
         </Center>
       </Box>
     );
   },
-  // Custom comparator: only re-render when the actual channel changes.
-  // The row object is a new TanStack Table reference on each render, but
-  // row.original.id is stable. Callbacks read fresh data at call time.
+  // The row object is a new reference per render; compare stable fields that
+  // drive visible menu labels so rows don't over-render.
   (prevProps, nextProps) =>
-    prevProps.row.original.id === nextProps.row.original.id
+    prevProps.row.original.id === nextProps.row.original.id &&
+    prevProps.row.original.user_hidden === nextProps.row.original.user_hidden &&
+    prevProps.row.original.user_locked === nextProps.row.original.user_locked
 );
 
 const ChannelsTable = ({ onReady }) => {
@@ -326,6 +369,7 @@ const ChannelsTable = ({ onReady }) => {
   const [showOnlyStreamlessChannels, setShowOnlyStreamlessChannels] =
     useState(false);
   const [showOnlyStaleChannels, setShowOnlyStaleChannels] = useState(false);
+  const [visibilityFilter, setVisibilityFilter] = useState('active');
 
   const [paginationString, setPaginationString] = useState('');
   const [filters, setFilters] = useState({
@@ -429,6 +473,7 @@ const ChannelsTable = ({ onReady }) => {
     if (showOnlyStaleChannels === true) {
       params.append('only_stale', true);
     }
+    params.append('visibility_filter', visibilityFilter);
 
     // Apply sorting
     if (sorting.length > 0) {
@@ -525,6 +570,7 @@ const ChannelsTable = ({ onReady }) => {
     selectedProfileId,
     showOnlyStreamlessChannels,
     showOnlyStaleChannels,
+    visibilityFilter,
   ]);
 
   const stopPropagation = useCallback((e) => {
@@ -659,6 +705,16 @@ const ChannelsTable = ({ onReady }) => {
       setIsLoading(false);
       setConfirmDeleteOpen(false);
     }
+  };
+
+  const toggleChannelHidden = async (channelId, hidden) => {
+    await API.updateChannel({ id: channelId, user_hidden: hidden });
+    await API.requeryChannels();
+  };
+
+  const toggleChannelLocked = async (channelId, locked) => {
+    await API.updateChannel({ id: channelId, user_locked: locked });
+    await API.requeryChannels();
   };
 
   const createRecording = useCallback((channel) => {
@@ -926,7 +982,37 @@ const ChannelsTable = ({ onReady }) => {
         size: columnSizing.name || 200,
         minSize: 100,
         grow: true,
-        cell: (props) => <EditableTextCell {...props} />,
+        cell: (props) => {
+          const row = props.row?.original || {};
+          return (
+            <Flex align="center" gap={6} style={{ minWidth: 0 }}>
+              <Box style={{ minWidth: 0, maxWidth: '100%' }}>
+                <EditableTextCell {...props} />
+              </Box>
+              {row.auto_created && (
+                <Tooltip
+                  label={
+                    row.user_locked
+                      ? 'Protected from auto-sync. Channel name, channel number, and group will not be overwritten on M3U refresh.'
+                      : 'Not protected from auto-sync. All channel information will be overwritten on M3U refresh.'
+                  }
+                >
+                  <Shield
+                    size={14}
+                    color={
+                      row.user_locked ? theme.tailwind.yellow[5] : '#9ca3af'
+                    }
+                  />
+                </Tooltip>
+              )}
+              {row.user_hidden && (
+                <Tooltip label="Hidden from HDHR, M3U, and EPG output to clients.">
+                  <EyeOff size={14} color="#9ca3af" />
+                </Tooltip>
+              )}
+            </Flex>
+          );
+        },
       },
       {
         id: 'epg',
@@ -989,6 +1075,8 @@ const ChannelsTable = ({ onReady }) => {
             handleWatchStream={handleWatchStream}
             createRecording={createRecording}
             getChannelURL={getChannelURL}
+            toggleChannelHidden={toggleChannelHidden}
+            toggleChannelLocked={toggleChannelLocked}
           />
         ),
       },
@@ -1180,6 +1268,13 @@ const ChannelsTable = ({ onReady }) => {
   });
 
   const rows = table.getRowModel().rows;
+
+  // Drives the "will be recreated on next refresh" note in the bulk delete
+  // dialog.
+  const bulkDeleteAutoCount = useMemo(
+    () => selectAutoCreatedInSelection(table?.selectedTableIds, data).count,
+    [table?.selectedTableIds, data]
+  );
 
   return (
     <>
@@ -1515,6 +1610,8 @@ const ChannelsTable = ({ onReady }) => {
             setShowOnlyStreamlessChannels={setShowOnlyStreamlessChannels}
             showOnlyStaleChannels={showOnlyStaleChannels}
             setShowOnlyStaleChannels={setShowOnlyStaleChannels}
+            visibilityFilter={visibilityFilter}
+            setVisibilityFilter={setVisibilityFilter}
           />
 
           {/* Table or ghost empty state inside Paper */}
@@ -1625,7 +1722,15 @@ const ChannelsTable = ({ onReady }) => {
         title={`Confirm ${isBulkDelete ? 'Bulk ' : ''}Channel Deletion`}
         message={
           isBulkDelete ? (
-            `Are you sure you want to delete ${table.selectedTableIds.length} channels? This action cannot be undone.`
+            bulkDeleteAutoCount === 0 ? (
+              `Are you sure you want to delete ${table.selectedTableIds.length} channels? This action cannot be undone.`
+            ) : (
+              <div style={{ whiteSpace: 'pre-line' }}>
+                {`Are you sure you want to delete ${table.selectedTableIds.length} channels? This action cannot be undone.
+
+Note: ${bulkDeleteAutoCount} of these ${bulkDeleteAutoCount === 1 ? 'channel was' : 'channels were'} created by auto-sync and will be recreated on the next M3U refresh. Use Edit > Hide from Clients instead to remove them permanently from downstream output.`}
+              </div>
+            )
           ) : channelToDelete ? (
             <div style={{ whiteSpace: 'pre-line' }}>
               {`Are you sure you want to delete the following channel?
@@ -1633,7 +1738,11 @@ const ChannelsTable = ({ onReady }) => {
 Name: ${channelToDelete.name}
 Channel Number: ${channelToDelete.channel_number}
 
-This action cannot be undone.`}
+This action cannot be undone.${
+                channelToDelete.auto_created
+                  ? '\n\nNote: this channel was created by auto-sync and will be recreated on the next M3U refresh. Use Hide instead to remove it permanently from downstream output.'
+                  : ''
+              }`}
             </div>
           ) : (
             'Are you sure you want to delete this channel? This action cannot be undone.'

--- a/frontend/src/components/tables/ChannelsTable/ChannelTableHeader.jsx
+++ b/frontend/src/components/tables/ChannelsTable/ChannelTableHeader.jsx
@@ -118,6 +118,8 @@ const ChannelTableHeader = ({
   setShowOnlyStreamlessChannels,
   showOnlyStaleChannels,
   setShowOnlyStaleChannels,
+  visibilityFilter,
+  setVisibilityFilter,
 }) => {
   const theme = useMantineTheme();
 
@@ -327,11 +329,41 @@ const ChannelTableHeader = ({
               <Menu.Item
                 onClick={toggleShowOnlyStaleChannels}
                 leftSection={
-                  showOnlyStaleChannels ? <SquareCheck size={18} /> : <Square size={18} />
+                  showOnlyStaleChannels ? (
+                    <SquareCheck size={18} />
+                  ) : (
+                    <Square size={18} />
+                  )
                 }
               >
                 <Text size="xs">Has Stale Streams</Text>
               </Menu.Item>
+
+              <Menu.Divider />
+
+              <Menu.Label>
+                <Text size="xs">Visibility</Text>
+              </Menu.Label>
+
+              {[
+                { value: 'active', label: 'Active Only' },
+                { value: 'hidden', label: 'Hidden Only' },
+                { value: 'all', label: 'Show All' },
+              ].map(({ value, label }) => (
+                <Menu.Item
+                  key={value}
+                  onClick={() => setVisibilityFilter(value)}
+                  leftSection={
+                    visibilityFilter === value ? (
+                      <SquareCheck size={18} />
+                    ) : (
+                      <Square size={18} />
+                    )
+                  }
+                >
+                  <Text size="xs">{label}</Text>
+                </Menu.Item>
+              ))}
             </Menu.Dropdown>
           </Menu>
 

--- a/frontend/src/components/tables/ChannelsTable/EditableCell.jsx
+++ b/frontend/src/components/tables/ChannelsTable/EditableCell.jsx
@@ -18,6 +18,18 @@ import {
 import API from '../../../api';
 import useChannelsTableStore from '../../../store/channelsTable';
 import useLogosStore from '../../../store/logos';
+import { IDENTITY_FIELDS } from '../../../utils/forms/ChannelUtils.js';
+
+const buildAutoLockUpdate = (row, columnId, payload) => {
+  if (
+    IDENTITY_FIELDS.includes(columnId) &&
+    row?.auto_created &&
+    !row?.user_locked
+  ) {
+    return { ...payload, user_locked: true };
+  }
+  return payload;
+};
 
 // Lightweight wrapper that only renders full editable cell when unlocked
 // This prevents 250+ heavy component instances when table is locked
@@ -103,10 +115,12 @@ const EditableTextCellInner = ({ row, column, getValue, onBlur }) => {
       }
 
       try {
-        const response = await API.updateChannel({
-          id: row.original.id,
-          [column.id]: newValue || null,
-        });
+        const response = await API.updateChannel(
+          buildAutoLockUpdate(row.original, column.id, {
+            id: row.original.id,
+            [column.id]: newValue || null,
+          })
+        );
         previousValue.current = newValue;
 
         // Update the table store to reflect the change
@@ -118,7 +132,7 @@ const EditableTextCellInner = ({ row, column, getValue, onBlur }) => {
         setValue(previousValue.current || '');
       }
     },
-    [row.original.id, column.id]
+    [row.original, column.id]
   );
 
   useEffect(() => {
@@ -249,10 +263,12 @@ const EditableNumberCellInner = ({ row, column, getValue, onBlur }) => {
       }
 
       try {
-        const response = await API.updateChannel({
-          id: row.original.id,
-          [column.id]: newValue,
-        });
+        const response = await API.updateChannel(
+          buildAutoLockUpdate(row.original, column.id, {
+            id: row.original.id,
+            [column.id]: newValue,
+          })
+        );
         previousValue.current = newValue;
 
         // Update the table store to reflect the change
@@ -270,7 +286,7 @@ const EditableNumberCellInner = ({ row, column, getValue, onBlur }) => {
         setValue(previousValue.current);
       }
     },
-    [row.original.id, column.id, onBlur]
+    [row.original, column.id, onBlur]
   );
 
   useEffect(() => {
@@ -366,10 +382,12 @@ const EditableGroupCellInner = ({
       }
 
       try {
-        const response = await API.updateChannel({
-          id: row.original.id,
-          channel_group_id: parseInt(newGroupId, 10),
-        });
+        const response = await API.updateChannel(
+          buildAutoLockUpdate(row.original, 'channel_group_id', {
+            id: row.original.id,
+            channel_group_id: parseInt(newGroupId, 10),
+          })
+        );
         previousGroupId.current = newGroupId;
 
         // Update the table store to reflect the change
@@ -380,7 +398,7 @@ const EditableGroupCellInner = ({
         console.error('Failed to update channel group:', error);
       }
     },
-    [row.original.id]
+    [row.original]
   );
 
   const handleChange = (newGroupId) => {

--- a/frontend/src/utils/forms/ChannelBatchUtils.js
+++ b/frontend/src/utils/forms/ChannelBatchUtils.js
@@ -32,6 +32,20 @@ export const getMatureContentChange = (isAdult) => {
   return `• Mature Content: ${isAdult === 'true' ? 'Yes' : 'No'}`;
 };
 
+export const getUserHiddenChange = (userHidden) => {
+  if (!userHidden || userHidden === '-1') return null;
+  return `• Hide from Clients: ${userHidden === 'true' ? 'Yes' : 'No'}`;
+};
+
+export const getUserLockedChange = (userLocked, autoCreatedCount) => {
+  if (!userLocked || userLocked === '-1') return null;
+  const scope =
+    autoCreatedCount > 0
+      ? ` (${autoCreatedCount} auto-created channel${autoCreatedCount === 1 ? '' : 's'} in selection)`
+      : ' (no auto-created channels in selection; skipped)';
+  return `• Protect from Auto-Sync: ${userLocked === 'true' ? 'Yes' : 'No'}${scope}`;
+};
+
 export const getRegexNameChange = (regexFind, regexReplace) => {
   if (!regexFind?.trim()) return null;
   return `• Name Change: Apply regex find "${regexFind}" replace with "${regexReplace || ''}"`;
@@ -150,6 +164,20 @@ export const buildSubmitValues = (
     delete values.is_adult;
   } else {
     values.is_adult = values.is_adult === 'true';
+  }
+
+  // user_locked applies only to auto-created channels; the caller splits the
+  // PATCH so manual rows never end up with user_locked=true.
+  if (values.user_hidden === '-1' || values.user_hidden === undefined) {
+    delete values.user_hidden;
+  } else {
+    values.user_hidden = values.user_hidden === 'true';
+  }
+
+  if (values.user_locked === '-1' || values.user_locked === undefined) {
+    delete values.user_locked;
+  } else {
+    values.user_locked = values.user_locked === 'true';
   }
 
   return values;

--- a/frontend/src/utils/forms/ChannelUtils.js
+++ b/frontend/src/utils/forms/ChannelUtils.js
@@ -40,6 +40,8 @@ export const getChannelFormDefaultValues = (channel, channelGroups) => {
     logo_id: channel?.logo_id ? `${channel.logo_id}` : '',
     user_level: `${channel?.user_level ?? '0'}`,
     is_adult: channel?.is_adult ?? false,
+    user_hidden: channel?.user_hidden ?? false,
+    user_locked: channel?.user_locked ?? false,
   };
 };
 
@@ -62,6 +64,35 @@ export const getFormattedValues = (values) => {
     formattedValues.tvc_guide_stationid || null;
 
   return formattedValues;
+};
+
+// Fields that auto-sync overwrites. Editing any of these on an auto-created
+// channel implies user_locked=true so the customization persists across
+// future refreshes.
+export const IDENTITY_FIELDS = ['name', 'channel_number', 'channel_group_id'];
+
+// Shared helper for bulk-selection flows that need to scope a user_locked
+// PATCH to auto-created rows only. Returns {ids, count} in one pass so
+// callers don't re-filter later.
+export const selectAutoCreatedInSelection = (channelIds, rows) => {
+  if (!channelIds?.length || !rows?.length) return { ids: [], count: 0 };
+  const selected = new Set(channelIds.map((id) => parseInt(id, 10)));
+  const ids = rows
+    .filter((c) => selected.has(c.id) && c.auto_created)
+    .map((c) => c.id);
+  return { ids, count: ids.length };
+};
+
+export const applyAutoProtect = (channel, values, formattedValues) => {
+  if (!channel?.auto_created) return;
+  if (channel.user_locked) return;
+  if (values.user_locked) return;
+  const identityChanged = IDENTITY_FIELDS.some(
+    (field) => formattedValues[field] !== channel[field]
+  );
+  if (identityChanged) {
+    formattedValues.user_locked = true;
+  }
 };
 
 export const handleEpgUpdate = async (

--- a/frontend/src/utils/forms/__tests__/ChannelUtils.test.js
+++ b/frontend/src/utils/forms/__tests__/ChannelUtils.test.js
@@ -134,6 +134,8 @@ describe('ChannelUtils', () => {
         logo_id: '10',
         user_level: '1',
         is_adult: false,
+        user_hidden: false,
+        user_locked: false,
       });
     });
 
@@ -230,6 +232,8 @@ describe('ChannelUtils', () => {
         logo_id: '',
         user_level: '0',
         is_adult: false,
+        user_hidden: false,
+        user_locked: false,
       });
     });
   });


### PR DESCRIPTION
## Description

Adds two new BooleanFields to the Channel model so users can selectively exempt auto-synced channels from refresh overwrites without losing their customizations.

- user_hidden: excludes a channel from HDHR, M3U, EPG, and XC output. Sync continues to refresh its provider metadata (tvg_id, logo, epg_data, tvc_guide_stationid) and never overwrites the flag itself.

- user_locked: preserves the user-chosen name, channel_number, and channel_group on auto-created channels across refreshes while provider metadata continues to flow through. Referred to as "Protected/Unprotected" in frontend to avoid naming collision with the "Unlock for editing" channels table feature.

Both default to false, existing installs see zero behavior change.

Backend changes:

- New fields + migration on Channel; user_hidden is indexed because it filters every downstream output queryset.
- ChannelSerializer exposes both fields (visible in OpenAPI schema).
- sync_auto_channels in apps/m3u/tasks.py gates renumber/rename/group-move on user_locked, and gates stale-delete / empty-group-delete / orphan-cleanup on a shared _channel_is_frozen helper (locked OR hidden).
- HDHR lineup, M3U output, EPG output, and XC (live streams + per-channel EPG + category channels) all apply .exclude(user_hidden=True).
- ChannelViewSet.get_queryset gains a visibility_filter query param (active / hidden / all) scoped to list, get_ids, and summary actions so retrieve/update/delete can still reach a hidden channel by id (needed for unhide).

Frontend changes:

- Row action menu: Hide/Unhide on every row, Protect/Unprotect only on auto_created rows.
- Shield icon on auto-created rows (grey = unprotected, yellow = protected); EyeOff badge on hidden rows, both with explanatory tooltips.
- Bulk edit modal: tri-state Selects for Hide from Clients and Protect from Auto-Sync. Protect is disabled when the selection contains no auto-created rows, and the submit path splits user_locked into a follow-up PATCH targeting only auto-created ids so manual channels never carry a misleading user_locked=true.
- Toolbar visibility filter: Active (default) / Hidden Only / Show All.
- Inline identity edits (name / channel_number / channel_group) on an auto-created channel auto-set user_locked=true in the outgoing PATCH so the customization persists across future refreshes.
- Delete confirmation warns for auto-created rows that the channel will be recreated on the next refresh and recommends Hide instead.

## Related Issue

Fulfills #1196

## How was it tested?

- Django unit tests: 14 tests covering field defaults, serializer round-trip, sync preservation of user_hidden and user_locked across refresh, hidden-channel metadata flow-through, locked channel identity preservation, locked channel survival of stream removal, provider tvg_id updates on locked channel, hidden channel number reservation. All 14 pass against a freshly migrated container.
- Vitest: 2701/2701 pass after updating mocks for the refactored ChannelUtils helpers (selectAutoCreatedInSelection, applyAutoProtect, IDENTITY_FIELDS) and the new user_hidden/user_locked default values.
- Playwright feature spec (not included in this PR): covers model + API basics (field exposure, default values, visibility_filter query param, PATCH round-trip), downstream output exclusion across HDHR / M3U / EPG / XC, sync behavior across all four flag permutations, row action menu for every transition, inline-edit auto-protect, bulk edit modal tri-state flow, bulk Protect filtering to auto-created rows only, visibility filter dropdown, shield / EyeOff indicators, delete confirmation warning grammar, edge case of every channel in a group hidden.
- Significant manual testing and verification

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change