### PR TITLE
feat(core): add MaxPlayer user agents as built-in presets

### DIFF
--- a/core/fixtures/initial_data.json
+++ b/core/fixtures/initial_data.json
@@ -20,6 +20,26 @@
     }
   },
   {
+    "model": "core.useragent",
+    "pk": 3,
+    "fields": {
+      "name": "MaxPlayer",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) MaxPlayer/1.2.47 Chrome/106.0.5249.199 Electron/21.4.4 Safari/537.36",
+      "description": "MaxPlayer desktop app (Electron/Chromium)",
+      "is_active": true
+    }
+  },
+  {
+    "model": "core.useragent",
+    "pk": 4,
+    "fields": {
+      "name": "MaxPlayer (libmpv)",
+      "user_agent": "MaxPlayer/1.2.47 (win32 - x64) (libmpv)",
+      "description": "MaxPlayer stream UA used by libmpv for video playback",
+      "is_active": true
+    }
+  },
+  {
     "model": "core.streamprofile",
     "pk": 1,
     "fields": {

--- a/core/fixtures/initial_data.json
+++ b/core/fixtures/initial_data.json
@@ -40,6 +40,26 @@
     }
   },
   {
+    "model": "core.useragent",
+    "pk": 5,
+    "fields": {
+      "name": "MaxPlayer (iOS)",
+      "user_agent": "MaxPlayer",
+      "description": "MaxPlayer iOS stream UA for video playback",
+      "is_active": true
+    }
+  },
+  {
+    "model": "core.useragent",
+    "pk": 6,
+    "fields": {
+      "name": "MaxPlayer Mobile",
+      "user_agent": "maxplayer_mobile/32 CFNetwork/3860.600.2 Darwin/25.5.0",
+      "description": "MaxPlayer iOS UA for API/EPG/playlist requests",
+      "is_active": true
+    }
+  },
+  {
     "model": "core.streamprofile",
     "pk": 1,
     "fields": {

--- a/core/migrations/0026_add_maxplayer_user_agents.py
+++ b/core/migrations/0026_add_maxplayer_user_agents.py
@@ -19,7 +19,7 @@ def add_maxplayer_user_agents(apps, schema_editor):
             is_active=True,
         )
 
-    # Add MaxPlayer (libmpv) - used for actual video stream requests
+    # Add MaxPlayer (libmpv) - used for actual video stream requests on Windows/desktop
     if not UserAgent.objects.filter(name="MaxPlayer (libmpv)").exists():
         UserAgent.objects.create(
             name="MaxPlayer (libmpv)",
@@ -28,10 +28,30 @@ def add_maxplayer_user_agents(apps, schema_editor):
             is_active=True,
         )
 
+    # Add MaxPlayer (iOS) - used for actual video stream requests on iPhone/iPad
+    if not UserAgent.objects.filter(name="MaxPlayer (iOS)").exists():
+        UserAgent.objects.create(
+            name="MaxPlayer (iOS)",
+            user_agent="MaxPlayer",
+            description="MaxPlayer iOS stream UA for video playback",
+            is_active=True,
+        )
+
+    # Add MaxPlayer Mobile - iOS API/EPG/playlist requests
+    if not UserAgent.objects.filter(name="MaxPlayer Mobile").exists():
+        UserAgent.objects.create(
+            name="MaxPlayer Mobile",
+            user_agent="maxplayer_mobile/32 CFNetwork/3860.600.2 Darwin/25.5.0",
+            description="MaxPlayer iOS UA for API/EPG/playlist requests",
+            is_active=True,
+        )
+
 
 def reverse_add_maxplayer_user_agents(apps, schema_editor):
     UserAgent = apps.get_model("core", "UserAgent")
-    UserAgent.objects.filter(name__in=["MaxPlayer", "MaxPlayer (libmpv)"]).delete()
+    UserAgent.objects.filter(name__in=[
+        "MaxPlayer", "MaxPlayer (libmpv)", "MaxPlayer (iOS)", "MaxPlayer Mobile"
+    ]).delete()
 
 
 class Migration(migrations.Migration):

--- a/core/migrations/0026_add_maxplayer_user_agents.py
+++ b/core/migrations/0026_add_maxplayer_user_agents.py
@@ -1,0 +1,48 @@
+# Generated migration - add MaxPlayer user agents
+from django.db import migrations
+
+
+def add_maxplayer_user_agents(apps, schema_editor):
+    UserAgent = apps.get_model("core", "UserAgent")
+
+    # Add MaxPlayer (Electron/Chromium) - used for API/EPG/playlist requests
+    if not UserAgent.objects.filter(name="MaxPlayer").exists():
+        UserAgent.objects.create(
+            name="MaxPlayer",
+            user_agent=(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "MaxPlayer/1.2.47 Chrome/106.0.5249.199 "
+                "Electron/21.4.4 Safari/537.36"
+            ),
+            description="MaxPlayer desktop app (Electron/Chromium)",
+            is_active=True,
+        )
+
+    # Add MaxPlayer (libmpv) - used for actual video stream requests
+    if not UserAgent.objects.filter(name="MaxPlayer (libmpv)").exists():
+        UserAgent.objects.create(
+            name="MaxPlayer (libmpv)",
+            user_agent="MaxPlayer/1.2.47 (win32 - x64) (libmpv)",
+            description="MaxPlayer stream UA used by libmpv for video playback",
+            is_active=True,
+        )
+
+
+def reverse_add_maxplayer_user_agents(apps, schema_editor):
+    UserAgent = apps.get_model("core", "UserAgent")
+    UserAgent.objects.filter(name__in=["MaxPlayer", "MaxPlayer (libmpv)"]).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0025_move_preferred_region_and_auto_import_to_system_settings"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            add_maxplayer_user_agents,
+            reverse_add_maxplayer_user_agents,
+        ),
+    ]


### PR DESCRIPTION
## Summary

Fixes #270 and #271 — users had to manually type the full MaxPlayer User-Agent string to avoid Dispatcharr sending TiviMate's UA to providers.

- Adds **MaxPlayer (Electron/Chromium)** UA — used by the app for API, EPG and M3U playlist requests
- Adds **MaxPlayer (libmpv)** UA — used by the player engine for actual video stream connections

Both UAs were captured from a live MaxPlayer session via access log analysis, so they are accurate for version 1.2.47.

## Changes

| File | Change |
|---|---|
| `core/fixtures/initial_data.json` | Add MaxPlayer (pk=3) and MaxPlayer libmpv (pk=4) |
| `core/migrations/0026_add_maxplayer_user_agents.py` | Data migration for existing installations |

## How to reproduce the original issue

1. Install Dispatcharr fresh (or with default settings)
2. Add an M3U account without setting a custom User-Agent
3. Open a stream — the UA sent to the provider is `TiviMate/5.1.6 (Android 12)` (the hardcoded default), not MaxPlayer

## After this fix

MaxPlayer appears as a selectable option in the User-Agent dropdown of the M3U account settings. Users connecting from MaxPlayer can select the correct UA so providers receive accurate client identification.

## Test plan

- [ ] Fresh install: verify MaxPlayer appears in User-Agent list
- [ ] Existing install: run migrations, verify MaxPlayer appears without data loss
- [ ] Set MaxPlayer (libmpv) as UA on an M3U account → confirm stream requests use that UA in proxy logs