### PR TITLE
fix(output): prevent reflected XSS in M3U endpoint error response

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -126,7 +126,7 @@ def generate_m3u(request, profile_name=None, user=None):
     # Check if this is a POST request with data (which we don't want to allow)
     if request.method == "POST" and request.body:
         if request.body.decode() != '{}':
-            return HttpResponseForbidden("POST requests with body are not allowed, body is: {}".format(request.body.decode()))
+            return HttpResponseForbidden("POST requests with body are not allowed, body is: {}".format(html.escape(request.body.decode())), content_type="text/plain")
 
     if user is not None:
         if user.user_level < 10:


### PR DESCRIPTION
Closes #1278

## Description

The `generate_m3u` function in `apps/output/views.py` reflects the raw POST request body directly into an `HttpResponseForbidden` response. Since Django's `HttpResponseForbidden` defaults to `Content-Type: text/html`, any HTML or JavaScript in the POST body is rendered by the browser as active content. This is a reflected cross-site scripting (XSS) vulnerability (CWE-79).

The endpoint is decorated with `@csrf_exempt` and accepts POST requests via `@require_http_methods(["GET", "POST", "HEAD"])`, which means an attacker can trigger this code path without needing a CSRF token — a simple form submission from a malicious page is sufficient.

## Affected code

`apps/output/views.py`, line 129 — the error branch for non-empty POST bodies:

```python
return HttpResponseForbidden(
    "POST requests with body are not allowed, body is: {}".format(request.body.decode())
)
```

## Proof of Concept

```bash
curl -X POST http://localhost:9000/output/m3u \
  -d '<script>alert(document.cookie)</script>' \
  -v
```

The server responds with HTTP 403, `Content-Type: text/html`, and the body:

```
POST requests with body are not allowed, body is: <script>alert(document.cookie)</script>
```

The browser executes the injected script. In practice, an attacker hosts a page with a hidden form that auto-submits a POST to the victim's Dispatcharr instance, executing arbitrary JavaScript in the Dispatcharr origin context.

## Fix

This PR applies two layered mitigations on the error response:

1. **`html.escape()`** on the reflected body content, neutralizing `<`, `>`, `&`, `"`, and `'`.
2. **`content_type="text/plain"`** on the response, so the browser treats the content as plain text and never parses it as HTML.

Either mitigation alone would prevent the XSS, but both together provide defense-in-depth.

## Related Issue

Closes #1278

## How was it tested?

- Verified that after the fix, sending `<script>alert(1)</script>` as the POST body returns a `text/plain` response with the script tags escaped as `&lt;script&gt;alert(1)&lt;/script&gt;`.
- Confirmed the fix does not change behavior for legitimate requests (GET requests, POST with empty body `{}`).
- Reviewed that `import html` is already present at line 15 of the file — no new imports needed.

## Adversarial review

Before submitting, we considered whether existing protections would prevent exploitation. The `network_access_allowed` check restricts the M3U endpoint to local CIDRs by default, which limits remote exploitation. However, this is a configurable setting that administrators routinely open for external IPTV player access, and the XSS is still exploitable from within the local network. The `@csrf_exempt` decorator removes the last framework-level protection that might have mitigated a form-based attack vector. Neither Django's `SecurityMiddleware` nor any `X-Content-Type-Options` header prevents the browser from interpreting the `text/html` response body as active HTML.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed — N/A, no model changes
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema — N/A, no new endpoints
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`) — N/A, no frontend changes
- [ ] Tests are included for new functionality — this is a one-line security fix to an existing error path
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change