### PR TITLE
Allow underscores in non-FQDN hostnames

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -613,7 +613,7 @@ def validate_flexible_url(value):
         # Matches: http://hostname, https://hostname/, http://hostname:port/path/to/file.xml, rtp://192.168.2.1,  rtsp://192.168.178.1, udp://239.0.0.1:1234
         # Also matches FQDNs for rtsp/rtp/udp protocols: rtsp://FQDN/path?query=value
         # Also supports authentication: rtsp://user:pass@hostname/path
-        non_fqdn_pattern = r'^(rts?p|https?|udp)://([a-zA-Z0-9_\-\.]+:[^\s@]+@)?([a-zA-Z0-9]([a-zA-Z0-9\-\.]{0,61}[a-zA-Z0-9])?|[0-9.]+)?(\:[0-9]+)?(/[^\s]*)?$'
+        non_fqdn_pattern = r'^(rts?p|https?|udp)://([a-zA-Z0-9_\-\.]+:[^\s@]+@)?([a-zA-Z0-9]([a-zA-Z0-9_\-\.]{0,61}[a-zA-Z0-9])?|[0-9.]+)?(\:[0-9]+)?(/[^\s]*)?$'
         non_fqdn_match = re.match(non_fqdn_pattern, value)
 
         if non_fqdn_match:


### PR DESCRIPTION
## Description
This PR updates the non_fqdn_pattern regex to allow underscores in non-FQDN hostnames. Such hostnames are commonly used in Docker networks, but Dispatcharr currently rejects them due to the overly strict regex.

## How was it tested?
Knowing enough regex to have it also accept underscores in non-FQDN hostnames.

## Checklist
- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change