### PR TITLE
fix(channels): add polling interval to refresh stream stats in expanded channel rows

### DIFF
--- a/frontend/src/components/tables/ChannelTableStreams.jsx
+++ b/frontend/src/components/tables/ChannelTableStreams.jsx
@@ -557,9 +557,18 @@ const ChannelStreams = ({ channel }) => {
     [patchChannelStreamStats]
   );
 
-  // Refresh once when the row is expanded.
+  // Refresh once on expand, then poll every 15 seconds while the row remains open.
+  // Pass since=null on interval ticks so we always fetch the full current stats
+  // rather than relying on a delta cursor that could miss updates.
   useEffect(() => {
     refreshStats();
+    const interval = setInterval(() => {
+      API.getChannelStreamStats(channelRef.current?.id, null).then((updates) => {
+        if (!updates || updates.length === 0) return;
+        patchChannelStreamStats(channelRef.current?.id, updates);
+      });
+    }, 15000);
+    return () => clearInterval(interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## Description

Stream stat badges (resolution, FPS, codec, audio, output bitrate) were not updating in expanded channel rows on the Channels page. For streams that had been played previously, stats would display on expand but never refresh. For streams that had never been played or were newly added to a channel, no stats were shown at all.

`ChannelTableStreams` called `refreshStats()` once on mount and never again. The drag-reorder action previously caused an incidental full re-render that happened to refresh stats as a side effect. PR #1202 (commit `17fbf1d4`) stabilized the TanStack column definitions and introduced `useRef`-based advanced stats tracking as a render performance optimization but removed that incidental trigger in the process.

The fix adds a `setInterval` that polls `API.getChannelStreamStats` with `since=null` every 15 seconds while the row is expanded, patching the store via `patchChannelStreamStats` on each tick. The interval is torn down in the `useEffect` cleanup when the row collapses so there are no lingering API calls for rows not in view. The initial on-expand fetch is preserved and still uses the delta cursor for efficiency.

The 15 second poll interval is intentionally shorter than the backend's 30 second `_bitrate_db_save_interval`. The throttle on output bitrate writes is specific to that field only — codec, resolution, FPS, and audio can update at any time (e.g. on stream failover) and should be picked up pretty much immediately. The poll is a lightweight read query and only runs while a row is actively expanded.

All render performance improvements from PR #1202 are left intact.

## Related Issue

Closes #1324 

## How was it tested?

Tested on dev build with an active stream. Expanded a channel row and confirmed stat badges update within 15 seconds without any user interaction. Confirmed the interval tears down cleanly on row collapse via browser network tab (no further requests after collapse). Confirmed drag-reorder still functions correctly.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change