### PR TITLE
Show currently-airing EPG title on each stream row

### DIFF
--- a/apps/channels/serializers.py
+++ b/apps/channels/serializers.py
@@ -17,7 +17,7 @@ from .models import (
 )
 from apps.epg.serializers import EPGDataSerializer
 from core.models import StreamProfile
-from apps.epg.models import EPGData
+from apps.epg.models import EPGData, ProgramData
 from django.db import connection, transaction
 from django.urls import reverse
 from rest_framework import serializers
@@ -117,6 +117,14 @@ class StreamSerializer(serializers.ModelSerializer):
         allow_null=True,
         required=False,
     )
+    # Currently-airing EPG programme title for this stream's tvg_id, if any.
+    # Lets a generically-named stream (a common PPV/event-slot pattern some
+    # providers use) show what's actually on it right now without having to
+    # rename anything. Resolved from context["_epg_now_cache"] when the caller
+    # batched the lookup (see ChannelSerializer.get_streams); falls back to a
+    # single-stream query so StreamSerializer stays correct when used on its
+    # own (e.g. the streams list view).
+    epg_now_title = serializers.SerializerMethodField()
     read_only_fields = ["is_custom", "m3u_account", "stream_hash", "stream_id", "stream_chno"]
 
     class Meta:
@@ -144,7 +152,23 @@ class StreamSerializer(serializers.ModelSerializer):
             "stream_chno",
             "is_catchup",
             "catchup_days",
+            "epg_now_title",
         ]
+
+    def get_epg_now_title(self, obj):
+        if not obj.tvg_id:
+            return None
+        cache = self.context.get("_epg_now_cache")
+        if cache is not None:
+            return cache.get(obj.tvg_id)
+        now = timezone.now()
+        return (
+            ProgramData.objects.filter(
+                epg__tvg_id=obj.tvg_id, start_time__lte=now, end_time__gt=now
+            )
+            .values_list("title", flat=True)
+            .first()
+        )
 
     def get_fields(self):
         fields = super().get_fields()
@@ -561,7 +585,22 @@ class ChannelSerializer(serializers.ModelSerializer):
             for cs in obj.channelstream_set.all()
             if cs.stream_id is not None
         ]
-        return StreamSerializer(ordered_streams, many=True).data
+        # One query for this channel's whole stream list instead of one per
+        # stream — see StreamSerializer.epg_now_title.
+        tvg_ids = {s.tvg_id for s in ordered_streams if s.tvg_id}
+        epg_now_cache = {}
+        if tvg_ids:
+            now = timezone.now()
+            epg_now_cache = dict(
+                ProgramData.objects.filter(
+                    epg__tvg_id__in=tvg_ids, start_time__lte=now, end_time__gt=now
+                ).values_list("epg__tvg_id", "title")
+            )
+        return StreamSerializer(
+            ordered_streams,
+            many=True,
+            context={**self.context, "_epg_now_cache": epg_now_cache},
+        ).data
 
     def create(self, validated_data):
         streams = validated_data.pop("streams", [])

--- a/frontend/src/components/tables/ChannelTableStreams.jsx
+++ b/frontend/src/components/tables/ChannelTableStreams.jsx
@@ -206,6 +206,18 @@ const StreamInfoCell = React.memo(
               {stream.quality}
             </Badge>
           )}
+          {stream.epg_now_title && (
+            <Tooltip label="Currently airing, from this stream's EPG data">
+              <Badge
+                size="xs"
+                variant="light"
+                color="grape"
+                style={{ textTransform: 'none' }}
+              >
+                {stream.epg_now_title}
+              </Badge>
+            </Tooltip>
+          )}
           {stream.url && (
             <>
               <Tooltip label={stream.url}>


### PR DESCRIPTION
## Summary

Some IPTV providers (e.g. IPTVboss-style PPV/event feeds) deliberately keep channel and stream names as generic placeholders (`PPV EVENT 04`, `LIVE EVENT 12`) and instead push the actual event information through EPG data on a rolling basis — the channel identity stays fixed, but its EPG programme updates to whatever's currently airing. That's a reasonable design on the provider side and gives genuinely good, timely EPG data — but it leaves the Channels page unable to show which stream currently carries which event without cross-referencing the EPG separately; the stream list gives no hint beyond the generic name.

This adds a read-only `epg_now_title` field to `StreamSerializer`, resolved from the stream's own `tvg_id` against `ProgramData` for the currently-active time window (`start_time <= now < end_time`), and surfaces it as a small badge next to the existing quality/URL badges in the expanded stream row (`ChannelTableStreams.jsx`) — only when present. It's the same underlying EPG data these providers already supply well; this just makes it visible where it's actually useful (picking the right stream) without requiring anything be renamed.

- Batched per-channel in `ChannelSerializer.get_streams` (one query per channel's stream list, not one per stream) to avoid N+1 queries when a channel page loads with `include_streams=true`.
- Provider-agnostic: shows the raw EPG title verbatim, no text cleanup — that kind of provider-specific string massaging belongs at the provider/plugin layer, not core.

## Test plan

- [x] Verified live against a real Dispatcharr instance (v0.28.2): `GET /api/channels/channels/{id}/?include_streams=true` returns `epg_now_title` per stream, correctly resolving e.g. `PPV EVENT 08` → `"AEW Redemption ᴺᵉʷ"`.
- [x] Confirmed the badge renders correctly in the Channels page stream list after a full frontend rebuild + deploy.
- [x] Confirmed no `epg_now_title` badge shown when a stream has no `tvg_id` or no currently-active `ProgramData` (field returns `null`, frontend conditionally renders).

Happy to adjust naming/placement/scope per maintainer preference — opening this for consideration since it seemed like a generally useful, low-risk addition for anyone using providers with this generic-placeholder pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)