### PR TITLE
fix(proxy): reconcile stale profile_connections Redis counters on startup

### DIFF
--- a/apps/proxy/live_proxy/apps.py
+++ b/apps/proxy/live_proxy/apps.py
@@ -1,5 +1,10 @@
 import sys
+import logging
+
 from django.apps import AppConfig
+
+logger = logging.getLogger(__name__)
+
 
 class LiveProxyConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
@@ -11,3 +16,69 @@ class LiveProxyConfig(AppConfig):
         if 'manage.py' not in sys.argv:
             from .server import ProxyServer
             ProxyServer.get_instance()
+            _reconcile_profile_connections()
+
+
+def _reconcile_profile_connections():
+    """
+    Reset profile_connections:* Redis counters to match the real number of
+    active channels stored in live:channel:*:metadata.
+
+    On a clean restart there are no active channels, so all counters become 0
+    and any stale values left by a previous crash are cleared.  On a live
+    reload (gunicorn SIGHUP / uWSGI chain-reload) the counters are rebuilt
+    from actual metadata, preventing false "max connections reached" errors.
+    """
+    try:
+        from core.utils import RedisClient
+        from .constants import ChannelMetadataField
+
+        redis_client = RedisClient.get_client()
+        if not redis_client:
+            return
+
+        # Count active channels per profile from the metadata hashes.
+        profile_counts: dict[str, int] = {}
+        cursor = 0
+        while True:
+            cursor, keys = redis_client.scan(
+                cursor, match="live:channel:*:metadata", count=200
+            )
+            for key in keys:
+                try:
+                    profile_id = redis_client.hget(key, ChannelMetadataField.M3U_PROFILE)
+                    if profile_id:
+                        pk = str(profile_id)
+                        profile_counts[pk] = profile_counts.get(pk, 0) + 1
+                except Exception:
+                    pass
+            if cursor == 0:
+                break
+
+        # Delete all stale profile_connections:* keys first.
+        stale_keys = []
+        cursor = 0
+        while True:
+            cursor, keys = redis_client.scan(
+                cursor, match="profile_connections:*", count=200
+            )
+            stale_keys.extend(keys)
+            if cursor == 0:
+                break
+
+        if stale_keys:
+            redis_client.delete(*stale_keys)
+
+        # Re-set counters from the actual channel counts.
+        for profile_id, count in profile_counts.items():
+            if count > 0:
+                redis_client.set(f"profile_connections:{profile_id}", count)
+
+        logger.info(
+            "profile_connections reconciled on startup: "
+            f"cleared {len(stale_keys)} stale key(s), "
+            f"rebuilt {len(profile_counts)} active profile counter(s)"
+        )
+
+    except Exception as exc:
+        logger.warning(f"profile_connections reconciliation failed (non-fatal): {exc}")


### PR DESCRIPTION
## Description

After a crash or force-kill, `profile_connections:<id>` Redis counters retain their last value. On the next start Dispatcharr sees ghost connections and rejects every new stream with:

> All active M3U profiles have reached maximum connection limits

even though no streams are running. The only workaround is to manually flush Redis or restart the container twice.

**Root cause:**

The cleanup path that decrements `profile_connections:*` only runs when a stream disconnects cleanly. A crash bypasses it entirely, leaving the counter permanently inflated until the key expires (which it never does — no TTL is set).

**Fix:**

`_reconcile_profile_connections()` added to `LiveProxyConfig.ready()`:

1. Scans `live:channel:*:metadata` to count genuinely active channels per M3U profile
2. Deletes all stale `profile_connections:*` keys
3. Re-sets each counter to the real active count

On a clean restart (no active channels) all counters become 0. On a live reload they are rebuilt from actual metadata. Failures are caught and logged as warnings so a Redis outage at startup cannot prevent the proxy from starting.

## Related Issue

Closes #1256

## How was it tested?

- [ ] Start Dispatcharr normally → log shows "profile_connections reconciled on startup" ✓
- [ ] Simulate crash while streaming → restart → new streams connect immediately without 503 ✓
- [ ] Redis unavailable at startup → warning logged, proxy starts normally ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change