### PR TITLE
fix(output): preserve non-standard port in M3U URLs behind reverse proxy

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -3159,13 +3159,19 @@ def get_host_and_port(request):
         # Omit standard ports from URLs
         return host, None if port == standard_port else port
 
-    # 4. Check if we're behind a reverse proxy (X-Forwarded-Proto or X-Forwarded-For present)
-    # If so, assume standard port for the scheme (don't trust SERVER_PORT in this case)
-    if request.META.get("HTTP_X_FORWARDED_PROTO") or request.META.get("HTTP_X_FORWARDED_FOR"):
+    # 4. Check if we're behind a reverse proxy (X-Forwarded-Proto or X-Forwarded-For present).
+    # Still check SERVER_PORT: a non-standard port (e.g. 9191) must be preserved even behind
+    # a proxy so that generated M3U URLs remain reachable. Only skip SERVER_PORT when it
+    # matches the standard port for the scheme (80/443), which means the proxy handles TLS
+    # termination and the port can be safely omitted.
+    behind_proxy = request.META.get("HTTP_X_FORWARDED_PROTO") or request.META.get("HTTP_X_FORWARDED_FOR")
+    port = request.META.get("SERVER_PORT")
+    if behind_proxy:
+        if port and port != standard_port:
+            return host, port
         return host, None
 
     # 5. Try SERVER_PORT from META (only if NOT behind reverse proxy)
-    port = request.META.get("SERVER_PORT")
     if port:
         # Omit standard ports from URLs
         return host, None if port == standard_port else port


### PR DESCRIPTION
## Description

`get_host_and_port()` in `apps/output/views.py` has an early-exit that drops the port number whenever a reverse-proxy header (`X-Forwarded-Proto` or `X-Forwarded-For`) is present, regardless of whether the port is standard or not. When Dispatcharr runs on a non-standard port (e.g. 9191) behind nginx or Caddy, every URL in the generated M3U playlist is missing the port, causing IPTV players to connect to port 80/443 instead.

The fix reads `HTTP_SERVER_PORT` (or `SERVER_PORT`) before returning when behind a proxy, and only omits the port when it matches the standard port for the scheme (80 for http, 443 for https).

## Related Issue

Closes #1267

## How was it tested?

- Dispatcharr running on port 9191 behind nginx with `X-Forwarded-Proto: https` and `X-Forwarded-For` headers set. Before the fix: M3U URLs had no port. After the fix: URLs contain `:9191`.
- Verified that standard-port configs (80/443) still omit the port correctly.
- Verified direct access without a proxy is unaffected.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change