### PR TITLE
fix(proxy): add null_ts_keepalive setting to suppress init keepalive TS packets

### DIFF
--- a/apps/proxy/live_proxy/output/ts/generator.py
+++ b/apps/proxy/live_proxy/output/ts/generator.py
@@ -169,12 +169,18 @@ class StreamGenerator:
                     yield create_ts_packet('error', "Error: Channel is stopping")
                     return False
 
-            # Send null packets to keep the connection alive during initialization.
+            # Send null TS packets to keep the connection alive during
+            # initialization. This can be disabled via the proxy setting
+            # null_ts_keepalive=False for clients (e.g. Emby) that
+            # misinterpret the null packet during codec probing and force
+            # an unwanted transcode.
             if time.time() - last_keepalive >= keepalive_interval:
-                logger.debug(f"[{self.client_id}] Sending keepalive during initialization")
-                keepalive_data = create_ts_packet('null')
-                yield keepalive_data
-                self.bytes_sent += len(keepalive_data)
+                from core.models import CoreSettings
+                if CoreSettings.get_null_ts_keepalive():
+                    logger.debug(f"[{self.client_id}] Sending keepalive during initialization")
+                    keepalive_data = create_ts_packet('null')
+                    yield keepalive_data
+                    self.bytes_sent += len(keepalive_data)
                 last_keepalive = time.time()
             else:
                 gevent.sleep(0.1)

--- a/core/models.py
+++ b/core/models.py
@@ -396,7 +396,17 @@ class CoreSettings(models.Model):
             "channel_shutdown_delay": 0,
             "channel_init_grace_period": 5,
             "new_client_behind_seconds": 5,
+            "null_ts_keepalive": True,
         })
+
+    @classmethod
+    def get_null_ts_keepalive(cls):
+        """Whether to send null TS packets while waiting for stream init.
+
+        Set to False when downstream clients (e.g. Emby) misinterpret the
+        null TS packet during codec probing and force an unwanted transcode.
+        """
+        return bool(cls.get_proxy_settings().get("null_ts_keepalive", True))
 
     # System Settings
     @classmethod


### PR DESCRIPTION
## Description

Null TS packets sent during channel initialization confuse clients that probe initial TS data for codec/format detection. Emby interprets the null packet and either forces an unwanted deinterlace transcode or fails playback entirely. The issue does not affect Streamlink profiles because they don't go through the null-packet keepalive path.

**Root cause:**

`_wait_for_initialization()` in `generator.py` sends a null TS packet every 0.5 s while waiting for the channel to become active. This was added to keep the HTTP connection alive during slow-starting streams, but null TS content is technically valid MPEG-TS and gets picked up by Emby's ffprobe during codec detection, producing incorrect stream metadata.

**Fix:**

Add `null_ts_keepalive` (default: `true`) to Proxy Settings. When set to `false`, the timer still advances (maintaining the 0.1 s sleep cadence) but no packet is yielded — the HTTP connection stays open without sending probeble TS data.

**Users experiencing the Emby deinterlace or playback issue should set `null_ts_keepalive=false` in Proxy Settings.**

## Related Issue

Closes #1280

## How was it tested?

- [ ] `null_ts_keepalive=true` (default): keepalive packets sent, existing behaviour preserved ✓
- [ ] `null_ts_keepalive=false`: no packets sent during init, Emby probes real stream data ✓
- [ ] Stream still starts correctly with keepalive disabled ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change