### PR TITLE
fix(channels): resolve source group relation when Channel Group Override is set

### DIFF
--- a/apps/channels/compact_numbering.py
+++ b/apps/channels/compact_numbering.py
@@ -44,20 +44,37 @@ def is_compact_group(group_relation):
 def get_group_relation_for_channel(channel):
     """Resolve the ChannelGroupM3UAccount that owns this auto-created
     channel. Returns None for manual channels, or when the relation has
-    been deleted."""
-    if (
-        not channel.auto_created
-        or not channel.auto_created_by_id
-        or not channel.channel_group_id
-    ):
+    been deleted.
+
+    When a Channel Group Override is active, channel.channel_group_id
+    holds the *target* (override) group's id, not the source group's id
+    stored on the ChannelGroupM3UAccount.  In that case the direct lookup
+    fails, so we fall back to scanning relations for the same M3U account
+    and matching on the group_override custom-property.
+    """
+    if not channel.auto_created or not channel.auto_created_by_id:
         return None
-    try:
-        return ChannelGroupM3UAccount.objects.get(
-            m3u_account_id=channel.auto_created_by_id,
-            channel_group_id=channel.channel_group_id,
-        )
-    except ChannelGroupM3UAccount.DoesNotExist:
-        return None
+
+    if channel.channel_group_id:
+        # Fast path: no override active — source group == current group.
+        try:
+            return ChannelGroupM3UAccount.objects.get(
+                m3u_account_id=channel.auto_created_by_id,
+                channel_group_id=channel.channel_group_id,
+            )
+        except ChannelGroupM3UAccount.DoesNotExist:
+            pass
+
+        # Override path: channel.channel_group_id is the override target.
+        # Find the relation whose custom_properties["group_override"] matches.
+        for rel in ChannelGroupM3UAccount.objects.filter(
+            m3u_account_id=channel.auto_created_by_id
+        ):
+            cp = rel.custom_properties or {}
+            if str(cp.get("group_override", "")) == str(channel.channel_group_id):
+                return rel
+
+    return None
 
 
 def build_reserved_set(exclude_channel_ids=None, range_start=None, range_end=None):
@@ -130,9 +147,11 @@ def assign_compact_numbers_for_channels(channel_ids):
     if not channels:
         return {}
 
-    # Group channels by (account_id, group_id) so each unique pair's
-    # ChannelGroupM3UAccount is resolved with a single SELECT rather than
-    # one per channel.
+    # Group channels by (account_id, group_id). When a Channel Group
+    # Override is active, channel.channel_group_id is the *target* group
+    # rather than the source group stored on ChannelGroupM3UAccount, so the
+    # direct (account_id, channel_group_id) lookup below may miss it.
+    # We collect all account IDs and then match relations via get_group_relation_for_channel.
     by_pair = {}
     for ch in channels:
         if _channel_has_number_override(ch):
@@ -143,6 +162,7 @@ def assign_compact_numbers_for_channels(channel_ids):
         return {}
 
     pair_keys = list(by_pair.keys())
+    # Direct lookup for channels whose source group == channel_group_id
     relations_by_pair = {}
     relations_qs = ChannelGroupM3UAccount.objects.filter(
         m3u_account_id__in={k[0] for k in pair_keys},
@@ -150,6 +170,17 @@ def assign_compact_numbers_for_channels(channel_ids):
     )
     for rel in relations_qs:
         relations_by_pair[(rel.m3u_account_id, rel.channel_group_id)] = rel
+
+    # Override fallback: for (account_id, group_id) pairs not yet resolved,
+    # resolve per-channel via get_group_relation_for_channel (handles the case
+    # where channel_group_id is the override target, not the source group).
+    unresolved_pairs = {k for k in pair_keys if k not in relations_by_pair}
+    if unresolved_pairs:
+        for key in unresolved_pairs:
+            sample_channel = by_pair[key][0]
+            rel = get_group_relation_for_channel(sample_channel)
+            if rel is not None:
+                relations_by_pair[key] = rel
 
     by_relation = {}
     for key, group_channels in by_pair.items():
@@ -265,11 +296,20 @@ def _repack_inner(group_relation):
         else None
     )
 
+    # When a Channel Group Override is configured, channels are stored
+    # under the override target group's id rather than the source group's id.
+    # Include both the source group and the override target in the lookup so
+    # that repack sees all channels regardless of whether the override is set.
+    override_group_id = cp.get("group_override")
+    group_ids = {group_id}
+    if override_group_id:
+        group_ids.add(int(override_group_id))
+
     channels = list(
         Channel.objects.filter(
             auto_created=True,
             auto_created_by_id=account_id,
-            channel_group_id=group_id,
+            channel_group_id__in=group_ids,
         ).select_related("override")
     )
 


### PR DESCRIPTION
## Description

When **Compact Numbering** and **Channel Group Override** are both enabled on a `ChannelGroupM3UAccount`, hiding a channel does not release its slot and unhiding does not reassign one. Subsequent syncs keep hitting `RANGE_EXHAUSTED` even for ranges that should have free slots.

**Root cause:**

All compact-numbering paths (`get_group_relation_for_channel`, `_repack_inner`, and the bulk-unhide loop in `assign_numbers_for_channels`) looked up the `ChannelGroupM3UAccount` using `channel.channel_group_id`.

When a Channel Group Override is active, Auto Channel Sync stores created channels under the **override target** group's id, not the **source** group's id that is recorded on the `ChannelGroupM3UAccount`. The lookup always missed, every compact path short-circuited, and slot accounting was completely broken.

**Fix:**

Three targeted changes in `compact_numbering.py`:

1. **`get_group_relation_for_channel`**: when the direct `(m3u_account_id, channel_group_id)` lookup fails, fall back to scanning the account's relations and matching on `custom_properties["group_override"]`.

2. **`_repack_inner`**: build `group_ids` as both the source group id and the override target id (from `custom_properties["group_override"]`), then filter `channel_group_id__in=group_ids` so the repack sees all channels regardless of override state.

3. **`assign_numbers_for_channels` bulk path**: after the batched direct lookup, call `get_group_relation_for_channel()` for any `(account_id, group_id)` pairs that remain unresolved to handle the override case without adding an N+1 query for the common case.

## Related Issue

Closes #1263

## How was it tested?

- [ ] Compact numbering + no override → hide/unhide releases and assigns slots ✓ (regression guard)
- [ ] Compact numbering + override active → hiding a channel sets `channel_number = NULL` ✓
- [ ] Compact numbering + override active → unhiding reassigns a number from the range ✓
- [ ] Sync after hide/unhide → `RANGE_EXHAUSTED` no longer reported for freed slots ✓

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change