### PR TITLE
fix(dvr): pass --threads=1 to comskip CLI to prevent SIGABRT in Docker

### DIFF
--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -3176,9 +3176,17 @@ def comskip_process_recording(recording_id: int):
     try:
         comskip_mode = CoreSettings.get_dvr_comskip_mode()
         hw_accel = CoreSettings.get_dvr_comskip_hw_accel()
+        threads = CoreSettings.get_dvr_comskip_threads()
         cmd = [comskip_bin, "--output", os.path.dirname(file_path)]
         if hw_accel != "none":
             cmd.insert(1, f"--{hw_accel}")
+        # Pass --threads on the CLI so it takes effect before ffmpeg decoder
+        # initialisation. The INI-based thread_count=0 setting is applied too
+        # late and causes SIGABRT on multi-threaded builds inside Docker.
+        # Default is 1 (safe); set comskip_threads=0 in DVR settings to let
+        # comskip auto-detect (useful on bare-metal with many cores).
+        if threads != 0:
+            cmd.append(f"--threads={threads}")
         # Prefer user-specified INI, fall back to known defaults
         ini_candidates = []
         try:

--- a/core/models.py
+++ b/core/models.py
@@ -315,6 +315,7 @@ class CoreSettings(models.Model):
             "comskip_custom_path": "",
             "comskip_mode": "cut",
             "comskip_hw_accel": "none",
+            "comskip_threads": 1,
             "pre_offset_minutes": 0,
             "post_offset_minutes": 0,
             "series_rules": [],
@@ -353,6 +354,14 @@ class CoreSettings(models.Model):
     def get_dvr_comskip_hw_accel(cls):
         hw = cls.get_dvr_settings().get("comskip_hw_accel", "none")
         return hw if hw in ("none", "cuvid", "qsv") else "none"
+
+    @classmethod
+    def get_dvr_comskip_threads(cls):
+        val = cls.get_dvr_settings().get("comskip_threads", 1)
+        try:
+            return max(0, int(val))
+        except (TypeError, ValueError):
+            return 1
 
     @classmethod
     def get_dvr_comskip_custom_path(cls):


### PR DESCRIPTION
## Description

Running comskip from the DVR UI succeeds (HTTP 200) but the Celery task fails silently. The root cause is that comskip's default `thread_count=0` (auto-detect all CPU cores) triggers SIGABRT during multi-threaded ffmpeg decoder initialisation inside the Docker container. Setting `thread_count=1` in the INI file does not help because the INI is applied after the ffmpeg init that causes the abort.

**Fix:**

Pass `--threads=<n>` on the comskip command line so it takes effect before ffmpeg initialisation. A new `comskip_threads` DVR setting (default: **1**) controls the value:

- `1` (default) — safe single-threaded mode, fixes the Docker crash
- `0` — omits the flag entirely, letting comskip auto-detect (useful on bare-metal with many cores)
- any other positive integer — passed directly to `--threads=N`

## Related Issue

Closes #1251

## How was it tested?

- [ ] Trigger "Run comskip" on a completed recording in Docker → completes without SIGABRT ✓
- [ ] Set `comskip_threads=0` in DVR settings → `--threads` flag is omitted, comskip auto-detects ✓
- [ ] Bare-metal install with `comskip_threads=4` → `--threads=4` passed to CLI ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change