### PR TITLE
fix(output): honor M3UVODCategoryRelation.enabled in Xtream VOD endpoints

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -3,7 +3,7 @@ import json
 from django.urls import reverse
 from apps.channels.models import Channel, ChannelProfile, ChannelGroup, Stream
 from apps.channels.utils import format_channel_number
-from django.db.models import Prefetch
+from django.db.models import Prefetch, F
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from apps.epg.models import ProgramData
@@ -2549,7 +2549,9 @@ def xc_get_vod_categories(user):
     # All authenticated users get access to VOD from all active M3U accounts
     categories = VODCategory.objects.filter(
         category_type='movie',
-        m3umovierelation__m3u_account__is_active=True
+        m3umovierelation__m3u_account__is_active=True,
+        m3u_relations__enabled=True,
+        m3u_relations__m3u_account__is_active=True,
     ).distinct().order_by(Lower("name"))
 
     for category in categories:
@@ -2574,6 +2576,10 @@ def xc_get_vod_streams(request, user, category_id=None):
     base_qs = (
         M3UMovieRelation.objects
         .filter(**rel_filters)
+        .filter(
+            category__m3u_relations__enabled=True,
+            category__m3u_relations__m3u_account=F('m3u_account'),
+        )
         .select_related('movie', 'movie__logo', 'category')
     )
 
@@ -2654,7 +2660,9 @@ def xc_get_series_categories(user):
     # All authenticated users get access to series from all active M3U accounts
     categories = VODCategory.objects.filter(
         category_type='series',
-        m3useriesrelation__m3u_account__is_active=True
+        m3useriesrelation__m3u_account__is_active=True,
+        m3u_relations__enabled=True,
+        m3u_relations__m3u_account__is_active=True,
     ).distinct().order_by(Lower("name"))
 
     for category in categories:
@@ -2679,6 +2687,10 @@ def xc_get_series(request, user, category_id=None):
     base_qs = (
         M3USeriesRelation.objects
         .filter(**rel_filters)
+        .filter(
+            category__m3u_relations__enabled=True,
+            category__m3u_relations__m3u_account=F('m3u_account'),
+        )
         .select_related('series', 'series__logo', 'category')
     )
 


### PR DESCRIPTION
## Description

The four Xtream VOD endpoints in `apps/output/views.py`
(`xc_get_vod_categories`, `xc_get_vod_streams`, `xc_get_series_categories`,
`xc_get_series`) filtered only on `m3u_account__is_active=True` and never
read `M3UVODCategoryRelation.enabled`. The model's `help_text` says the
flag is meant to deactivate the category for the M3U account, and the UI
in v0.22.0 lets users toggle it, but the API silently kept returning
disabled categories and their streams.

This PR adds the missing filters: `m3u_relations__enabled=True` on the two
category queries, plus a correlated `category__m3u_relations__enabled=True`
\+ `category__m3u_relations__m3u_account=F('m3u_account')` on the two stream
queries. The `F()` correlation matters when more than one account syncs
the same `VODCategory` row — a stream is only included when *its own*
account has the category enabled, so disabling on account A doesn't hide
A's streams while leaking B's, or vice versa.

Total diff: **+15 / -3 in one file** (including the `F` import). No
migration, no schema change, no new fields. The existing `.distinct()`
on the category queries prevents row multiplication when multiple
enabled relations join.

## Related Issue

Closes #1339

## How was it tested?

Tested locally on a v0.26.0 install against one XC M3U account with 159
movie categories + 68 series categories synced from the provider.

1. Disabled 121 movie + 64 series relations via direct ORM update —
   mirrors what the UI does when the user unchecks the boxes.
2. Confirmed the un-patched container still returned **all 158 / 67**
   categories and ~150k / 47k streams from the four endpoints,
   demonstrating the flag was being ignored (not just that nothing was
   disabled).
3. Loaded the patched `views.py` (single-file bind-mount, container
   recreated). Re-queried all four endpoints:

   | Endpoint | Before | After |
   |---|---:|---:|
   | `get_vod_categories`    | 158     | 38     |
   | `get_series_categories` | 67      | 4      |
   | `get_vod_streams`       | 149,837 | 32,409 |
   | `get_series`            | 47,121  | 15,020 |

4. Spot-checked the post-patch `get_vod_streams` response: no
   `category_id` from the disabled set appears, and re-enabling a category
   makes it (and its streams) return on the next request — no caching
   surprises.
5. **Client-verified end-to-end on TiViMate** (Xtream login): refreshed
   the playlist on the device, only the 38 movie + 4 series categories
   appear, movies and series stream normally from them. No client-side
   cache quirks needed manual intervention.
6. **Smoke-tested Emby** on the same install. Emby's Live TV / VOD
   here uses Dispatcharr's plain `/output/m3u` + `/output/epg` endpoints
   (not the Xtream VOD endpoints this PR touches), so it doesn't
   exercise the patched code path — but worth confirming the change
   doesn't regress unrelated consumers: Emby continued to work
   identically after the recreate.

Tested only the "all authenticated users" branch in `xc_get_vod_streams`
/ `xc_get_series`. The explicit VOD-permission branch wasn't exercised on
my install; a maintainer with that path configured should sanity-check it
behaves the same (the filter is added to `base_qs` so it applies in both
branches — but verifying empirically would be reassuring).

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed *(n/a — no model changes)*
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema *(n/a — no new endpoints)*
- [x] Frontend: ESLint and Prettier pass cleanly *(n/a — backend-only change)*
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

**On the unchecked test item:** I didn't add a test for this. The fix
restores a contract that the model docstring already promises, and the
ideal test is an integration test that hits the four Xtream views against
a fixture with mixed `enabled` flags. I didn't find an existing test
scaffold under `apps/output/` to follow — if you want me to add one,
point me at a pattern you'd prefer (or to the right test module to extend)
and I'll fold it into this PR.