### PR TITLE
fix(frontend): clean up profiles state when playlists are deleted

### DIFF
--- a/frontend/src/store/__tests__/playlists.test.jsx
+++ b/frontend/src/store/__tests__/playlists.test.jsx
@@ -194,15 +194,25 @@ describe('usePlaylistsStore', () => {
     });
   });
 
-  it('should remove playlists', () => {
+  it('should remove playlists and their profiles', () => {
     const { result } = renderHook(() => usePlaylistsStore());
 
     act(() => {
-      result.current.playlists = [
-        { id: 'playlist1', name: 'Playlist 1' },
-        { id: 'playlist2', name: 'Playlist 2' },
-        { id: 'playlist3', name: 'Playlist 3' },
-      ];
+      result.current.addPlaylist({
+        id: 'playlist1',
+        name: 'Playlist 1',
+        profiles: ['profile1'],
+      });
+      result.current.addPlaylist({
+        id: 'playlist2',
+        name: 'Playlist 2',
+        profiles: ['profile2'],
+      });
+      result.current.addPlaylist({
+        id: 'playlist3',
+        name: 'Playlist 3',
+        profiles: ['profile3'],
+      });
     });
 
     act(() => {
@@ -210,8 +220,11 @@ describe('usePlaylistsStore', () => {
     });
 
     expect(result.current.playlists).toEqual([
-      { id: 'playlist2', name: 'Playlist 2' },
+      { id: 'playlist2', name: 'Playlist 2', profiles: ['profile2'] },
     ]);
+    expect(result.current.profiles).toEqual({ playlist2: ['profile2'] });
+    expect(result.current.profiles.playlist1).toBeUndefined();
+    expect(result.current.profiles.playlist3).toBeUndefined();
   });
 
   it('should set refresh progress with two parameters', () => {

--- a/frontend/src/store/playlists.jsx
+++ b/frontend/src/store/playlists.jsx
@@ -86,12 +86,16 @@ const usePlaylistsStore = create((set) => ({
     })),
 
   removePlaylists: (playlistIds) =>
-    set((state) => ({
-      playlists: state.playlists.filter(
-        (playlist) => !playlistIds.includes(playlist.id)
-      ),
-      // @TODO: remove playlist profiles here
-    })),
+    set((state) => {
+      const updatedProfiles = { ...state.profiles };
+      playlistIds.forEach((id) => delete updatedProfiles[id]);
+      return {
+        playlists: state.playlists.filter(
+          (playlist) => !playlistIds.includes(playlist.id)
+        ),
+        profiles: updatedProfiles,
+      };
+    }),
 
   setRefreshProgress: (accountIdOrData, data) =>
     set((state) => {


### PR DESCRIPTION
## Description

Deleting the last playlist (or any playlist) shows a full-screen crash:

> Something went wrong: undefined is not an object (evaluating 'P[R].name')

**Root cause:**

`removePlaylists()` in `frontend/src/store/playlists.jsx` filtered the `playlists` array but never removed the corresponding entries from the `profiles` map. The `@TODO` comment on line 93 marks the missing code that was never implemented:

```js
removePlaylists: (playlistIds) =>
  set((state) => ({
    playlists: state.playlists.filter(...),
    // @TODO: remove playlist profiles here  ← never done
  })),
```

After deletion, components reading `profiles[deletedId].name` receive `undefined` and crash.

**Fix:**

Build a copy of `profiles` with the deleted playlist IDs removed and return it in the same state update:

```js
removePlaylists: (playlistIds) =>
  set((state) => {
    const updatedProfiles = { ...state.profiles };
    playlistIds.forEach((id) => delete updatedProfiles[id]);
    return {
      playlists: state.playlists.filter(
        (playlist) => !playlistIds.includes(playlist.id)
      ),
      profiles: updatedProfiles,
    };
  }),
```

## Related Issue

Closes #1269

## How was it tested?

- [ ] Create two playlists, delete one → no error
- [ ] Delete the remaining (last) playlist → screen renders normally, no crash
- [ ] Delete multiple playlists at once → no error

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change