### PR TITLE
fix(channels): account for group_override in the auto-sync range-conflict check

### DIFF
--- a/apps/m3u/tests/test_sync_correctness.py
+++ b/apps/m3u/tests/test_sync_correctness.py
@@ -644,6 +644,34 @@ class NumbersInRangeLookupTests(TestCase):
         )
         self.assertFalse(occupant["has_channel_number_override"])
 
+    def test_group_override_channel_reports_target_group(self):
+        # When auto-sync routes channels into a different group via
+        # group_override, the occupant's channel_group_id is the override
+        # target, not the source group being configured. The frontend relies
+        # on this to recognize override-routed channels as the config's own
+        # output (effectiveSyncGroupId), so the warning does not flag them.
+        account = _make_account()
+        source = _make_group(name="SourceGrp")
+        target = _make_group(name="TargetGrp")
+        Channel.objects.create(
+            name="Routed",
+            channel_number=3210,
+            channel_group=target,
+            auto_created=True,
+            auto_created_by=account,
+        )
+        client = self._client()
+
+        response = client.get(
+            "/api/channels/channels/numbers-in-range/?start=3210&end=3210"
+        )
+
+        occupant = response.data["occupants"][0]
+        self.assertEqual(occupant["channel_group_id"], target.id)
+        self.assertNotEqual(occupant["channel_group_id"], source.id)
+        self.assertTrue(occupant["auto_created"])
+        self.assertEqual(occupant["auto_created_by_account_id"], account.id)
+
     def test_manual_channel_exposed_with_auto_created_false(self):
         # Manual channels are always a real collision worth surfacing.
         # The response must flag them with auto_created=False and a null

--- a/frontend/src/components/forms/LiveGroupFilter.jsx
+++ b/frontend/src/components/forms/LiveGroupFilter.jsx
@@ -34,6 +34,7 @@ import {
   getRegexOptions,
   getStreamsRegexPreview,
   isExpectedOccupantForGroup,
+  effectiveSyncGroupId,
   isGroupVisible,
   rangeFor,
 } from '../../utils/forms/LiveGroupFilterUtils.js';
@@ -131,7 +132,12 @@ const LiveGroupFilter = ({
   // (in-memory range overlap with sibling groups) sources so the sweep
   // can refresh form-overlap synchronously without firing HTTP for
   // groups that did not change.
-  const scheduleConflictScan = (groupId, rawStart, rawEnd) => {
+  const scheduleConflictScan = (
+    groupId,
+    rawStart,
+    rawEnd,
+    expectedGroupId = groupId
+  ) => {
     if (conflictTimersRef.current[groupId]) {
       clearTimeout(conflictTimersRef.current[groupId]);
     }
@@ -156,7 +162,7 @@ const LiveGroupFilter = ({
           ? result.occupants
           : [];
         const unexpected = occupants.filter(
-          (o) => !isExpectedOccupantForGroup(o, groupId, playlist)
+          (o) => !isExpectedOccupantForGroup(o, expectedGroupId, playlist)
         );
         setConflictSource(groupId, 'occupant', unexpected.length > 0);
       } catch (e) {
@@ -221,7 +227,8 @@ const LiveGroupFilter = ({
         scheduleConflictScan(
           g.channel_group,
           range.startRaw,
-          g.auto_sync_channel_end
+          g.auto_sync_channel_end,
+          effectiveSyncGroupId(g)
         );
       }
     }

--- a/frontend/src/utils/forms/LiveGroupFilterUtils.js
+++ b/frontend/src/utils/forms/LiveGroupFilterUtils.js
@@ -57,6 +57,18 @@ export const isExpectedOccupantForGroup = (
   );
 };
 
+// The group the sync's own channels actually land in. A group_override
+// routes auto-created channels into a different ChannelGroup, so the
+// conflict check must recognize occupants of that target group as this
+// config's own output rather than flagging them against the source group.
+export const effectiveSyncGroupId = (group) => {
+  const override = group?.custom_properties?.group_override;
+  if (override !== undefined && override !== null && override !== '') {
+    return Number(override);
+  }
+  return group?.channel_group;
+};
+
 export const rangeFor = (g) => {
   if (!g.enabled || !g.auto_channel_sync) return null;
   const mode = g.custom_properties?.channel_numbering_mode || 'fixed';

--- a/frontend/src/utils/forms/__tests__/LiveGroupFilterUtils.test.js
+++ b/frontend/src/utils/forms/__tests__/LiveGroupFilterUtils.test.js
@@ -4,6 +4,7 @@ import {
   getChannelsInRange,
   getStreamsRegexPreview,
   isExpectedOccupantForGroup,
+  effectiveSyncGroupId,
   rangeFor,
   abortTimers,
   getRegexOptions,
@@ -224,6 +225,116 @@ describe('LiveGroupFilterUtils', () => {
       expect(isExpectedOccupantForGroup(occupant, 1, makePlaylist())).toBe(
         true
       );
+    });
+  });
+
+  // ── effectiveSyncGroupId ───────────────────────────────────────────────────
+  describe('effectiveSyncGroupId', () => {
+    it('returns the source channel_group when there is no override', () => {
+      expect(effectiveSyncGroupId(makeGroup({ channel_group: 7 }))).toBe(7);
+    });
+
+    it('returns the group_override target when set', () => {
+      const group = makeGroup({
+        channel_group: 7,
+        custom_properties: { group_override: 9 },
+      });
+      expect(effectiveSyncGroupId(group)).toBe(9);
+    });
+
+    it('coerces a string-stored group_override to a number', () => {
+      const group = makeGroup({
+        channel_group: 7,
+        custom_properties: { group_override: '9' },
+      });
+      expect(effectiveSyncGroupId(group)).toBe(9);
+    });
+
+    it('falls back to the source group when group_override is blank', () => {
+      const group = makeGroup({
+        channel_group: 7,
+        custom_properties: { group_override: '' },
+      });
+      expect(effectiveSyncGroupId(group)).toBe(7);
+    });
+
+    // Regression guard for the group-override range-conflict false positive:
+    // the auto-sync's own channels land in the override target group, so
+    // comparing against the source group (pre-fix) flags them as a conflict,
+    // while comparing against the effective target recognizes them as this
+    // config's own output.
+    it("makes group-override occupants count as this group's own", () => {
+      const group = makeGroup({
+        channel_group: 7,
+        custom_properties: { group_override: 9 },
+      });
+      const occupant = makeOccupant({ channel_group_id: 9 });
+      // Pre-fix comparison (source group) treats own channels as a conflict.
+      expect(
+        isExpectedOccupantForGroup(
+          occupant,
+          group.channel_group,
+          makePlaylist()
+        )
+      ).toBe(false);
+      // Comparing against the effective target recognizes them as expected.
+      expect(
+        isExpectedOccupantForGroup(
+          occupant,
+          effectiveSyncGroupId(group),
+          makePlaylist()
+        )
+      ).toBe(true);
+    });
+
+    // Guards against over-suppression: resolving the effective target group
+    // must still surface genuine collisions in an override config's range.
+    // Only the config's own output (auto-created, this account, in the
+    // target group, unpinned) is excluded.
+    it('still flags genuine collisions in a group-override config', () => {
+      const group = makeGroup({
+        channel_group: 7,
+        custom_properties: { group_override: 9 },
+      });
+      const target = effectiveSyncGroupId(group);
+      // Manual channel sitting in the range.
+      expect(
+        isExpectedOccupantForGroup(
+          makeOccupant({ channel_group_id: 9, auto_created: false }),
+          target,
+          makePlaylist()
+        )
+      ).toBe(false);
+      // Auto-created by a different account.
+      expect(
+        isExpectedOccupantForGroup(
+          makeOccupant({
+            channel_group_id: 9,
+            auto_created_by_account_id: 999,
+          }),
+          target,
+          makePlaylist()
+        )
+      ).toBe(false);
+      // A channel in a different group than the override target.
+      expect(
+        isExpectedOccupantForGroup(
+          makeOccupant({ channel_group_id: 123 }),
+          target,
+          makePlaylist()
+        )
+      ).toBe(false);
+      // A user-pinned channel number.
+      expect(
+        isExpectedOccupantForGroup(
+          makeOccupant({
+            channel_group_id: 9,
+            has_channel_number_override: true,
+          }),
+          target,
+          makePlaylist()
+        )
+      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description

The Auto Channel Sync "Range conflict" warning on the M3U group settings falsely fired on a group's own auto-sync channels when the group used a channel-group override.

The warning scans for channels already occupying the configured number range and classifies each as either this config's own auto-sync output or a real conflict. That classification compared each occupant's channel group against the source group being configured. When a group sets a `group_override`, auto-sync creates its channels in the override target group, so those channels did not match the source group and were misclassified as a conflict, even though they are the expected output of the very config being edited.

This change resolves the effective target group for the comparison: the override target when `group_override` is set, otherwise the source group. The config's own output is then recognized and no longer triggers the warning. The warning is not suppressed for override groups - the check is simply performed against the group the channels actually land in, so genuine conflicts (manual channels, channels from another account, channels in a different group, or user-pinned numbers) within the range still surface. The backend `numbers-in-range` endpoint already reported the channel's actual group, so the change is limited to the frontend classification.

No model changes, no migration, and no new endpoints.

## Related Issue

Closes #1331


## How was it tested?

Reproduced first: with a group override configured, the auto-sync's own channels in the configured range were classified as a conflict, while the same setup without an override classified them correctly.

Added tests:
- Frontend unit tests for the new effective-group resolver: it returns the source group with no override, the override target when set (coercing a string-stored value), and falls back to the source group when the override is blank. A regression guard confirms an occupant in the override target group is recognized as the config's own output rather than a conflict.
- An over-suppression guard confirms that, even with a group override, a manual channel, a channel from another account, a channel in a different group, or a user-pinned number in the range is still flagged as a conflict.
- A backend test asserting the numbers-in-range endpoint reports the override target group for an override-routed auto-created channel, locking the contract the frontend classification relies on.

The existing range-lookup and group-settings test suites continue to pass.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
