### PR TITLE
fix: limit EPGSource fields in XMLTV export prefetch

### DIFF
--- a/apps/output/epg.py
+++ b/apps/output/epg.py
@@ -19,7 +19,7 @@ from django.utils import timezone as django_timezone
 
 from apps.channels.models import Channel, ChannelProfile, Stream
 from apps.channels.utils import format_channel_number
-from apps.epg.models import ProgramData
+from apps.epg.models import ProgramData, EPGSource
 from apps.output.streaming_chunk_cache import stream_cached_response
 from core.utils import build_absolute_uri_with_port, log_system_event
 
@@ -1170,7 +1170,9 @@ def generate_epg(request, profile_name=None, user=None):
             .exclude(hidden_from_output=True)
             .order_by("effective_channel_number")
             .prefetch_related(
-                Prefetch('streams', queryset=Stream.objects.only('id', 'name').order_by('channelstream__order'))
+                Prefetch('streams', queryset=Stream.objects.only('id', 'name').order_by('channelstream__order')),
+                Prefetch('epg_data__epg_source', queryset=EPGSource.objects.only('id', 'source_type', 'custom_properties')),
+                Prefetch('override__epg_data__epg_source', queryset=EPGSource.objects.only('id', 'source_type', 'custom_properties')),
             )
         )
         channel_count = len(channels)


### PR DESCRIPTION
## Description

This narrows the `EPGSource` prefetch used during XMLTV export so the export path only loads the fields it actually reads: `id`, `source_type`, and `custom_properties`.

The main goal is memory reduction. `EPGSource.programme_index` is a large JSON field, and pulling it into the `epg_data__epg_source` / `override__epg_data__epg_source` prefetches creates unnecessary memory pressure when exporting large channel sets. Limiting the prefetched fields avoids carrying that payload through the export loop while keeping the existing behavior intact.

In a large-library XMLTV export scenario, the pre-change path could OOM even on a 32 GB host because `programme_index` was being prefetched unnecessarily. After this change, export-related memory pressure stays below 1 GB in the same scenario.

## Related Issue

None linked. This appears to fit the contributing guide's small, obvious bug-fix exception rather than a new feature or non-trivial product change.

## How was it tested?

- Reproduced the relevant export-path queryset change locally in the repo checkout
- Confirmed the diff is scoped to the XMLTV export prefetch logic only
- Ran the backend test suite in the repo's dev container:
  - `python manage.py test`
- Ran the frontend test suite locally:
  - `cd frontend && npm test`
- Observed the large-library XMLTV export scenario go from OOM on a 32 GB host before the change to staying under 1 GB of export-related memory pressure after the change

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed *(not applicable — no model changes)*
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema *(not applicable — no API changes)*
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`) *(not applicable — no frontend changes)*
- [x] Tests are included for new functionality *(not applicable — no new functionality, targeted query optimization only)*
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
