### PR TITLE
Node25+ Test Compatibility

### DIFF
--- a/frontend/src/test/setupTests.js
+++ b/frontend/src/test/setupTests.js
@@ -32,33 +32,41 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
   window.ResizeObserver = ResizeObserver;
 }
 
-if (
-  typeof window !== 'undefined' &&
-  typeof window.localStorage?.clear !== 'function'
-) {
-  let store = {};
-  const storage = {
-    getItem: (key) => store[key] ?? null,
-    setItem: (key, value) => {
-      store[key] = String(value);
-    },
-    removeItem: (key) => {
-      delete store[key];
-    },
-    clear: () => {
-      store = {};
-    },
-    get length() {
-      return Object.keys(store).length;
-    },
-    key: (i) => Object.keys(store)[i] ?? null,
-  };
-  Object.defineProperty(window, 'localStorage', {
-    configurable: true,
-    enumerable: true,
-    writable: true,
-    value: storage,
-  });
+// Node 25+ exposes a broken native localStorage stub on globalThis (missing
+// Storage methods) that shadows jsdom's implementation.
+if (typeof window !== 'undefined') {
+  const brokenTargets = [globalThis, window].filter(
+    (target) => typeof target?.localStorage?.getItem !== 'function'
+  );
+
+  if (brokenTargets.length > 0) {
+    let store = {};
+    const storage = {
+      getItem: (key) => store[key] ?? null,
+      setItem: (key, value) => {
+        store[key] = String(value);
+      },
+      removeItem: (key) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+      get length() {
+        return Object.keys(store).length;
+      },
+      key: (i) => Object.keys(store)[i] ?? null,
+    };
+
+    for (const target of brokenTargets) {
+      Object.defineProperty(target, 'localStorage', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: storage,
+      });
+    }
+  }
 }
 
 if (typeof window !== 'undefined') {

--- a/frontend/src/test/setupTests.js
+++ b/frontend/src/test/setupTests.js
@@ -32,6 +32,35 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
   window.ResizeObserver = ResizeObserver;
 }
 
+if (
+  typeof window !== 'undefined' &&
+  typeof window.localStorage?.clear !== 'function'
+) {
+  let store = {};
+  const storage = {
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, value) => {
+      store[key] = String(value);
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (i) => Object.keys(store)[i] ?? null,
+  };
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: storage,
+  });
+}
+
 if (typeof window !== 'undefined') {
   if (!window.requestAnimationFrame) {
     window.requestAnimationFrame = (cb) => setTimeout(cb, 16);


### PR DESCRIPTION
## Description

Updated the test setup file to ensure that localStorage is always a usable property.

Ensures frontend test compatibility with newer Node versions accessing localStorage.

Before:
Tests may fail when localStorage is not fully initialized. 
`TypeError: localStorage.clear is not a function` e.g. frontend/src/utils/components/__tests__/FloatingVideoUtils.test.js:389:35

After:
Tests pass successfully

## Related Issue

NA

## How was it tested?

Ran `vitest --run` with Node versions 24, 25, 26

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
