### PR TITLE
feat: built-in XC catch-up (timeshift) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **XC catch-up (timeshift) support**. Adds a native `/timeshift/{user}/{pass}/{stream_id}/{timestamp}/{duration}.ts` endpoint that proxies replay sessions from an Xtream Codes provider to clients such as iPlayTV (Apple TV) and TiviMate. Auth reuses the same `xc_password` custom-property the live `/live/.../{id}.ts` endpoint already uses. Catch-up sessions appear on `/stats` with a violet `TIMESHIFT` badge alongside live sessions and respect per-channel access rules.
+  - **`xc_get_live_streams` / `xc_get_epg` now expose catch-up flags** (`tv_archive`, `tv_archive_duration`) and emit the provider's `stream_id` *only when the channel actually has catch-up support* — for channels without catch-up, `stream_id` keeps its existing internal-id value so existing XC client favorites continue to resolve unchanged. The dual-resolution logic in `stream_xc` already handles both forms.
+  - **`xc_get_epg` JSON timestamps and timeshift URLs** are emitted in the provider's local timezone via a new `Settings → Timeshift` panel (timezone, language, debug logging, XMLTV `prev_days` override). Defaults are neutral: `UTC`, `en`, off. The `/epg.xml` XMLTV endpoint continues to emit UTC times for backward compatibility with Jellyfin / Plex / Channels DVR consumers — the timeshift timezone setting does NOT influence `/epg.xml`.
+  - **EPG XMLTV `prev_days` auto-detection** from the provider's largest `tv_archive_duration` (capped at 30 days), overridable via the new `xmltv_prev_days_override` setting or the `?prev_days=` URL parameter.
+  - **Byte path uses a dedicated producer thread + `os.pipe`** so the upstream socket read is decoupled from the WSGI yield, matching the pattern used by `apps.proxy.ts_proxy.http_streamer.HTTPStreamReader` for live streams. This delivers throughput comfortably above the typical 5 Mbps FHD bitrate so clients do not buffer.
+
 ## [0.24.0] - 2026-05-03
 
 ### Security

--- a/apps/channels/utils.py
+++ b/apps/channels/utils.py
@@ -4,6 +4,59 @@ lock = threading.Lock()
 # Dictionary to track usage: {account_id: current_usage}
 active_streams_map = {}
 
+
+def resolve_channel_by_provider_stream_id(provider_stream_id):
+    """Find a Channel + Stream by the XC provider's stream_id.
+
+    XC clients address channels via the provider's `stream_id` (stored in
+    `Stream.custom_properties["stream_id"]`), not Dispatcharr's internal
+    `Channel.id`. Returns `(Channel, Stream)` on hit, `(None, None)` on miss.
+    """
+    from apps.channels.models import Stream
+
+    stream = (
+        Stream.objects.filter(
+            custom_properties__stream_id=str(provider_stream_id),
+            m3u_account__account_type="XC",
+        )
+        .select_related("m3u_account")
+        .first()
+    )
+    if stream is None:
+        return None, None
+    channel = stream.channels.first()
+    if channel is None:
+        return None, None
+    return channel, stream
+
+
+def get_channel_catchup_info(channel):
+    """Return catch-up info for a Channel, or None if no stream has tv_archive.
+
+    Walks `channel.streams` in `channelstream__order`, returns a dict for the
+    first archive-enabled stream: `{stream, props, provider_stream_id,
+    tv_archive_duration}`. `tv_archive` may be stored as 1, "1", True or
+    "True" depending on the M3U importer that wrote it.
+    """
+    for stream in channel.streams.order_by("channelstream__order"):
+        props = stream.custom_properties or {}
+        if str(props.get("tv_archive")) not in ("1", "True"):
+            continue
+        provider_stream_id = props.get("stream_id")
+        if not provider_stream_id:
+            continue
+        try:
+            archive_days = int(props.get("tv_archive_duration", 7) or 7)
+        except (TypeError, ValueError):
+            archive_days = 7
+        return {
+            "stream": stream,
+            "props": props,
+            "provider_stream_id": str(provider_stream_id),
+            "tv_archive_duration": archive_days,
+        }
+    return None
+
 def increment_stream_count(account):
     with lock:
         current_usage = active_streams_map.get(account.id, 0)

--- a/apps/m3u/serializers.py
+++ b/apps/m3u/serializers.py
@@ -1,7 +1,12 @@
 from core.utils import validate_flexible_url
 from rest_framework import serializers, status
 from rest_framework.response import Response
-from .models import M3UAccount, M3UFilter, ServerGroup, M3UAccountProfile
+from .models import (
+    M3UAccount,
+    M3UFilter,
+    ServerGroup,
+    M3UAccountProfile,
+)
 from core.models import UserAgent
 from apps.channels.models import ChannelGroup, ChannelGroupM3UAccount
 from apps.channels.serializers import (
@@ -374,7 +379,6 @@ class M3UAccountSerializer(serializers.ModelSerializer):
             }
             for p in profiles
         ]
-
 
 class ServerGroupSerializer(serializers.ModelSerializer):
     """Serializer for Server Group"""

--- a/apps/output/tests.py
+++ b/apps/output/tests.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.test import TestCase, Client
 from django.urls import reverse
 from apps.channels.models import Channel, ChannelGroup
@@ -7,12 +8,15 @@ import xml.etree.ElementTree as ET
 class OutputM3UTest(TestCase):
     def setUp(self):
         self.client = Client()
+        # m3u_endpoint memoises its rendered response; clear so each test
+        # exercises the uncached path and isn't affected by sibling tests.
+        cache.clear()
     
     def test_generate_m3u_response(self):
         """
         Test that the M3U endpoint returns a valid M3U file.
         """
-        url = reverse('output:generate_m3u')
+        url = reverse('output:m3u_endpoint')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
@@ -22,7 +26,7 @@ class OutputM3UTest(TestCase):
         """
         Test that a POST request with an empty body returns 200 OK.
         """
-        url = reverse('output:generate_m3u')
+        url = reverse('output:m3u_endpoint')
 
         response = self.client.post(url, data=None, content_type='application/x-www-form-urlencoded')
         content = response.content.decode()
@@ -34,7 +38,7 @@ class OutputM3UTest(TestCase):
         """
         Test that a POST request with a non-empty body returns 403 Forbidden.
         """
-        url = reverse('output:generate_m3u')
+        url = reverse('output:m3u_endpoint')
 
         response = self.client.post(url, data={'evilstring': 'muhahaha'})
 
@@ -47,6 +51,9 @@ class OutputEPGXMLEscapingTest(TestCase):
 
     def setUp(self):
         self.client = Client()
+        # generate_epg memoises its rendered response; clear so each test
+        # exercises the uncached StreamingHttpResponse path.
+        cache.clear()
         self.group = ChannelGroup.objects.create(name="Test Group")
 
     def test_channel_id_with_ampersand(self):
@@ -58,11 +65,11 @@ class OutputEPGXMLEscapingTest(TestCase):
             channel_group=self.group
         )
 
-        url = reverse('output:generate_epg') + '?tvg_id_source=tvg_id'
+        url = reverse('output:epg_endpoint') + '?tvg_id_source=tvg_id'
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 200)
-        content = response.content.decode()
+        content = b"".join(response.streaming_content).decode()
 
         # Should contain escaped ampersand
         self.assertIn('id="News &amp; Sports"', content)
@@ -83,10 +90,10 @@ class OutputEPGXMLEscapingTest(TestCase):
             channel_group=self.group
         )
 
-        url = reverse('output:generate_epg') + '?tvg_id_source=tvg_id'
+        url = reverse('output:epg_endpoint') + '?tvg_id_source=tvg_id'
         response = self.client.get(url)
 
-        content = response.content.decode()
+        content = b"".join(response.streaming_content).decode()
         self.assertIn('id="Channel &lt;HD&gt;"', content)
 
         try:
@@ -103,16 +110,21 @@ class OutputEPGXMLEscapingTest(TestCase):
             channel_group=self.group
         )
 
-        url = reverse('output:generate_epg') + '?tvg_id_source=tvg_id'
+        url = reverse('output:epg_endpoint') + '?tvg_id_source=tvg_id'
         response = self.client.get(url)
 
-        content = response.content.decode()
+        content = b"".join(response.streaming_content).decode()
         self.assertIn('id="Test &amp; &quot;Special&quot; &lt;Chars&gt;"', content)
 
         try:
             tree = ET.fromstring(content)
-            # Verify we can find the channel with correct ID in parsed tree
-            channel_elem = tree.find('.//channel[@id="Test & \\"Special\\" <Chars>"]')
+            # ElementTree XPath cannot quote both `"` and `<>` in one selector,
+            # so walk channels by hand and compare the decoded id attribute.
+            expected_id = 'Test & "Special" <Chars>'
+            channel_elem = next(
+                (ch for ch in tree.findall('.//channel') if ch.get('id') == expected_id),
+                None,
+            )
             self.assertIsNotNone(channel_elem)
         except ET.ParseError as e:
             self.fail(f"Generated EPG with all special chars is not valid XML: {e}")
@@ -129,10 +141,10 @@ class OutputEPGXMLEscapingTest(TestCase):
             channel_group=self.group
         )
 
-        url = reverse('output:generate_epg') + '?tvg_id_source=tvg_id'
+        url = reverse('output:epg_endpoint') + '?tvg_id_source=tvg_id'
         response = self.client.get(url)
 
-        content = response.content.decode()
+        content = b"".join(response.streaming_content).decode()
 
         # Check programme elements have escaped channel attributes
         self.assertIn('channel="News &amp; Sports"', content)

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -2,6 +2,10 @@ from django.http import HttpResponse, JsonResponse, Http404, HttpResponseForbidd
 from rest_framework.response import Response
 from django.urls import reverse
 from apps.channels.models import Channel, ChannelProfile, ChannelGroup, Stream
+from apps.channels.utils import (
+    get_channel_catchup_info,
+    resolve_channel_by_provider_stream_id,
+)
 from django.db.models import Prefetch
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
@@ -11,6 +15,7 @@ from dispatcharr.utils import network_access_allowed
 from django.utils import timezone as django_timezone
 from django.shortcuts import get_object_or_404
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 import html
 import time
 from tzlocal import get_localzone
@@ -22,6 +27,7 @@ import os
 from apps.m3u.utils import calculate_tuner_count
 from apps.proxy.utils import get_user_active_connections
 import regex
+from core.models import CoreSettings
 from core.utils import log_system_event
 import hashlib
 
@@ -1286,16 +1292,50 @@ def generate_epg(request, profile_name=None, user=None):
         num_days = max(0, min(num_days, 365))
     except (ValueError, TypeError):
         num_days = 0
-    try:
-        prev_days = int(request.GET.get('prev_days', user_custom.get('epg_prev_days', 0)))
-        prev_days = max(0, min(prev_days, 30))
-    except (ValueError, TypeError):
-        prev_days = 0
+
+    # Timeshift: prev_days resolution order
+    #   1. URL ?prev_days= (explicit, even 0 means "no past")
+    #   2. user.custom_properties.epg_prev_days
+    #   3. CoreSettings.timeshift_settings.xmltv_prev_days_override (>0)
+    #   4. Auto-detect: max provider tv_archive_duration capped at 30
+    url_prev = request.GET.get('prev_days')
+    user_prev = user_custom.get('epg_prev_days') if user_custom else None
+    if url_prev is not None:
+        try:
+            prev_days = max(0, min(int(url_prev), 30))
+        except (ValueError, TypeError):
+            prev_days = 0
+    elif user_prev not in (None, ""):
+        try:
+            prev_days = max(0, min(int(user_prev), 30))
+        except (ValueError, TypeError):
+            prev_days = 0
+    else:
+        from apps.timeshift.helpers import compute_provider_archive_days_capped
+        timeshift_settings = CoreSettings.get_timeshift_settings()
+        try:
+            override = int(timeshift_settings.get("xmltv_prev_days_override", 0) or 0)
+        except (TypeError, ValueError):
+            override = 0
+        if override > 0:
+            prev_days = max(0, min(override, 30))
+        else:
+            prev_days = compute_provider_archive_days_capped()
     use_cached_logos = request.GET.get('cachedlogos', 'true').lower() != 'false'
     tvg_id_source = request.GET.get('tvg_id_source', 'channel_number').lower()
+
+    # Always emit XMLTV programme times in UTC. XMLTV consumers (Jellyfin,
+    # Plex, etc.) parse the `%z` offset correctly, so UTC is the safest
+    # interchange format. The catch-up URL builder + `xc_get_epg` handle the
+    # provider-local conversion separately using the timeshift `default_timezone`
+    # setting — that setting does NOT influence /epg.xml output.
+    local_tz = ZoneInfo("UTC")
+    xmltv_tz_name = "UTC"
+
     cache_params = (
         f"{profile_name or 'all'}:{user.username if user else 'anonymous'}"
         f":d={num_days}:p={prev_days}:logos={use_cached_logos}:tvgid={tvg_id_source}"
+        f":tz={xmltv_tz_name}"
     )
     content_cache_key = f"epg_content:{cache_params}"
 
@@ -1559,8 +1599,8 @@ def generate_epg(request, profile_name=None, user=None):
                 epg_source=epg_source
             )
             for program in dummy_programs:
-                start_str = program['start_time'].strftime("%Y%m%d%H%M%S %z")
-                stop_str = program['end_time'].strftime("%Y%m%d%H%M%S %z")
+                start_str = program['start_time'].astimezone(local_tz).strftime("%Y%m%d%H%M%S %z")
+                stop_str = program['end_time'].astimezone(local_tz).strftime("%Y%m%d%H%M%S %z")
                 yield f'  <programme start="{start_str}" stop="{stop_str}" channel="{html.escape(channel_id)}">\n'
                 yield f"    <title>{html.escape(program['title'])}</title>\n"
                 if program.get('sub_title'):
@@ -1652,8 +1692,8 @@ def generate_epg(request, profile_name=None, user=None):
 
                     # Build programme XML for primary channel_id
                     primary_cid = channel_ids_for_epg[0]
-                    start_str = prog['start_time'].strftime("%Y%m%d%H%M%S %z")
-                    stop_str = prog['end_time'].strftime("%Y%m%d%H%M%S %z")
+                    start_str = prog['start_time'].astimezone(local_tz).strftime("%Y%m%d%H%M%S %z")
+                    stop_str = prog['end_time'].astimezone(local_tz).strftime("%Y%m%d%H%M%S %z")
 
                     program_xml = [f'  <programme start="{start_str}" stop="{stop_str}" channel="{html.escape(primary_cid)}">']
                     program_xml.append(f'    <title>{html.escape(prog["title"])}</title>')
@@ -2220,12 +2260,32 @@ def xc_get_live_streams(request, user, category_id=None):
     for channel in channels:
         channel_num_int = channel_num_map[channel.id]
 
+        # Timeshift enrichment: for channels with catch-up (tv_archive=1) we
+        # emit the provider's stream_id as the XC `stream_id` so the same
+        # value works for both live and catch-up URLs (XC clients reuse
+        # `stream_id` to build /timeshift/.../{provider_stream_id}.ts).
+        # For channels without catch-up, we keep stream_id = channel.id so
+        # existing XC client favorites on non-catchup channels are unchanged.
+        # `stream_xc` accepts both forms (provider stream_id and internal id).
+        catchup = get_channel_catchup_info(channel)
+        if catchup is not None:
+            tv_archive = 1
+            tv_archive_duration = catchup["tv_archive_duration"]
+            try:
+                stream_id_value = int(catchup["provider_stream_id"])
+            except (TypeError, ValueError):
+                stream_id_value = channel.id
+        else:
+            tv_archive = 0
+            tv_archive_duration = 0
+            stream_id_value = channel.id
+
         streams.append(
             {
                 "num": channel_num_int,
                 "name": channel.name,
                 "stream_type": "live",
-                "stream_id": channel.id,
+                "stream_id": stream_id_value,
                 "stream_icon": (
                     None
                     if not channel.logo
@@ -2240,9 +2300,9 @@ def xc_get_live_streams(request, user, category_id=None):
                 "category_id": str(channel.channel_group.id if channel.channel_group else _get_default_group_id()),
                 "category_ids": [channel.channel_group.id if channel.channel_group else _get_default_group_id()],
                 "custom_sid": None,
-                "tv_archive": 0,
+                "tv_archive": tv_archive,
                 "direct_source": "",
-                "tv_archive_duration": 0,
+                "tv_archive_duration": tv_archive_duration,
             }
         )
 
@@ -2254,6 +2314,14 @@ def xc_get_epg(request, user, short=False):
     if not channel_id:
         raise Http404()
 
+    # Timeshift: clients address channels via the provider stream_id we expose
+    # in xc_get_live_streams. Resolve that to an internal Channel.id before
+    # running the existing access-control queries.
+    resolved_channel_id = channel_id
+    provider_channel, _ = resolve_channel_by_provider_stream_id(channel_id)
+    if provider_channel is not None:
+        resolved_channel_id = provider_channel.id
+
     channel = None
     if user.user_level < 10:
         user_profile_count = user.channel_profiles.count()
@@ -2262,7 +2330,7 @@ def xc_get_epg(request, user, short=False):
         if user_profile_count == 0:
             # No profile filtering - user sees all channels based on user_level
             filters = {
-                "id": channel_id,
+                "id": resolved_channel_id,
                 "user_level__lte": user.user_level
             }
             # Hide adult content if user preference is set
@@ -2272,7 +2340,7 @@ def xc_get_epg(request, user, short=False):
         else:
             # User has specific limited profiles assigned
             filters = {
-                "id": channel_id,
+                "id": resolved_channel_id,
                 "channelprofilemembership__enabled": True,
                 "user_level__lte": user.user_level,
                 "channelprofilemembership__channel_profile__in": user.channel_profiles.all()
@@ -2285,10 +2353,31 @@ def xc_get_epg(request, user, short=False):
         if not channel:
             raise Http404()
     else:
-        channel = get_object_or_404(Channel.objects.select_related('epg_data__epg_source'), id=channel_id)
+        channel = get_object_or_404(Channel.objects.select_related('epg_data__epg_source'), id=resolved_channel_id)
 
     if not channel:
         raise Http404()
+
+    # Timeshift: detect catch-up support and remember the provider's stream_id
+    # for the response (Issue #8 fallback chain — uses the first archive-enabled
+    # stream in channelstream__order).
+    catchup = get_channel_catchup_info(channel)
+    if catchup is not None:
+        timeshift_tv_archive = 1
+        timeshift_archive_days = catchup["tv_archive_duration"]
+        timeshift_provider_stream_id = catchup["provider_stream_id"]
+    else:
+        timeshift_tv_archive = 0
+        timeshift_archive_days = 0
+        timeshift_provider_stream_id = None
+
+    timeshift_settings = CoreSettings.get_timeshift_settings()
+    timeshift_timezone = timeshift_settings.get("default_timezone", "UTC")
+    timeshift_language = timeshift_settings.get("default_language", "en")
+    try:
+        local_tz = ZoneInfo(timeshift_timezone)
+    except Exception:
+        local_tz = ZoneInfo("UTC")
 
     # Calculate the collision-free integer channel number for this channel
     # This must match the logic in xc_get_live_streams to ensure consistency
@@ -2331,6 +2420,16 @@ def xc_get_epg(request, user, short=False):
         prev_days = max(0, min(prev_days, 30))
     except (ValueError, TypeError):
         prev_days = 0
+    # Timeshift: when the channel exposes catch-up and the client did not
+    # explicitly request a different lookback, expose the full archive window
+    # so XC clients see has_archive=1 on past programmes.
+    if (
+        timeshift_tv_archive
+        and timeshift_archive_days > 0
+        and request.GET.get('prev_days') is None
+        and not user_custom.get('epg_prev_days')
+    ):
+        prev_days = max(prev_days, min(timeshift_archive_days, 30))
     now = django_timezone.now()
     lookback_cutoff = now - timedelta(days=prev_days)
     forward_cutoff = now + timedelta(days=num_days) if num_days > 0 else None
@@ -2393,23 +2492,47 @@ def xc_get_epg(request, user, short=False):
         # Use the actual EPGData ID when available, otherwise fall back to 0
         epg_id = str(channel.epg_data.id) if channel.epg_data else "0"
 
+        # Timeshift: emit the start/end strings in the configured local
+        # timezone (XC clients display these verbatim) but keep the unix
+        # timestamps in UTC because XC clients expect that.
+        try:
+            start_local = start.astimezone(local_tz) if start.tzinfo else start.replace(tzinfo=ZoneInfo("UTC")).astimezone(local_tz)
+            end_local = end.astimezone(local_tz) if end.tzinfo else end.replace(tzinfo=ZoneInfo("UTC")).astimezone(local_tz)
+        except Exception:
+            start_local = start
+            end_local = end
+
+        # Use the provider's stream_id if we have one; XC clients use this for
+        # subsequent /timeshift/...ts requests.
+        stream_id_for_output = (
+            str(timeshift_provider_stream_id)
+            if timeshift_provider_stream_id is not None
+            else f"{channel_id}"
+        )
+
         program_output = {
             "id": program_id,
             "epg_id": epg_id,
             "title": base64.b64encode((title or "").encode()).decode(),
-            "lang": "",
-            "start": start.strftime("%Y-%m-%d %H:%M:%S"),
-            "end": end.strftime("%Y-%m-%d %H:%M:%S"),
+            "lang": timeshift_language,
+            "start": start_local.strftime("%Y-%m-%d %H:%M:%S"),
+            "end": end_local.strftime("%Y-%m-%d %H:%M:%S"),
             "description": base64.b64encode((description or "").encode()).decode(),
             "channel_id": str(channel_num_int),
             "start_timestamp": str(int(start.timestamp())),
             "stop_timestamp": str(int(end.timestamp())),
-            "stream_id": f"{channel_id}",
+            "stream_id": stream_id_for_output,
         }
 
         if short == False:
-            program_output["now_playing"] = 1 if start <= django_timezone.now() <= end else 0
-            program_output["has_archive"] = 0
+            now = django_timezone.now()
+            program_output["now_playing"] = 1 if start <= now <= end else 0
+            has_archive = 0
+            if timeshift_tv_archive and end < now:
+                days_ago = (now - end).days
+                if days_ago <= timeshift_archive_days:
+                    has_archive = 1
+            program_output["has_archive"] = has_archive
 
         output['epg_listings'].append(program_output)
 

--- a/apps/proxy/ts_proxy/channel_status.py
+++ b/apps/proxy/ts_proxy/channel_status.py
@@ -401,6 +401,20 @@ class ChannelStatus:
             if channel_name:
                 info['channel_name'] = channel_name
 
+            info['is_timeshift'] = bool(metadata.get(ChannelMetadataField.IS_TIMESHIFT))
+
+            for key, field in (
+                ('logo_id', ChannelMetadataField.LOGO_ID),
+                ('m3u_profile_id', ChannelMetadataField.M3U_PROFILE),
+            ):
+                raw = metadata.get(field)
+                if not raw:
+                    continue
+                try:
+                    info[key] = int(raw)
+                except (TypeError, ValueError):
+                    pass
+
             stream_id_bytes = metadata.get(ChannelMetadataField.STREAM_ID)
             if stream_id_bytes:
                 try:

--- a/apps/proxy/ts_proxy/constants.py
+++ b/apps/proxy/ts_proxy/constants.py
@@ -52,6 +52,8 @@ class ChannelMetadataField:
     STREAM_ID = "stream_id"
     CHANNEL_NAME = "channel_name"
     STREAM_NAME = "stream_name"
+    IS_TIMESHIFT = "is_timeshift"
+    LOGO_ID = "logo_id"
 
     # Profile fields
     STREAM_PROFILE = "stream_profile"

--- a/apps/proxy/ts_proxy/server.py
+++ b/apps/proxy/ts_proxy/server.py
@@ -1368,6 +1368,16 @@ class ProxyServer:
                 try:
                     channel_id = key.split(':')[2]
 
+                    # Skip channel ids that don't follow Dispatcharr's UUID
+                    # convention: those are managed by features outside of
+                    # ProxyServer (e.g. timeshift catch-up sessions, which
+                    # use a `timeshift_<channel>_<ts>_<sid>` virtual id and
+                    # are owned by the WSGI request that opened them — not
+                    # by a worker heartbeat). They expire naturally via the
+                    # CLIENT_RECORD_TTL on the clients-set key.
+                    if channel_id.startswith("timeshift_"):
+                        continue
+
                     # Get metadata first
                     metadata = self.redis_client.hgetall(key)
                     if not metadata:

--- a/apps/proxy/ts_proxy/views.py
+++ b/apps/proxy/ts_proxy/views.py
@@ -572,6 +572,30 @@ def stream_xc(request, username, password, channel_id):
     if custom_properties["xc_password"] != password:
         return Response({"error": "Invalid credentials"}, status=401)
 
+    # Resolve the channel id. For channels with catch-up support
+    # xc_get_live_streams emits the provider's `stream_id` (from
+    # custom_properties) as the XC stream_id, so try that lookup first and
+    # fall back to the internal Channel.id path. The channel-profile filter
+    # below applies to whatever Channel we resolved — neither path bypasses
+    # access control.
+    from apps.channels.utils import resolve_channel_by_provider_stream_id
+    resolved_internal_id = None
+    try:
+        provider_lookup_value = str(int(channel_id))
+    except (TypeError, ValueError):
+        provider_lookup_value = None
+
+    if provider_lookup_value is not None:
+        provider_channel, _ = resolve_channel_by_provider_stream_id(provider_lookup_value)
+        if provider_channel is not None:
+            resolved_internal_id = provider_channel.id
+
+    if resolved_internal_id is None:
+        try:
+            resolved_internal_id = int(channel_id)
+        except (TypeError, ValueError):
+            return JsonResponse({"error": "Not found"}, status=404)
+
     if user.user_level < 10:
         user_profile_count = user.channel_profiles.count()
 
@@ -579,14 +603,14 @@ def stream_xc(request, username, password, channel_id):
         if user_profile_count == 0:
             # No profile filtering - user sees all channels based on user_level
             filters = {
-                "id": int(channel_id),
+                "id": resolved_internal_id,
                 "user_level__lte": user.user_level
             }
             channel = Channel.objects.filter(**filters).first()
         else:
             # User has specific limited profiles assigned
             filters = {
-                "id": int(channel_id),
+                "id": resolved_internal_id,
                 "channelprofilemembership__enabled": True,
                 "user_level__lte": user.user_level,
                 "channelprofilemembership__channel_profile__in": user.channel_profiles.all()
@@ -596,7 +620,7 @@ def stream_xc(request, username, password, channel_id):
         if not channel:
             return JsonResponse({"error": "Not found"}, status=404)
     else:
-        channel = get_object_or_404(Channel, id=channel_id)
+        channel = get_object_or_404(Channel, id=resolved_internal_id)
 
     # @TODO: we've got the  file 'type' via extension, support this when we support multiple outputs
     return stream_ts(request._request, str(channel.uuid), user)

--- a/apps/timeshift/apps.py
+++ b/apps/timeshift/apps.py
@@ -4,4 +4,4 @@ from django.apps import AppConfig
 class TimeshiftConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.timeshift"
-    verbose_name = "Timeshift (XC Catch-up)"
+    verbose_name = "Timeshift"

--- a/apps/timeshift/apps.py
+++ b/apps/timeshift/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class TimeshiftConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.timeshift"
+    verbose_name = "Timeshift (XC Catch-up)"

--- a/apps/timeshift/helpers.py
+++ b/apps/timeshift/helpers.py
@@ -1,0 +1,108 @@
+"""URL builders + timestamp conversion + archive-days probe for XC catch-up."""
+
+import logging
+from datetime import datetime, timezone as dt_timezone
+from zoneinfo import ZoneInfo
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DURATION_MINUTES = 120
+DURATION_BUFFER_MINUTES = 5
+MAX_DURATION_MINUTES = 480
+
+PROVIDER_ARCHIVE_CACHE_TTL_SECONDS = 300
+MAX_AUTO_PREV_DAYS = 30
+
+
+def compute_provider_archive_days_capped():
+    """Largest `tv_archive_duration` advertised by any XC stream (capped, cached).
+
+    Returns 0 when no XC stream advertises catch-up.
+    """
+    def _scan():
+        from apps.channels.models import Stream
+
+        max_days = 0
+        for props in (
+            Stream.objects.filter(m3u_account__account_type="XC")
+            .exclude(custom_properties__isnull=True)
+            .values_list("custom_properties", flat=True)
+        ):
+            try:
+                if not int((props or {}).get("tv_archive", 0) or 0):
+                    continue
+                value = int((props or {}).get("tv_archive_duration", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if value > max_days:
+                max_days = value
+        return min(max_days, MAX_AUTO_PREV_DAYS)
+
+    return cache.get_or_set(
+        "timeshift:provider_archive_days_capped",
+        _scan,
+        PROVIDER_ARCHIVE_CACHE_TTL_SECONDS,
+    )
+
+
+def get_programme_duration(channel, timestamp_str):
+    """Duration in minutes of the EPG programme starting at `timestamp_str`.
+
+    `timestamp_str` is `YYYY-MM-DD:HH-MM` in the provider's local time
+    (already converted by the caller). Falls back to a 120-minute default.
+    """
+    try:
+        dt = datetime.strptime(timestamp_str, "%Y-%m-%d:%H-%M")
+        if not channel.epg_data:
+            return DEFAULT_DURATION_MINUTES
+
+        programme = channel.epg_data.programs.filter(
+            start_time__lte=dt, end_time__gt=dt
+        ).first()
+        if not programme:
+            return DEFAULT_DURATION_MINUTES
+
+        duration_seconds = (programme.end_time - programme.start_time).total_seconds()
+        duration_minutes = int(duration_seconds / 60) + DURATION_BUFFER_MINUTES
+        return min(duration_minutes, MAX_DURATION_MINUTES)
+    except Exception:
+        return DEFAULT_DURATION_MINUTES
+
+
+def build_timeshift_url_format_a(m3u_account, stream_id, timestamp, duration_minutes):
+    """Format A: `/streaming/timeshift.php?username=&password=&stream=&start=&duration=`."""
+    return (
+        f"{m3u_account.server_url.rstrip('/')}/streaming/timeshift.php"
+        f"?username={m3u_account.username}"
+        f"&password={m3u_account.password}"
+        f"&stream={stream_id}"
+        f"&start={timestamp}"
+        f"&duration={duration_minutes}"
+    )
+
+
+def build_timeshift_url_format_b(m3u_account, stream_id, timestamp, duration_minutes):
+    """Format B: `/timeshift/{user}/{pass}/{duration}/{timestamp}/{stream_id}.ts`."""
+    return (
+        f"{m3u_account.server_url.rstrip('/')}/timeshift"
+        f"/{m3u_account.username}"
+        f"/{m3u_account.password}"
+        f"/{duration_minutes}"
+        f"/{timestamp}"
+        f"/{stream_id}.ts"
+    )
+
+
+def convert_timestamp_to_local(timestamp, timezone_str):
+    """Convert a UTC `YYYY-MM-DD:HH-MM` timestamp into the provider's local zone.
+
+    XC providers typically expect their own local time; clients deal in UTC.
+    """
+    try:
+        utc_time = datetime.strptime(timestamp, "%Y-%m-%d:%H-%M").replace(tzinfo=dt_timezone.utc)
+        return utc_time.astimezone(ZoneInfo(timezone_str)).strftime("%Y-%m-%d:%H-%M")
+    except Exception as e:
+        logger.error("Timeshift timestamp conversion failed for %r in %s: %s", timestamp, timezone_str, e)
+        return timestamp

--- a/apps/timeshift/views.py
+++ b/apps/timeshift/views.py
@@ -1,0 +1,479 @@
+"""XC catch-up (timeshift) HTTP view — proxies the provider's
+`/streaming/timeshift.php` endpoint to clients like iPlayTV and TiviMate.
+
+URL parameter quirk matching what iPlayTV / TiviMate emit:
+    Position "stream_id"  -> EPG channel number, IGNORED here.
+    Position "duration"   -> actually the provider's stream_id.
+"""
+
+import hmac
+import logging
+import os
+import threading
+import time
+import uuid
+
+import requests
+from django.http import (
+    Http404,
+    HttpResponseBadRequest,
+    HttpResponseForbidden,
+    StreamingHttpResponse,
+)
+
+from apps.accounts.models import User
+from apps.channels.utils import (
+    get_channel_catchup_info,
+    resolve_channel_by_provider_stream_id,
+)
+from apps.proxy.ts_proxy.config_helper import ConfigHelper
+from apps.proxy.ts_proxy.constants import ChannelMetadataField, ChannelState
+from apps.proxy.ts_proxy.redis_keys import RedisKeys
+from apps.proxy.ts_proxy.utils import get_client_ip
+from core.models import CoreSettings
+from core.utils import RedisClient
+
+from .helpers import (
+    build_timeshift_url_format_a,
+    build_timeshift_url_format_b,
+    convert_timestamp_to_local,
+    get_programme_duration,
+)
+
+logger = logging.getLogger(__name__)
+
+CLIENT_TTL_SECONDS = 60
+
+
+def timeshift_proxy(request, username, password, stream_id, timestamp, duration):
+    # The "duration" URL slot is the provider's stream_id — see module docstring.
+    provider_stream_id = duration[:-3] if duration.endswith(".ts") else duration
+
+    user = _authenticate_user(username, password)
+    if user is None:
+        return HttpResponseForbidden("Invalid credentials")
+
+    channel, _source_stream = resolve_channel_by_provider_stream_id(provider_stream_id)
+    if channel is None:
+        raise Http404("Channel not found")
+
+    if not _user_can_access_channel(user, channel):
+        return HttpResponseForbidden("Access denied")
+
+    catchup = get_channel_catchup_info(channel)
+    if catchup is None:
+        return HttpResponseBadRequest("Timeshift not supported for this channel")
+
+    catchup_stream = catchup["stream"]
+    props = catchup["props"]
+    m3u_account = catchup_stream.m3u_account
+    if m3u_account is None or m3u_account.account_type != "XC":
+        return HttpResponseBadRequest("Channel not from Xtream Codes provider")
+
+    timeshift_settings = CoreSettings.get_timeshift_settings()
+    timezone_str = timeshift_settings.get("default_timezone", "UTC")
+    debug = bool(timeshift_settings.get("debug_logging", False))
+
+    local_timestamp = convert_timestamp_to_local(timestamp, timezone_str)
+    duration_minutes = get_programme_duration(channel, local_timestamp)
+    stream_id_value = (props or {}).get("stream_id")
+    if stream_id_value is None:
+        return HttpResponseBadRequest("Cannot build timeshift URL")
+    primary_url = build_timeshift_url_format_a(m3u_account, stream_id_value, local_timestamp, duration_minutes)
+    fallback_url = build_timeshift_url_format_b(m3u_account, stream_id_value, local_timestamp, duration_minutes)
+
+    try:
+        user_agent = m3u_account.get_user_agent().user_agent
+    except AttributeError:
+        user_agent = ""
+
+    safe_ts = timestamp.replace(":", "-").replace("/", "-")
+    virtual_channel_id = f"timeshift_{channel.id}_{safe_ts}_{provider_stream_id}"
+    client_id = f"timeshift_{uuid.uuid4().hex[:16]}"
+    client_ip = get_client_ip(request)
+    range_header = request.META.get("HTTP_RANGE")
+
+    # Resolve channel logo + M3U default profile so the Stats card can render
+    # the same logo + M3U profile name as for live streams.
+    channel_logo_id = getattr(channel, "logo_id", None)
+    default_profile = m3u_account.profiles.filter(is_default=True).first()
+    m3u_profile_id = default_profile.id if default_profile is not None else None
+
+    if debug:
+        logger.info(
+            "Timeshift request: channel=%s ts=%s provider_sid=%s vid=%s client=%s range=%s",
+            channel.name,
+            local_timestamp,
+            provider_stream_id,
+            virtual_channel_id,
+            client_id,
+            range_header or "(none)",
+        )
+
+    return _stream_from_provider(
+        primary_url=primary_url,
+        fallback_url=fallback_url,
+        user_agent=user_agent,
+        range_header=range_header,
+        virtual_channel_id=virtual_channel_id,
+        client_id=client_id,
+        client_ip=client_ip,
+        user=user,
+        channel_display_name=channel.name,
+        timestamp_utc=timestamp,
+        channel_logo_id=channel_logo_id,
+        m3u_profile_id=m3u_profile_id,
+        debug=debug,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authentication, lookup, access control
+# ---------------------------------------------------------------------------
+
+
+def _authenticate_user(username, password):
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        return None
+    expected = (user.custom_properties or {}).get("xc_password")
+    if not expected:
+        return None
+    if not hmac.compare_digest(str(expected), str(password)):
+        return None
+    return user
+
+
+def _user_can_access_channel(user, channel):
+    if user.user_level < channel.user_level:
+        return False
+    if user.user_level >= User.UserLevel.ADMIN:
+        return True
+    profile_count = user.channel_profiles.count()
+    if profile_count == 0:
+        return True
+    return (
+        type(channel).objects.filter(
+            id=channel.id,
+            channelprofilemembership__enabled=True,
+            channelprofilemembership__channel_profile__in=user.channel_profiles.all(),
+        )
+        .exists()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stats integration (direct Redis writes, no ClientManager instance)
+# ---------------------------------------------------------------------------
+
+
+def _register_stats_client(
+    redis_client,
+    virtual_channel_id,
+    client_id,
+    client_ip,
+    user_agent,
+    user,
+    *,
+    channel_display_name,
+    timestamp_utc,
+    primary_url,
+    channel_logo_id=None,
+    m3u_profile_id=None,
+):
+    """Write the same Redis keys ts_proxy's ClientManager writes so the
+    catch-up viewer appears on `/stats`. `is_timeshift=1` toggles the badge."""
+    if redis_client is None:
+        return
+    client_set_key = RedisKeys.clients(virtual_channel_id)
+    client_key = f"ts_proxy:channel:{virtual_channel_id}:clients:{client_id}"
+    metadata_key = RedisKeys.channel_metadata(virtual_channel_id)
+    now = str(time.time())
+    client_payload = {
+        "user_agent": user_agent or "unknown",
+        "ip_address": client_ip,
+        "connected_at": now,
+        "last_active": now,
+        "user_id": str(user.id) if user is not None else "0",
+        "username": user.username if user is not None else "unknown",
+    }
+    metadata_payload = {
+        ChannelMetadataField.STATE: ChannelState.ACTIVE,
+        ChannelMetadataField.INIT_TIME: now,
+        ChannelMetadataField.OWNER: "timeshift",
+        ChannelMetadataField.CHANNEL_NAME: channel_display_name or "Timeshift",
+        ChannelMetadataField.STREAM_NAME: f"Catch-up @ {timestamp_utc} UTC" if timestamp_utc else "Catch-up",
+        ChannelMetadataField.URL: _redact_url(primary_url) if primary_url else "",
+        ChannelMetadataField.IS_TIMESHIFT: "1",
+    }
+    if channel_logo_id is not None:
+        metadata_payload[ChannelMetadataField.LOGO_ID] = str(channel_logo_id)
+    if m3u_profile_id is not None:
+        metadata_payload[ChannelMetadataField.M3U_PROFILE] = str(m3u_profile_id)
+    try:
+        redis_client.hset(client_key, mapping=client_payload)
+        redis_client.expire(client_key, CLIENT_TTL_SECONDS)
+        redis_client.sadd(client_set_key, client_id)
+        redis_client.expire(client_set_key, CLIENT_TTL_SECONDS)
+        redis_client.hset(metadata_key, mapping=metadata_payload)
+        redis_client.expire(metadata_key, CLIENT_TTL_SECONDS)
+    except Exception as exc:
+        logger.warning("Timeshift stats register failed: %s", exc)
+
+
+def _heartbeat_stats_client(redis_client, virtual_channel_id, client_id, bytes_delta=0):
+    if redis_client is None:
+        return
+    client_set_key = RedisKeys.clients(virtual_channel_id)
+    client_key = f"ts_proxy:channel:{virtual_channel_id}:clients:{client_id}"
+    metadata_key = RedisKeys.channel_metadata(virtual_channel_id)
+    try:
+        redis_client.hset(client_key, "last_active", str(time.time()))
+        redis_client.expire(client_key, CLIENT_TTL_SECONDS)
+        redis_client.expire(client_set_key, CLIENT_TTL_SECONDS)
+        if bytes_delta > 0:
+            redis_client.hincrby(metadata_key, ChannelMetadataField.TOTAL_BYTES, bytes_delta)
+        redis_client.expire(metadata_key, CLIENT_TTL_SECONDS)
+    except Exception:
+        pass
+
+
+def _unregister_stats_client(redis_client, virtual_channel_id, client_id):
+    if redis_client is None:
+        return
+    client_set_key = RedisKeys.clients(virtual_channel_id)
+    client_key = f"ts_proxy:channel:{virtual_channel_id}:clients:{client_id}"
+    metadata_key = RedisKeys.channel_metadata(virtual_channel_id)
+    try:
+        redis_client.srem(client_set_key, client_id)
+        redis_client.delete(client_key)
+        if (redis_client.scard(client_set_key) or 0) == 0:
+            redis_client.delete(client_set_key)
+            redis_client.delete(metadata_key)
+    except Exception as exc:
+        logger.warning("Timeshift stats unregister failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Provider streaming
+# ---------------------------------------------------------------------------
+
+
+class _UpstreamPipe:
+    """Read an upstream `requests` response in a real OS thread, write bytes
+    to an `os.pipe`. Decouples the upstream socket read from the WSGI yield
+    so the provider does not back-pressure when uWSGI is briefly slow to
+    accept a chunk. Mirrors `ts_proxy.http_streamer.HTTPStreamReader`.
+    """
+
+    def __init__(self, response, chunk_size):
+        self.response = response
+        self.chunk_size = chunk_size
+        self._stop = threading.Event()
+        self._thread = None
+        self.pipe_read_fd = None
+        self._pipe_write_fd = None
+
+    def start(self):
+        self.pipe_read_fd, self._pipe_write_fd = os.pipe()
+        self._thread = threading.Thread(target=self._produce, daemon=True)
+        self._thread.start()
+        return self.pipe_read_fd
+
+    def stop(self):
+        self._stop.set()
+        try:
+            self.response.close()
+        except Exception:
+            pass
+        try:
+            if self._pipe_write_fd is not None:
+                os.close(self._pipe_write_fd)
+                self._pipe_write_fd = None
+        except OSError:
+            pass
+
+    def _produce(self):
+        try:
+            for chunk in self.response.iter_content(chunk_size=self.chunk_size):
+                if self._stop.is_set():
+                    break
+                if not chunk:
+                    continue
+                view = memoryview(chunk)
+                while view:
+                    try:
+                        written = os.write(self._pipe_write_fd, view)
+                    except (BrokenPipeError, OSError):
+                        return
+                    view = view[written:]
+        except requests.exceptions.RequestException:
+            pass
+        except Exception:
+            logger.exception("Timeshift upstream producer failed")
+        finally:
+            try:
+                self.response.close()
+            except Exception:
+                pass
+            if self._pipe_write_fd is not None:
+                try:
+                    os.close(self._pipe_write_fd)
+                except OSError:
+                    pass
+                self._pipe_write_fd = None
+
+
+def _open_upstream(url, user_agent, range_header):
+    """Open the upstream HTTP request (status + headers known synchronously)."""
+    headers = {}
+    if user_agent:
+        headers["User-Agent"] = user_agent
+    if range_header:
+        headers["Range"] = range_header
+    return requests.get(
+        url,
+        headers=headers,
+        stream=True,
+        timeout=ConfigHelper.connection_timeout(),
+    )
+
+
+def _stream_from_provider(
+    *,
+    primary_url,
+    fallback_url,
+    user_agent,
+    range_header,
+    virtual_channel_id,
+    client_id,
+    client_ip,
+    user,
+    channel_display_name,
+    timestamp_utc,
+    channel_logo_id,
+    m3u_profile_id,
+    debug,
+):
+    # Use 64 KB chunks: amortises per-yield gevent hub overhead across more
+    # bytes than the live-path 8 KB baseline.
+    chunk_size = max(ConfigHelper.chunk_size(), 65536)
+
+    try:
+        upstream = _open_upstream(primary_url, user_agent, range_header)
+    except requests.exceptions.RequestException as exc:
+        logger.error("Timeshift provider unreachable: %s", exc)
+        return HttpResponseBadRequest("Provider connection error")
+
+    if upstream.status_code == 400 and fallback_url:
+        upstream.close()
+        try:
+            upstream = _open_upstream(fallback_url, user_agent, range_header)
+        except requests.exceptions.RequestException as exc:
+            logger.error("Timeshift fallback provider unreachable: %s", exc)
+            return HttpResponseBadRequest("Provider connection error")
+
+    if upstream.status_code not in (200, 206):
+        upstream.close()
+        logger.error("Timeshift upstream rejected: status=%s url=%s",
+                     upstream.status_code, _redact_url(primary_url))
+        return HttpResponseBadRequest(f"Provider error: {upstream.status_code}")
+
+    content_type = upstream.headers.get("Content-Type", "video/mp2t")
+    content_range = upstream.headers.get("Content-Range", "")
+    status = upstream.status_code
+
+    redis_client = RedisClient.get_client()
+    _register_stats_client(
+        redis_client,
+        virtual_channel_id,
+        client_id,
+        client_ip,
+        user_agent,
+        user,
+        channel_display_name=channel_display_name,
+        timestamp_utc=timestamp_utc,
+        primary_url=primary_url,
+        channel_logo_id=channel_logo_id,
+        m3u_profile_id=m3u_profile_id,
+    )
+
+    pipe = _UpstreamPipe(upstream, chunk_size)
+    pipe_read_fd = pipe.start()
+    pipe_reader = os.fdopen(pipe_read_fd, "rb", buffering=0)
+
+    def stream_generator():
+        last_heartbeat = time.time()
+        bytes_since_heartbeat = 0
+        total_yielded = 0
+        loop_start = time.time()
+        try:
+            while True:
+                data = pipe_reader.read(chunk_size)
+                if not data:
+                    break
+                yield data
+                bytes_since_heartbeat += len(data)
+                total_yielded += len(data)
+
+                now = time.time()
+                if now - last_heartbeat >= 5:
+                    interval = now - last_heartbeat
+                    mbps = (bytes_since_heartbeat * 8) / interval / 1_000_000 if interval > 0 else 0
+                    if debug:
+                        logger.info(
+                            "Timeshift heartbeat: vid=%s client=%s bytes=%d throughput=%.2fMbps",
+                            virtual_channel_id, client_id, bytes_since_heartbeat, mbps,
+                        )
+                    _heartbeat_stats_client(
+                        redis_client,
+                        virtual_channel_id,
+                        client_id,
+                        bytes_delta=bytes_since_heartbeat,
+                    )
+                    last_heartbeat = now
+                    bytes_since_heartbeat = 0
+        except GeneratorExit:
+            if debug:
+                logger.info(
+                    "Timeshift disconnect: vid=%s client=%s yielded=%d bytes in %.1fs",
+                    virtual_channel_id, client_id, total_yielded, time.time() - loop_start,
+                )
+        except Exception:
+            logger.exception("Timeshift stream loop error")
+        finally:
+            pipe.stop()
+            try:
+                pipe_reader.close()
+            except Exception:
+                pass
+            _unregister_stats_client(redis_client, virtual_channel_id, client_id)
+
+    response = StreamingHttpResponse(
+        stream_generator(),
+        content_type=content_type,
+        status=status,
+    )
+    # Tell nginx not to buffer this streaming response. Without this, the
+    # default uwsgi_buffering=on under `location /` throttles the response
+    # roughly to half the upstream rate (back-pressure from buffer flushes
+    # propagates back into the generator).
+    response["X-Accel-Buffering"] = "no"
+    # Forward Content-Range so iPlayTV / TiviMate seek cursor stays correct.
+    # Content-Length is intentionally NOT forwarded: chunked transfer is the
+    # safer interchange format for long-lived streaming.
+    if content_range:
+        response["Content-Range"] = content_range
+    response["Accept-Ranges"] = "bytes"
+    return response
+
+
+def _redact_url(url):
+    """Strip credentials from a URL for safe logging."""
+    if not url or "://" not in url:
+        return url
+    scheme, rest = url.split("://", 1)
+    if "@" in rest:
+        rest = rest.split("@", 1)[1]
+    return f"{scheme}://{rest.split('?')[0]}/..."

--- a/core/models.py
+++ b/core/models.py
@@ -157,6 +157,14 @@ NETWORK_ACCESS_KEY = "network_access"
 SYSTEM_SETTINGS_KEY = "system_settings"
 EPG_SETTINGS_KEY = "epg_settings"
 USER_LIMITS_SETTINGS_KEY = "user_limit_settings"
+TIMESHIFT_SETTINGS_KEY = "timeshift_settings"
+
+TIMESHIFT_DEFAULTS = {
+    "default_timezone": "UTC",
+    "default_language": "en",
+    "xmltv_prev_days_override": 0,
+    "debug_logging": False,
+}
 
 
 class CoreSettings(models.Model):
@@ -371,6 +379,22 @@ class CoreSettings(models.Model):
             "ignore_same_channel_connections": False,
             "terminate_oldest": True,
         })
+
+    # Timeshift Settings (XC catch-up)
+    @classmethod
+    def get_timeshift_settings(cls):
+        """Return all timeshift-related settings, falling back to neutral defaults."""
+        stored = cls._get_group(TIMESHIFT_SETTINGS_KEY, {}) or {}
+        merged = dict(TIMESHIFT_DEFAULTS)
+        for key, value in stored.items():
+            if key in merged and value is not None:
+                merged[key] = value
+        return merged
+
+    @classmethod
+    def update_timeshift_settings(cls, updates):
+        clean = {k: v for k, v in (updates or {}).items() if k in TIMESHIFT_DEFAULTS}
+        return cls._update_group(TIMESHIFT_SETTINGS_KEY, "Timeshift Settings", clean)
 
 
 class SystemEvent(models.Model):

--- a/dispatcharr/settings.py
+++ b/dispatcharr/settings.py
@@ -97,6 +97,7 @@ INSTALLED_APPS = [
     "django_filters",
     "django_celery_beat",
     "apps.plugins",
+    "apps.timeshift.apps.TimeshiftConfig",
 ]
 
 # EPG Processing optimization settings

--- a/dispatcharr/urls.py
+++ b/dispatcharr/urls.py
@@ -7,6 +7,7 @@ from .routing import websocket_urlpatterns
 from apps.output.views import xc_player_api, xc_panel_api, xc_get, xc_xmltv
 from apps.proxy.ts_proxy.views import stream_xc
 from apps.proxy.vod_proxy.views import stream_xc_movie, stream_xc_episode
+from apps.timeshift.views import timeshift_proxy
 
 urlpatterns = [
     # API Routes
@@ -40,6 +41,13 @@ urlpatterns = [
         "<str:username>/<str:password>/<str:channel_id>",
         stream_xc,
         name="xc_stream_endpoint",
+    ),
+    # XC catch-up (timeshift). The "duration" slot is actually the provider's
+    # stream_id — matches what iPlayTV / TiviMate emit (see apps/timeshift/views).
+    path(
+        "timeshift/<str:username>/<str:password>/<str:stream_id>/<str:timestamp>/<str:duration>",
+        timeshift_proxy,
+        name="timeshift_proxy",
     ),
     # XC VOD endpoints
     path(

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -96,4 +96,5 @@ server {
         uwsgi_send_timeout 300s;
         client_max_body_size 0;
     }
+
 }

--- a/frontend/src/components/cards/StreamConnectionCard.jsx
+++ b/frontend/src/components/cards/StreamConnectionCard.jsx
@@ -25,6 +25,7 @@ import {
   HardDriveDownload,
   HardDriveUpload,
   Radio,
+  Rewind,
   SquareX,
   Timer,
   Users,
@@ -505,7 +506,10 @@ const StreamConnectionCard = ({
   }, [channel.name, channel.stream_id]);
 
   const channelName =
-    channel.name || previewedStream?.name || 'Unnamed Channel';
+    channel.name ||
+    channel.channel_name ||
+    previewedStream?.name ||
+    'Unnamed Channel';
   const uptime = channel.uptime || 0;
   const bitrates = channel.bitrates || [];
   const totalBytes = channel.total_bytes || 0;
@@ -717,6 +721,29 @@ const StreamConnectionCard = ({
 
         {/* Add stream information badges */}
         <Group gap="xs" mt="5">
+          {channel.is_timeshift ? (
+            <Tooltip label="Catch-up (timeshift)">
+              <Badge
+                size="sm"
+                variant="light"
+                color="violet"
+                leftSection={<Rewind size={12} />}
+              >
+                TIMESHIFT
+              </Badge>
+            </Tooltip>
+          ) : (
+            <Tooltip label="Live channel">
+              <Badge
+                size="sm"
+                variant="light"
+                color="green"
+                leftSection={<Radio size={12} />}
+              >
+                LIVE
+              </Badge>
+            </Tooltip>
+          )}
           {channel.resolution && (
             <Tooltip label="Video resolution">
               <Badge size="sm" variant="light" color="red">

--- a/frontend/src/components/forms/settings/TimeshiftSettingsForm.jsx
+++ b/frontend/src/components/forms/settings/TimeshiftSettingsForm.jsx
@@ -1,0 +1,100 @@
+import useSettingsStore from '../../../store/settings.jsx';
+import React, { useEffect, useState, useMemo } from 'react';
+import {
+  getChangedSettings,
+  parseSettings,
+  saveChangedSettings,
+} from '../../../utils/pages/SettingsUtils.js';
+import { Button, NumberInput, Select, Stack, Switch, Text, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { buildTimeZoneOptions } from '../../../utils/dateTimeUtils.js';
+import {
+  getTimeshiftSettingsFormInitialValues,
+  getTimeshiftSettingsFormValidation,
+} from '../../../utils/forms/settings/TimeshiftSettingsFormUtils.js';
+
+const TimeshiftSettingsForm = React.memo(({ active }) => {
+  const settings = useSettingsStore((s) => s.settings);
+  const [saved, setSaved] = useState(false);
+
+  const form = useForm({
+    mode: 'controlled',
+    initialValues: getTimeshiftSettingsFormInitialValues(),
+    validate: getTimeshiftSettingsFormValidation(),
+  });
+
+  const tzOptions = useMemo(
+    () => buildTimeZoneOptions(form.getValues().timeshift_default_timezone || 'UTC'),
+    []
+  );
+
+  useEffect(() => {
+    if (!active) setSaved(false);
+  }, [active]);
+
+  useEffect(() => {
+    if (settings) {
+      const parsed = parseSettings(settings);
+      form.setValues({
+        timeshift_default_timezone: parsed.timeshift_default_timezone,
+        timeshift_default_language: parsed.timeshift_default_language,
+        xmltv_prev_days_override: parsed.xmltv_prev_days_override,
+        timeshift_debug_logging: parsed.timeshift_debug_logging,
+      });
+    }
+  }, [settings]);
+
+  const onSubmit = async () => {
+    setSaved(false);
+    const changed = getChangedSettings(form.getValues(), settings);
+    try {
+      await saveChangedSettings(settings, changed);
+      setSaved(true);
+    } catch (error) {
+      console.error('Error saving timeshift settings:', error);
+    }
+  };
+
+  return (
+    <form onSubmit={form.onSubmit(onSubmit)}>
+      <Stack>
+        <Text size="sm" c="dimmed">
+          XC catch-up uses these settings to convert UTC EPG timestamps into the
+          provider&apos;s local time and to set the XMLTV lookback window. The
+          defaults are neutral (UTC, en, off) — adjust to match your provider.
+        </Text>
+        <Select
+          label="Default timezone"
+          description="IANA timezone used for XC EPG strings (start/end) and provider timeshift URLs."
+          data={tzOptions}
+          searchable
+          {...form.getInputProps('timeshift_default_timezone')}
+        />
+        <TextInput
+          label="Default language"
+          description="ISO 639-1 language code (2 letters) emitted in EPG entries."
+          maxLength={2}
+          {...form.getInputProps('timeshift_default_language')}
+        />
+        <NumberInput
+          label="XMLTV prev_days override"
+          description="0 = auto-detect from provider tv_archive_duration (capped at 30). Greater than 0 forces that many days of past programmes."
+          min={0}
+          max={30}
+          step={1}
+          {...form.getInputProps('xmltv_prev_days_override')}
+        />
+        <Switch
+          label="Verbose timeshift logging"
+          description="Log catch-up request details (channel, timestamp, URL) for debugging."
+          {...form.getInputProps('timeshift_debug_logging', { type: 'checkbox' })}
+        />
+        <Button type="submit" variant="filled" mt="sm">
+          {saved ? 'Saved' : 'Save'}
+        </Button>
+      </Stack>
+    </form>
+  );
+});
+
+export default TimeshiftSettingsForm;

--- a/frontend/src/components/forms/settings/TimeshiftSettingsForm.jsx
+++ b/frontend/src/components/forms/settings/TimeshiftSettingsForm.jsx
@@ -35,11 +35,13 @@ const TimeshiftSettingsForm = React.memo(({ active }) => {
   useEffect(() => {
     if (settings) {
       const parsed = parseSettings(settings);
+      // Fall back explicitly to the neutral defaults so the Select shows
+      // "UTC (now UTC+00:00)" when no setting has been saved yet.
       form.setValues({
-        timeshift_default_timezone: parsed.timeshift_default_timezone,
-        timeshift_default_language: parsed.timeshift_default_language,
-        xmltv_prev_days_override: parsed.xmltv_prev_days_override,
-        timeshift_debug_logging: parsed.timeshift_debug_logging,
+        timeshift_default_timezone: parsed.timeshift_default_timezone || 'UTC',
+        timeshift_default_language: parsed.timeshift_default_language || 'en',
+        xmltv_prev_days_override: parsed.xmltv_prev_days_override ?? 0,
+        timeshift_debug_logging: !!parsed.timeshift_debug_logging,
       });
     }
   }, [settings]);
@@ -68,6 +70,7 @@ const TimeshiftSettingsForm = React.memo(({ active }) => {
           description="IANA timezone used for XC EPG strings (start/end) and provider timeshift URLs."
           data={tzOptions}
           searchable
+          allowDeselect={false}
           {...form.getInputProps('timeshift_default_timezone')}
         />
         <TextInput

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -45,6 +45,9 @@ const SystemSettingsForm = React.lazy(
 const NavOrderForm = React.lazy(
   () => import('../components/forms/settings/NavOrderForm.jsx')
 );
+const TimeshiftSettingsForm = React.lazy(
+  () => import('../components/forms/settings/TimeshiftSettingsForm.jsx')
+);
 
 const SettingsPage = () => {
   const authUser = useAuthStore((s) => s.user);
@@ -211,6 +214,19 @@ const SettingsPage = () => {
                     <Suspense fallback={<Loader />}>
                       <UserLimitsForm
                         active={accordianValue === 'user-limits'}
+                      />
+                    </Suspense>
+                  </ErrorBoundary>
+                </AccordionPanel>
+              </AccordionItem>
+
+              <AccordionItem value="timeshift-settings">
+                <AccordionControl>Timeshift (XC catch-up)</AccordionControl>
+                <AccordionPanel>
+                  <ErrorBoundary>
+                    <Suspense fallback={<Loader />}>
+                      <TimeshiftSettingsForm
+                        active={accordianValue === 'timeshift-settings'}
                       />
                     </Suspense>
                   </ErrorBoundary>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -221,7 +221,7 @@ const SettingsPage = () => {
               </AccordionItem>
 
               <AccordionItem value="timeshift-settings">
-                <AccordionControl>Timeshift (XC catch-up)</AccordionControl>
+                <AccordionControl>Timeshift</AccordionControl>
                 <AccordionPanel>
                   <ErrorBoundary>
                     <Suspense fallback={<Loader />}>

--- a/frontend/src/utils/dateTimeUtils.js
+++ b/frontend/src/utils/dateTimeUtils.js
@@ -266,7 +266,11 @@ const formatOffset = (minutes) => {
 };
 
 export const buildTimeZoneOptions = (preferredZone) => {
-  const zones = getSupportedTimeZones();
+  // Some browsers / runtimes return an IANA list that does not include the
+  // plain `UTC` synonym (only `Etc/UTC`), which breaks the form's default
+  // value and prevents the user from selecting UTC. Dedupe-prepend ensures
+  // UTC is always reachable.
+  const zones = Array.from(new Set(['UTC', ...getSupportedTimeZones()]));
   const referenceYear = new Date().getUTCFullYear();
   const janDate = new Date(Date.UTC(referenceYear, 0, 1, 12, 0, 0));
   const julDate = new Date(Date.UTC(referenceYear, 6, 1, 12, 0, 0));

--- a/frontend/src/utils/forms/settings/TimeshiftSettingsFormUtils.js
+++ b/frontend/src/utils/forms/settings/TimeshiftSettingsFormUtils.js
@@ -1,0 +1,17 @@
+export const getTimeshiftSettingsFormInitialValues = () => {
+  return {
+    timeshift_default_timezone: 'UTC',
+    timeshift_default_language: 'en',
+    xmltv_prev_days_override: 0,
+    timeshift_debug_logging: false,
+  };
+};
+
+export const getTimeshiftSettingsFormValidation = () => {
+  return {
+    timeshift_default_language: (value) =>
+      value && !/^[a-z]{2}$/i.test(value)
+        ? 'Must be a 2-letter ISO 639-1 code'
+        : null,
+  };
+};

--- a/frontend/src/utils/pages/SettingsUtils.js
+++ b/frontend/src/utils/pages/SettingsUtils.js
@@ -24,6 +24,7 @@ export const saveChangedSettings = async (settings, changedSettings) => {
     dvr_settings: {},
     backup_settings: {},
     system_settings: {},
+    timeshift_settings: {},
   };
 
   // Map of field prefixes to their groups
@@ -61,6 +62,12 @@ export const saveChangedSettings = async (settings, changedSettings) => {
     'schedule_cron_expression',
   ];
   const systemFields = ['time_zone', 'max_system_events'];
+  const timeshiftFields = [
+    'timeshift_default_timezone',
+    'timeshift_default_language',
+    'xmltv_prev_days_override',
+    'timeshift_debug_logging',
+  ];
 
   for (const formKey in changedSettings) {
     let value = changedSettings[formKey];
@@ -113,6 +120,7 @@ export const saveChangedSettings = async (settings, changedSettings) => {
       'retention_count',
       'schedule_day_of_week',
       'max_system_events',
+      'xmltv_prev_days_override',
     ];
     if (numericFields.includes(formKey) && value != null) {
       value = typeof value === 'number' ? value : parseInt(value, 10);
@@ -122,10 +130,21 @@ export const saveChangedSettings = async (settings, changedSettings) => {
       'comskip_enabled',
       'schedule_enabled',
       'auto_import_mapped_files',
+      'timeshift_debug_logging',
     ];
     if (booleanFields.includes(formKey) && value != null) {
       value = typeof value === 'boolean' ? value : Boolean(value);
     }
+
+    // Map UI form keys (with timeshift_ prefix) to the storage subkeys used in
+    // CoreSettings.value. The prefix lets us share form keys across groups
+    // without ambiguity but the JSON storage uses short keys.
+    const timeshiftFormKeyToStorage = {
+      timeshift_default_timezone: 'default_timezone',
+      timeshift_default_language: 'default_language',
+      xmltv_prev_days_override: 'xmltv_prev_days_override',
+      timeshift_debug_logging: 'debug_logging',
+    };
 
     // Route to appropriate group
     if (streamFields.includes(formKey)) {
@@ -138,6 +157,9 @@ export const saveChangedSettings = async (settings, changedSettings) => {
       groupedChanges.backup_settings[formKey] = value;
     } else if (systemFields.includes(formKey)) {
       groupedChanges.system_settings[formKey] = value;
+    } else if (timeshiftFields.includes(formKey)) {
+      const storageKey = timeshiftFormKeyToStorage[formKey];
+      groupedChanges.timeshift_settings[storageKey] = value;
     }
   }
 
@@ -335,6 +357,27 @@ export const parseSettings = (settings) => {
         ? systemSettings.max_system_events
         : parseInt(systemSettings.max_system_events, 10) || 100;
   }
+
+  // Timeshift settings - direct mapping with timeshift_ prefixed form keys
+  const timeshiftSettings = settings['timeshift_settings']?.value;
+  parsed.timeshift_default_timezone =
+    timeshiftSettings && timeshiftSettings.default_timezone
+      ? String(timeshiftSettings.default_timezone)
+      : 'UTC';
+  parsed.timeshift_default_language =
+    timeshiftSettings && timeshiftSettings.default_language
+      ? String(timeshiftSettings.default_language)
+      : 'en';
+  parsed.xmltv_prev_days_override =
+    timeshiftSettings && timeshiftSettings.xmltv_prev_days_override != null
+      ? typeof timeshiftSettings.xmltv_prev_days_override === 'number'
+        ? timeshiftSettings.xmltv_prev_days_override
+        : parseInt(timeshiftSettings.xmltv_prev_days_override, 10) || 0
+      : 0;
+  parsed.timeshift_debug_logging =
+    timeshiftSettings && timeshiftSettings.debug_logging != null
+      ? Boolean(timeshiftSettings.debug_logging)
+      : false;
 
   // Proxy and network access are already grouped objects
   if (settings['proxy_settings']?.value) {


### PR DESCRIPTION
## Summary

Adds a native `/timeshift/{user}/{pass}/{stream_id}/{timestamp}/{duration}.ts` endpoint that proxies Xtream Codes catch-up sessions to clients like iPlayTV (Apple TV) and TiviMate.

**Based on v0.24.0.** Single self-contained commit (re-opened after a cleanup pass that dropped ~190 lines; supersedes #1239).

## What's new

(full details in `CHANGELOG.md` under `[Unreleased]`)

- **`/timeshift/` endpoint** reuses the same `xc_password` auth as `/live/.../{id}.ts` — no new auth model.
- **`/stats` integration**: catch-up sessions appear next to live sessions with a violet `TIMESHIFT` badge.
- **`xc_get_live_streams` / `xc_get_epg`** now expose catch-up flags (`tv_archive`, `tv_archive_duration`) and emit the provider's `stream_id` **only when the channel has `tv_archive=1`** — non-catchup channels keep `stream_id = channel.id` so existing XC client favorites resolve unchanged. The dual-resolution logic in `stream_xc` handles both forms.
- **New `Settings → Timeshift` panel** with four knobs (defaults: `UTC`, `en`, `0`, off):
  - `default_timezone` (provider local time for `xc_get_epg` JSON + timeshift URL building)
  - `default_language` (XMLTV `<lang>`)
  - `xmltv_prev_days_override` (force a specific lookback window; `0` = auto-detect)
  - `debug_logging` (verbose per-request logs)
- **`/epg.xml` continues to emit UTC times** for Jellyfin / Plex / Channels DVR compatibility. The timeshift timezone setting only affects `xc_get_epg` JSON + the catch-up URL building.
- **XMLTV `prev_days` auto-detected** from the provider's largest `tv_archive_duration` (capped at 30 days), overridable via setting or `?prev_days=`.
- **Byte path uses a dedicated producer thread + `os.pipe`**, mirroring `apps/proxy/ts_proxy/http_streamer.py:HTTPStreamReader` for live streams. Throughput stays comfortably above the typical 5 Mbps FHD bitrate so clients don't buffer.

## Architecture

- **`apps/channels/utils.py`** gains two helpers used by `xc_get_live_streams`, `xc_get_epg`, `stream_xc`, and the new `timeshift_proxy` view:
  - `resolve_channel_by_provider_stream_id(provider_stream_id) → (Channel, Stream)`
  - `get_channel_catchup_info(channel) → dict | None`
- **`ChannelMetadataField`** gains `IS_TIMESHIFT`, `LOGO_ID`, `M3U_PROFILE` so the `/stats` card can render the right logo + profile + badge for both live and catch-up. (`LOGO_ID` is generally useful for live too.)
- **`ProxyServer._check_orphaned_metadata`** skips channel ids starting with `timeshift_` — those are managed by the WSGI request lifecycle, not by a worker heartbeat key.

## Test plan

- [ ] Catch-up playback in iPlayTV (Apple TV) on an XC provider — programme replays without buffering
- [ ] Catch-up playback in TiviMate — same
- [ ] Live `/live/.../{id}.ts` regression: stream_id remap is gated by `tv_archive=1`, so non-catchup XC favorites still resolve via the legacy internal-id path
- [ ] `/stats` page: catch-up viewer appears with violet `TIMESHIFT` badge, disappears within `CLIENT_RECORD_TTL` (60 s) when client disconnects
- [ ] `/epg.xml` consumed by Jellyfin / Plex / Channels DVR: programme times remain in UTC regardless of the timeshift `default_timezone` setting
- [ ] Settings → Timeshift: round-trip persistence works for all 4 fields