### PR TITLE
fix(frontend): show Clear Overrides button when override value matches provider

### DIFF
--- a/frontend/src/components/forms/Channel.jsx
+++ b/frontend/src/components/forms/Channel.jsx
@@ -52,6 +52,7 @@ import {
   getProviderHint,
   handleEpgUpdate,
   isFormFieldOverridden,
+  listOverriddenFields,
   matchChannelEpg,
   OVERRIDABLE_FIELDS,
   OVERRIDE_FIELD_LABELS,
@@ -381,11 +382,13 @@ const ChannelForm = ({ channel: channelProp = null, isOpen, onClose }) => {
   const watchedFormValues = watch();
   const overriddenFieldLabels = useMemo(() => {
     if (!channel) return [];
-    return OVERRIDABLE_FIELDS.filter((field) =>
-      isFormFieldOverridden(channel, field, watchedFormValues[field])
-    ).map((field) => OVERRIDE_FIELD_LABELS[field]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [channel, JSON.stringify(watchedFormValues)]);
+    // Use the stored override record (channel.override) to decide whether the
+    // "Clear All Overrides" button should appear, not the form-vs-provider diff.
+    // isFormFieldOverridden returns false when the override value happens to
+    // equal the current provider value, hiding the button even though the
+    // override is still stored and will block future auto-sync updates.
+    return listOverriddenFields(channel);
+  }, [channel]);
   const hasAnyOverride = overriddenFieldLabels.length > 0;
 
   const onSubmit = async (values) => {


### PR DESCRIPTION
## Description

The **Clear All Overrides** button disappears from the channel edit form when the stored override value happens to be identical to the current provider value, even though the override is still active. The yellow pencil in the channel list correctly shows the override is present, but there is no way to remove it.

**Steps to reproduce:**
1. Auto-synced channel — set group override to "apple"
2. In M3U Group Filter, set the auto-sync group override to "apple" (matching)
3. Re-open channel edit → Clear button is gone, pencil remains

**Root cause:**

`overriddenFieldLabels` was computed with `isFormFieldOverridden()`, which returns `false` when the current form value equals the provider value — regardless of what is stored in `channel.override`. When the two values coincidentally match, the function reports "no override" and the button is hidden.

`listOverriddenFields()` already exists and does the right thing: it inspects `channel.override[field]` directly and returns labels for every field that has a non-null stored override.

**Fix:**

Replace the `isFormFieldOverridden()` call in the `overriddenFieldLabels` memo with `listOverriddenFields(channel)`. The button now reflects the actual database state rather than a value comparison.

## Related Issue

Closes #1276

## How was it tested?

- [ ] Set group override to the same value as the provider group → Clear button remains visible
- [ ] Clear the override → pencil disappears, button disappears ✓
- [ ] Overriding to a different value than provider → button still appears ✓
- [ ] Channel with no overrides → button hidden ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change