### PR TITLE
fix(dvr): surface scheduled_count in recurring rule creation response

### DIFF
--- a/apps/channels/api_views.py
+++ b/apps/channels/api_views.py
@@ -3173,10 +3173,20 @@ class RecurringRecordingRuleViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         rule = serializer.save()
         try:
-            sync_recurring_rule_impl(rule.id, drop_existing=True)
+            rule._created_count = sync_recurring_rule_impl(rule.id, drop_existing=True)
         except Exception as err:
             logger.warning(f"Failed to initialize recurring rule {rule.id}: {err}")
+            rule._created_count = 0
         return rule
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        rule = self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        data = serializer.data
+        data['scheduled_count'] = getattr(rule, '_created_count', 0)
+        return Response(data, status=status.HTTP_201_CREATED, headers=headers)
 
     def perform_update(self, serializer):
         rule = serializer.save()

--- a/frontend/src/components/forms/Recording.jsx
+++ b/frontend/src/components/forms/Recording.jsx
@@ -304,7 +304,7 @@ const RecordingModal = ({
   const handleRecurringSubmit = async (values) => {
     try {
       setSubmitting(true);
-      await API.createRecurringRule({
+      const result = await API.createRecurringRule({
         channel: values.channel_id,
         days_of_week: (values.days_of_week || []).map((d) => Number(d)),
         start_time: toTimeString(values.start_time),
@@ -315,12 +315,28 @@ const RecordingModal = ({
       });
 
       await Promise.all([fetchRecurringRules(), fetchRecordings()]);
-      notifications.show({
-        title: 'Recurring rule saved',
-        message: 'Future slots will be scheduled automatically',
-        color: 'green',
-        autoClose: 2500,
-      });
+
+      const count = result?.scheduled_count ?? null;
+      if (count === 0) {
+        notifications.show({
+          title: 'Recurring rule saved',
+          message:
+            'Rule created, but no upcoming slots were found in the next 14 days. ' +
+            'Check that your selected days and date range include future dates.',
+          color: 'yellow',
+          autoClose: 6000,
+        });
+      } else {
+        notifications.show({
+          title: 'Recurring rule saved',
+          message:
+            count != null
+              ? `${count} slot${count !== 1 ? 's' : ''} scheduled`
+              : 'Future slots will be scheduled automatically',
+          color: 'green',
+          autoClose: 2500,
+        });
+      }
       handleClose();
     } catch (error) {
       console.error('Failed to create recurring rule', error);


### PR DESCRIPTION
## Description

Creating a recurring DVR rule shows HTTP 200 success but nothing appears in the DVR schedule. The UI gives no feedback about why.

**Root cause:**

`sync_recurring_rule_impl` silently returns 0 when no recording slots fall within the scheduling horizon — e.g. because:
- `start_date == end_date == today` and the selected time has already passed
- The selected days of the week don't include any dates in the rule's date range
- The rule's end_date is in the past

The API returned HTTP 201 regardless, with no count of scheduled recordings. The frontend showed a generic "Future slots will be scheduled automatically" notification and closed the modal — leaving the user with a rule that exists but no visible recordings.

**Fix:**

**Backend**: override `RecurringRecordingRuleViewSet.create()` to include `scheduled_count` (the number of recording instances generated) in the 201 response body.

**Frontend**: read `scheduled_count` from the response:
- `> 0` → green notification confirming the count (e.g. "3 slots scheduled")
- `== 0` → yellow warning: *"Rule created, but no upcoming slots were found in the next 14 days. Check that your selected days and date range include future dates."*

The rule is always saved; only the feedback changes.

## Related Issue

Closes #1277

## How was it tested?

- [ ] Create recurring rule for tomorrow → notification says "N slots scheduled" ✓
- [ ] Create rule for today with a time that has already passed → yellow warning shown ✓
- [ ] Create rule for a past date range → yellow warning shown ✓
- [ ] Update/delete an existing rule → unaffected ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change