### PR TITLE
fix: prevent Redis restart loop caused by uwsgi attach-daemon

### DIFF
--- a/docker/uwsgi.debug.ini
+++ b/docker/uwsgi.debug.ini
@@ -6,7 +6,7 @@
 exec-before = python /app/scripts/wait_for_redis.py
 
 ; Start Redis first
-attach-daemon = redis-server --daemonize no
+smart-attach-daemon = /tmp/redis.pid redis-server --daemonize yes --pidfile /tmp/redis.pid
 ; Default prefork worker: every queue except `dvr`.
 attach-daemon = nice -n $(CELERY_NICE_LEVEL) celery -A dispatcharr worker -Q celery -n default@%%h --autoscale=6,1
 ; DVR worker: thread pool for the long-running, I/O-bound run_recording task.

--- a/docker/uwsgi.debug.ini
+++ b/docker/uwsgi.debug.ini
@@ -6,7 +6,7 @@
 exec-before = python /app/scripts/wait_for_redis.py
 
 ; Start Redis first
-attach-daemon = redis-server
+attach-daemon = redis-server --daemonize no
 ; Default prefork worker: every queue except `dvr`.
 attach-daemon = nice -n $(CELERY_NICE_LEVEL) celery -A dispatcharr worker -Q celery -n default@%%h --autoscale=6,1
 ; DVR worker: thread pool for the long-running, I/O-bound run_recording task.

--- a/docker/uwsgi.dev.ini
+++ b/docker/uwsgi.dev.ini
@@ -8,7 +8,7 @@
 exec-pre = python /app/scripts/wait_for_redis.py
 
 ; Start Redis first
-attach-daemon = redis-server --protected-mode no
+attach-daemon = redis-server --daemonize no --protected-mode no
 ; Default prefork worker: every queue except `dvr`.
 attach-daemon = nice -n $(CELERY_NICE_LEVEL) celery -A dispatcharr worker -Q celery -n default@%%h --autoscale=6,1
 ; DVR worker: thread pool for the long-running, I/O-bound run_recording task.

--- a/docker/uwsgi.dev.ini
+++ b/docker/uwsgi.dev.ini
@@ -8,7 +8,7 @@
 exec-pre = python /app/scripts/wait_for_redis.py
 
 ; Start Redis first
-attach-daemon = redis-server --daemonize no --protected-mode no
+smart-attach-daemon = /tmp/redis.pid redis-server --daemonize yes --pidfile /tmp/redis.pid --protected-mode no
 ; Default prefork worker: every queue except `dvr`.
 attach-daemon = nice -n $(CELERY_NICE_LEVEL) celery -A dispatcharr worker -Q celery -n default@%%h --autoscale=6,1
 ; DVR worker: thread pool for the long-running, I/O-bound run_recording task.

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -8,7 +8,7 @@
 exec-pre = python /app/scripts/wait_for_redis.py
 
 ; Start Redis first
-attach-daemon = redis-server
+attach-daemon = redis-server --daemonize no
 ; Default prefork worker: every queue except `dvr`.
 attach-daemon = nice -n $(CELERY_NICE_LEVEL) celery -A dispatcharr worker -Q celery -n default@%%h --autoscale=6,1
 ; DVR worker: thread pool for the long-running, I/O-bound run_recording task.

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -8,7 +8,7 @@
 exec-pre = python /app/scripts/wait_for_redis.py
 
 ; Start Redis first
-attach-daemon = redis-server --daemonize no
+smart-attach-daemon = /tmp/redis.pid redis-server --daemonize yes --pidfile /tmp/redis.pid
 ; Default prefork worker: every queue except `dvr`.
 attach-daemon = nice -n $(CELERY_NICE_LEVEL) celery -A dispatcharr worker -Q celery -n default@%%h --autoscale=6,1
 ; DVR worker: thread pool for the long-running, I/O-bound run_recording task.


### PR DESCRIPTION
## Root cause

`redis-server` on Debian/Ubuntu automatically loads `/etc/redis/redis.conf`, which includes `daemonize yes`. When launched via `attach-daemon`, Redis forks and the parent process (tracked by uwsgi) exits. uwsgi interprets this exit as a crash and tries to respawn Redis indefinitely. Each respawn attempt finds port 6379 already bound by the forked child, producing an endless restart loop visible in logs from the very first container start:

```
[uwsgi-daemons] respawning "redis-server"
Failed listening on port 6379 (tcp), aborting.
Address already in use
[uwsgi-daemons] throttling "redis-server" for N seconds
```

Redis itself runs fine (the forked child responds to PING), but the log noise is confusing and the repeated spawns waste resources. Passing `--daemonize no` does not help because the system `/etc/redis/redis.conf` is loaded and the `daemonize yes` directive inside it takes precedence in this Redis build.

## Fix

Switch to `smart-attach-daemon` with an explicit PID file. uwsgi's `smart-attach-daemon` is specifically designed for self-daemonizing processes: it waits for the PID file to appear after launch, then monitors that PID for the daemon's lifetime. If the daemon actually crashes, uwsgi detects the missing/stale PID and restarts it correctly.

```ini
smart-attach-daemon = /tmp/redis.pid redis-server --daemonize yes --pidfile /tmp/redis.pid
```

**Before:** Redis starts successfully but uwsgi thinks it crashed (parent exits after fork) → restart loop every few seconds.

**After:** Redis daemonizes, writes PID to `/tmp/redis.pid`, uwsgi tracks the correct PID → no spurious restarts.

## Files changed

- `docker/uwsgi.ini` — production AIO
- `docker/uwsgi.debug.ini` — debug mode
- `docker/uwsgi.dev.ini` — dev mode (preserves existing `--protected-mode no`)
- `docker/uwsgi.modular.ini` — **not changed** (uses external Redis in modular mode)