### PR TITLE
Reduce OCI image bloat by making large optional dependencies actually optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,12 @@ uv run python manage.py migrate
 uv run python manage.py runserver
 ```
 
+If you need ML-enhanced channel matching locally, install the optional ML extra:
+
+```bash
+uv sync --extra ml
+```
+
 ### Frontend
 
 ```bash

--- a/debian_install.sh
+++ b/debian_install.sh
@@ -192,7 +192,11 @@ setup_python_env() {
   env/bin/python -m ensurepip --upgrade
 
   export UV_PROJECT_ENVIRONMENT="$APP_DIR/env"
-  uv sync --no-dev
+  UV_EXTRA_ARGS=""
+  if [ "${DISPATCHARR_INSTALL_ML:-false}" = "true" ]; then
+    UV_EXTRA_ARGS="--extra ml"
+  fi
+  uv sync --no-dev ${UV_EXTRA_ARGS}
 
   env/bin/python -m pip install -q gunicorn
 EOSU

--- a/docker/DispatcharrBase
+++ b/docker/DispatcharrBase
@@ -6,6 +6,7 @@ ENV VIRTUAL_ENV=/dispatcharrpy
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
+ARG DISPATCHARR_INSTALL_ML=false
 
 # --- Install Python 3.13 and build dependencies ---
 # Note: Hardware acceleration (VA-API, VDPAU, NVENC) already included in base ffmpeg image
@@ -28,7 +29,9 @@ WORKDIR /tmp/build
 COPY pyproject.toml /tmp/build/
 COPY version.py /tmp/build/
 COPY README.md /tmp/build/
-RUN uv sync --python 3.13 --no-cache --no-install-project --no-dev && \
+RUN UV_EXTRA_ARGS="" && \
+    if [ "${DISPATCHARR_INSTALL_ML}" = "true" ]; then UV_EXTRA_ARGS="--extra ml"; fi && \
+    uv sync --python 3.13 --no-cache --no-install-project --no-dev ${UV_EXTRA_ARGS} && \
     rm -rf /tmp/build
 WORKDIR /
 

--- a/docker/init/99-init-dev.sh
+++ b/docker/init/99-init-dev.sh
@@ -16,8 +16,12 @@ if [ ! -e "/tmp/init" ]; then
 
     # Install frontend dependencies
     cd /app/frontend && npm install
-    # Install Python dependencies using UV
-    cd /app && uv sync --python $UV_PROJECT_ENVIRONMENT/bin/python --no-install-project --no-dev
+    # Install Python dependencies using UV. ML deps are optional and heavy.
+    UV_EXTRA_ARGS=""
+    if [ "${DISPATCHARR_INSTALL_ML:-false}" = "true" ]; then
+        UV_EXTRA_ARGS="--extra ml"
+    fi
+    cd /app && uv sync --python $UV_PROJECT_ENVIRONMENT/bin/python --no-install-project --no-dev ${UV_EXTRA_ARGS}
 
     # Install debugpy for remote debugging
     if [ "$DISPATCHARR_DEBUG" = "true" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ dependencies = [
     "regex",
     "tzlocal",
     "pytz",
-    "torch==2.11.0+cpu",
-    "sentence-transformers==5.4.1",
     "channels",
     "channels-redis==4.3.0",
     "django-filter",
@@ -36,6 +34,12 @@ dependencies = [
     "lxml==6.1.0",
     "packaging",
     "python-gnupg",
+]
+
+[project.optional-dependencies]
+ml = [
+    "torch==2.11.0+cpu",
+    "sentence-transformers==5.4.1",
 ]
 
 [build-system]


### PR DESCRIPTION
## Description


This pull request introduces optional installation of machine learning (ML) dependencies, making ML features easier to enable or exclude in local, Docker, and Debian-based setups. The main change is moving heavy ML packages (like `torch` and `sentence-transformers`) into an optional dependency group, and updating installation scripts and documentation to support this new workflow.

Dependency management improvements:

* Moved `torch` and `sentence-transformers` from the main `dependencies` list in `pyproject.toml` to a new `[project.optional-dependencies] ml` group, making them optional and only installed when needed. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L30-L31) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R39-R44)

Installer and environment updates:

* Updated Docker build (`docker/DispatcharrBase`) and initialization scripts (`docker/init/99-init-dev.sh`) to accept a `DISPATCHARR_INSTALL_ML` flag. When set to `true`, ML dependencies are installed via the `--extra ml` option to `uv sync`. [[1]](diffhunk://#diff-37c17d7a8c67a652b9fa00cebe2ed520f5c7b6741e119b2a7a1c397f2406acddR9) [[2]](diffhunk://#diff-37c17d7a8c67a652b9fa00cebe2ed520f5c7b6741e119b2a7a1c397f2406acddL31-R34) [[3]](diffhunk://#diff-27106270658cfbe5ba212625df3a9e9061943baad7cbbae4a0b94a9f70fdedb7L19-R24)
* Modified the Debian installation script (`debian_install.sh`) to install ML dependencies only if `DISPATCHARR_INSTALL_ML` is set.

Documentation:

* Updated `CONTRIBUTING.md` to document how to install ML dependencies locally using the `--extra ml` option with `uv sync`.

## Related Issue

A 1.5GB OCI image is beyond suboptimal, it needs no justification that artifacts that excessively large are not shipped

## How was it tested?

Existing code gates against failure to load ML dependencies, I've just exercised our ability for them to never exist instead of forcing them to.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [ ] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [ ] Existing tests still pass
- [ ] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [ ] I have not reformatted or refactored code outside the scope of this change
