### PR TITLE
fix(proxy): match IPTV player HTTP headers on provider stream connections

### DIFF
--- a/apps/proxy/live_proxy/input/http_streamer.py
+++ b/apps/proxy/live_proxy/input/http_streamer.py
@@ -48,8 +48,17 @@ class HTTPStreamReader:
     def _read_stream(self):
         """Thread worker that reads HTTP stream and writes to pipe"""
         try:
-            # Build headers
-            headers = {}
+            # Build headers that closely match what a real IPTV player sends.
+            # Explicitly clear Accept-Encoding and Connection so requests does
+            # not add them — video streams are never compressed and the extra
+            # headers can reveal the client is an HTTP library rather than a
+            # native player.
+            headers = {
+                'Accept': '*/*',
+                'Accept-Language': 'en_US',
+                'Accept-Encoding': None,   # suppress requests default
+                'Connection': None,        # suppress requests default
+            }
             if self.user_agent:
                 headers['User-Agent'] = self.user_agent
 

--- a/apps/proxy/live_proxy/input/manager.py
+++ b/apps/proxy/live_proxy/input/manager.py
@@ -131,11 +131,17 @@ class StreamManager:
         """Create and configure requests session with optimal settings"""
         session = requests.Session()
 
-        # Configure session headers
+        # Configure session headers to match a native IPTV player.
+        # Suppress Accept-Encoding and Connection so requests does not add
+        # them automatically — they reveal an HTTP library and video streams
+        # are never compressed.
         session.headers.update({
             'User-Agent': self.user_agent,
-            'Connection': 'keep-alive'
+            'Accept': '*/*',
+            'Accept-Language': 'en_US',
         })
+        session.headers.pop('Accept-Encoding', None)
+        session.headers.pop('Connection', None)
 
         # Set up connection pooling for better performance
         adapter = requests.adapters.HTTPAdapter(


### PR DESCRIPTION
## Description

When Dispatcharr proxies a stream to the client, it connects to the provider's stream URL using Python's `requests` library. The library automatically adds `Accept-Encoding: gzip, deflate, br, zstd` and `Connection: keep-alive` headers that a real IPTV player (libmpv, etc.) never sends for video stream connections. These extra headers, combined with the missing `Accept-Language` header that real players do send, form a fingerprint that Cloudflare and provider-side detection can use to identify the client as an HTTP library rather than a native player.

**Fix:**

- `HTTPStreamReader._read_stream()`: set `Accept`, `Accept-Language`, and suppress `Accept-Encoding` / `Connection` via `None` values (requests honours `None` as "remove this header").
- `InputManager._create_session()`: same treatment on the session-level headers.

**Headers comparison:**

| Header | MaxPlayer (captured live) | Python requests (before) | After fix |
|---|---|---|---|
| `User-Agent` | `MaxPlayer` / `MaxPlayer (win32 - x64) (libmpv)` | configured value | configured value ✓ |
| `Accept` | `*/*` | `*/*` | `*/*` ✓ |
| `Accept-Language` | `en_US` | *(absent)* | `en_US` ✓ |
| `Accept-Encoding` | *(absent)* | `gzip, deflate, br, zstd` | *(removed)* ✓ |
| `Connection` | *(absent)* | `keep-alive` | *(removed)* ✓ |

Headers were captured from live MaxPlayer iOS and Windows sessions via Caddy access logs.

**Note on TLS fingerprinting:**

The stream connections go to `103.163.132.7:80` (plain HTTP, not HTTPS), so JA3/TLS fingerprinting does not apply to stream proxy traffic. This fix addresses the HTTP-layer header fingerprint only.

## Related Issue

<!-- No linked issue -->

## How was it tested?



## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change