### PR TITLE
Avoid resaving default M3U profile on account updates

### DIFF
--- a/apps/m3u/models.py
+++ b/apps/m3u/models.py
@@ -348,10 +348,7 @@ def create_profile_for_m3u_account(sender, instance, created, **kwargs):
             replace_pattern="$1",
         )
     else:
-        profile = M3UAccountProfile.objects.get(
+        M3UAccountProfile.objects.filter(
             m3u_account=instance,
             is_default=True,
-        )
-
-        profile.max_streams = instance.max_streams
-        profile.save()
+        ).update(max_streams=instance.max_streams)

--- a/apps/m3u/tests/test_account_profile_signals.py
+++ b/apps/m3u/tests/test_account_profile_signals.py
@@ -1,0 +1,40 @@
+from django.db.models.signals import post_save
+from django.test import TestCase
+
+from apps.m3u.models import M3UAccount, M3UAccountProfile
+
+
+class M3UAccountProfileSignalTests(TestCase):
+    def test_account_max_streams_update_does_not_resave_default_profile(self):
+        account = M3UAccount.objects.create(
+            name="KPTV FAST",
+            server_url="http://example.com/playlist.m3u",
+            max_streams=1,
+        )
+        profile = account.profiles.get(is_default=True)
+        self.assertEqual(profile.max_streams, 1)
+
+        profile_post_save_events = []
+
+        def capture_profile_save(sender, instance, created, **kwargs):
+            profile_post_save_events.append((instance.pk, created))
+
+        dispatch_uid = "test_account_max_streams_update_does_not_resave_default_profile"
+        post_save.connect(
+            capture_profile_save,
+            sender=M3UAccountProfile,
+            weak=False,
+            dispatch_uid=dispatch_uid,
+        )
+        try:
+            account.max_streams = 4
+            account.save(update_fields=["max_streams"])
+        finally:
+            post_save.disconnect(
+                sender=M3UAccountProfile,
+                dispatch_uid=dispatch_uid,
+            )
+
+        profile.refresh_from_db()
+        self.assertEqual(profile.max_streams, 4)
+        self.assertEqual(profile_post_save_events, [])


### PR DESCRIPTION
## Summary
- Avoid resaving the default `M3UAccountProfile` when an existing `M3UAccount` only needs to mirror `max_streams` into its default profile.
- Use a queryset `update()` for the default profile instead of mutating the model instance and calling `profile.save()`.
- Add a regression test proving the default profile value is updated without firing an additional `M3UAccountProfile.post_save` signal.

## Why
A KPTV-FAST M3U account refresh on a live Dispatcharr 0.26.0 instance failed after groups were enabled with:

`Field 'id' expected a number but got '62ba60f059624e000781c436'`

Applying this change as a live hotfix allowed the same account to refresh successfully and process 1170 streams. The issue appears to come from the unnecessary default-profile save fan-out during account update/refresh paths; updating the one mirrored field directly avoids re-entering profile signal work.

## Verification
- `python -m py_compile apps/m3u/models.py apps/m3u/tests/test_account_profile_signals.py`
- Live Unraid/Dispatcharr verification with the equivalent hotfix: KPTV-FAST account refresh completed successfully and output channels were generated.

Note: I could not run the new Django test locally in this checkout because this workstation only has Python 3.12 and no `uv`, while Dispatcharr now requires Python 3.13. The regression test is included so CI can exercise the exact Django signal behavior.