### PR TITLE
fix(dvr): recover from corrupt AAC frames during HLS→MKV finalization

### DIFF
--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -2503,9 +2503,13 @@ def run_recording(recording_id, channel_id, start_time_str, end_time_str):
                     _escaped = seg.replace("'", "'\\''")
                     _cl.write(f"file '{_escaped}'\n")
 
+            # Common flags that tolerate corrupt frames in the input segments.
+            _corrupt_flags = ["-fflags", "+discardcorrupt", "-err_detect", "ignore_err"]
+
             concat_result = subprocess.run(
                 [
                     "ffmpeg", "-y",
+                    *_corrupt_flags,
                     "-f", "concat", "-safe", "0",
                     "-i", concat_list_path,
                     "-c", "copy",
@@ -2522,8 +2526,7 @@ def run_recording(recording_id, channel_id, start_time_str, end_time_str):
             # MP4-intermediate fallback: some MPEG-TS streams (parameter set
             # changes mid-stream, weird PMT updates, audio discontinuities)
             # fail to mux directly into Matroska but go through an MP4
-            # container cleanly, which can then be remuxed losslessly to
-            # MKV.  Try this before declaring the recording lost.
+            # container cleanly, which can then be remuxed losslessly to MKV.
             if not _ok:
                 logger.warning(
                     f"DVR recording {recording_id}: direct HLS\u2192MKV concat failed "
@@ -2546,6 +2549,7 @@ def run_recording(recording_id, channel_id, start_time_str, end_time_str):
                 _mp4_concat = subprocess.run(
                     [
                         "ffmpeg", "-y",
+                        *_corrupt_flags,
                         "-f", "concat", "-safe", "0",
                         "-i", concat_list_path,
                         "-c", "copy",
@@ -2587,6 +2591,43 @@ def run_recording(recording_id, channel_id, start_time_str, end_time_str):
                         f"failed (rc={_mp4_concat.returncode}). stderr: "
                         f"{(_mp4_concat.stderr or '')[:300]}"
                     )
+                    # Last-resort fallback: re-encode audio to flush corrupt AAC
+                    # frames that neither stream copy nor aac_adtstoasc can handle.
+                    if not _ok:
+                        logger.warning(
+                            f"DVR recording {recording_id}: attempting audio re-encode "
+                            f"fallback to recover from corrupt AAC frames"
+                        )
+                        _reencode_result = subprocess.run(
+                            [
+                                "ffmpeg", "-y",
+                                *_corrupt_flags,
+                                "-f", "concat", "-safe", "0",
+                                "-i", concat_list_path,
+                                "-c:v", "copy",
+                                "-c:a", "aac", "-b:a", "192k",
+                                "-map", "0:v:0", "-map", "0:a:0",
+                                final_path,
+                            ],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                        )
+                        if (
+                            _reencode_result.returncode == 0
+                            and os.path.exists(final_path)
+                            and os.path.getsize(final_path) > 0
+                        ):
+                            _ok = True
+                            _fallback_used = True
+                            logger.info(
+                                f"DVR recording {recording_id}: audio re-encode "
+                                f"fallback succeeded"
+                            )
+                        else:
+                            logger.error(
+                                f"DVR recording {recording_id}: audio re-encode "
+                                f"fallback failed (rc={_reencode_result.returncode}). "
+                                f"stderr: {(_reencode_result.stderr or '')[:300]}"
+                            )
                 try:
                     if os.path.exists(_intermediate_mp4):
                         os.remove(_intermediate_mp4)


### PR DESCRIPTION
## Description

DVR recordings are silently truncated when any HLS segment contains a corrupt AAC ADTS frame. The direct HLS→MKV concat fails (rc=183), and the MP4-intermediate fallback also fails because `aac_adtstoasc` raises *"Error parsing ADTS frame header"*. No error is shown in the UI; the output MKV exists but is missing the segments after the corrupt frame.

**Fix:**

Three-tier approach:

1. **Primary path** — add `-fflags +discardcorrupt -err_detect ignore_err` so ffmpeg skips corrupt packets and continues to the end of the recording rather than aborting at the first bad frame.

2. **MP4-intermediate fallback** — same flags applied, so `aac_adtstoasc` no longer aborts on the corrupt frame.

3. **Audio re-encode fallback** — if both copy paths still fail, re-encode audio with `-c:a aac -b:a 192k` (matching the user's manual workaround). This produces a complete file at the cost of a lossy audio re-encode for the affected recording only.

Each step is logged at warning/error level so the fallback chain is visible in container logs.

## Related Issue

Closes #1225

## How was it tested?

- [ ] Recording with no corrupt frames → primary path succeeds, behaviour unchanged ✓
- [ ] Recording with corrupt AAC frame → primary path succeeds with discardcorrupt ✓
- [ ] Very corrupt stream → MP4 fallback succeeds ✓
- [ ] Worst case → audio re-encode fallback produces complete MKV ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change