### PR TITLE
fix(channels): honor per-channel stream profile override during streaming

### DIFF
--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -451,10 +451,8 @@ class Channel(models.Model):
     def effective_stream_profile_obj(self):
         return self._resolve_effective_fk("stream_profile")
 
+    # @TODO: honor stream's stream profile
     def get_stream_profile(self):
-        # Respect per-channel overrides: effective_stream_profile_obj uses
-        # _resolve_effective_fk which picks override.stream_profile when set,
-        # falling back to the channel's own stream_profile field.
         stream_profile = self.effective_stream_profile_obj
         if not stream_profile:
             stream_profile = StreamProfile.objects.get(

--- a/apps/channels/models.py
+++ b/apps/channels/models.py
@@ -451,9 +451,11 @@ class Channel(models.Model):
     def effective_stream_profile_obj(self):
         return self._resolve_effective_fk("stream_profile")
 
-    # @TODO: honor stream's stream profile
     def get_stream_profile(self):
-        stream_profile = self.stream_profile
+        # Respect per-channel overrides: effective_stream_profile_obj uses
+        # _resolve_effective_fk which picks override.stream_profile when set,
+        # falling back to the channel's own stream_profile field.
+        stream_profile = self.effective_stream_profile_obj
         if not stream_profile:
             stream_profile = StreamProfile.objects.get(
                 id=CoreSettings.get_default_stream_profile_id()


### PR DESCRIPTION
## Description

A per-channel **Stream Profile** override saved through the channel edit UI is ignored at stream time. Dispatcharr always uses the global default profile regardless, even though the yellow override indicator correctly appears in the UI.

**Root cause:**

`Channel.get_stream_profile()` reads `self.stream_profile` directly, bypassing the override system entirely. The override-aware property `effective_stream_profile_obj` already existed and called `_resolve_effective_fk('stream_profile')` — which correctly picks `override.stream_profile` when set — but the streaming code path (`url_utils.py`, `input/manager.py`, `views.py`) calls `get_stream_profile()`, not the property.

**Fix:**

One-line change in `get_stream_profile()`: replace `self.stream_profile` with `self.effective_stream_profile_obj`. All callers automatically pick up per-channel overrides without further changes.

```python
# Before
stream_profile = self.stream_profile

# After
stream_profile = self.effective_stream_profile_obj  # override-aware
```

## Related Issue

Closes #1268

## How was it tested?

- [ ] Set a custom stream profile override on a channel → stream via Xtream API → Active Streams shows the custom profile ✓
- [ ] Clear the override → stream uses global default again ✓
- [ ] Channel without any override → global default used, no regression ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change