### PR TITLE
migrate official plugin repo URL to GitHub Pages

### DIFF
--- a/apps/plugins/migrations/0003_update_official_repo_url.py
+++ b/apps/plugins/migrations/0003_update_official_repo_url.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+def update_url(apps, schema_editor):
+    PluginRepo = apps.get_model("plugins", "PluginRepo")
+    PluginRepo.objects.filter(is_official=True).update(
+        url="https://dispatcharr.github.io/Plugins/manifest.json"
+    )
+
+
+def revert_url(apps, schema_editor):
+    PluginRepo = apps.get_model("plugins", "PluginRepo")
+    PluginRepo.objects.filter(is_official=True).update(
+        url="https://raw.githubusercontent.com/Dispatcharr/Plugins/releases/manifest.json"
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("plugins", "0002_pluginrepo"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_url, revert_url),
+    ]

--- a/apps/plugins/models.py
+++ b/apps/plugins/models.py
@@ -36,9 +36,7 @@ class PluginConfig(models.Model):
         return f"{self.name} ({self.key})"
 
 
-OFFICIAL_REPO_URL = (
-    "https://raw.githubusercontent.com/Dispatcharr/Plugins/releases/manifest.json"
-)
+OFFICIAL_REPO_URL = "https://dispatcharr.github.io/Plugins/manifest.json"
 
 
 class PluginRepo(models.Model):


### PR DESCRIPTION
## Description

Updates the official plugin manifest URL from GitHub raw content to GitHub Pages. Adds a data migration to update existing databases in-place; fresh installs are handled by the existing seed + new migration running in sequence.

The old URL will continue to work, but this new pages URL will bypass the weird caching that github does on raw content without indication.

OLD: https://raw.githubusercontent.com/Dispatcharr/Plugins/releases/manifest.json
NEW: https://dispatcharr.github.io/Plugins/manifest.json

## How was it tested?

Ran `python manage.py migrate` on a database with the old URL present and confirmed the `PluginRepo` row updated to the new URL.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [ ] Existing tests still pass
- [ ] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [ ] I have not reformatted or refactored code outside the scope of this change
