### PR TITLE
Add sanitization for VOD logo URLs, including tests and model integra…

### DIFF
--- a/apps/vod/models.py
+++ b/apps/vod/models.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from apps.m3u.models import M3UAccount
+from apps.vod.utils import sanitize_logo_url
 import uuid
 
 
@@ -12,12 +13,18 @@ class VODLogo(models.Model):
     name = models.CharField(max_length=255)
     url = models.TextField(unique=True)
 
+    def save(self, *args, **kwargs):
+        if self.url:
+            self.url = sanitize_logo_url(self.url)
+        super().save(*args, **kwargs)
+
     def __str__(self):
         return self.name
 
     class Meta:
         verbose_name = 'VOD Logo'
         verbose_name_plural = 'VOD Logos'
+
 
 
 class VODCategory(models.Model):

--- a/apps/vod/tasks.py
+++ b/apps/vod/tasks.py
@@ -8,6 +8,7 @@ from .models import (
     VODCategory, Series, Movie, Episode, VODLogo,
     M3USeriesRelation, M3UMovieRelation, M3UEpisodeRelation, M3UVODCategoryRelation
 )
+from .utils import sanitize_logo_url
 from datetime import datetime
 import logging
 import json
@@ -493,7 +494,7 @@ def process_movie_batch(account, batch, categories, relations, scan_start_time=N
             duration_secs = extract_duration_from_data(movie_data)
             trailer_raw = movie_data.get('trailer') or movie_data.get('youtube_trailer') or ''
             trailer = extract_string_from_array_or_string(trailer_raw) if trailer_raw else None
-            logo_url = movie_data.get('stream_icon') or ''
+            logo_url = sanitize_logo_url(movie_data.get('stream_icon') or '')
 
             director = extract_string_from_array_or_string(
                 movie_data.get('director') or ''
@@ -855,7 +856,7 @@ def process_series_batch(account, batch, categories, relations, scan_start_time=
             description = series_data.get('plot', '')
             rating = normalize_rating(series_data.get('rating'))
             genre = series_data.get('genre', '')
-            logo_url = series_data.get('cover') or ''
+            logo_url = sanitize_logo_url(series_data.get('cover') or '')
 
             # Extract additional metadata for custom_properties
             additional_metadata = {}

--- a/apps/vod/tests/test_logo_sanitization.py
+++ b/apps/vod/tests/test_logo_sanitization.py
@@ -1,0 +1,55 @@
+"""
+Unit tests for VOD logo URL sanitization and VODLogo model integration.
+"""
+from django.test import SimpleTestCase, TestCase
+from apps.vod.models import VODLogo
+from apps.vod.utils import sanitize_logo_url
+
+
+class VODLogoSanitizationTests(SimpleTestCase):
+    def test_exchange_cdn_movie_url_with_double_slash(self):
+        url = "http://cmc.exchange-cdn.com:8080/images/movies//tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg"
+        expected = "https://image.tmdb.org/t/p/w500/tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg"
+        self.assertEqual(sanitize_logo_url(url), expected)
+
+    def test_exchange_cdn_series_url_with_double_slash(self):
+        url = "http://cmc.exchange-cdn.com:8080/images/series//uP7bWcpzzjvo6Y0955zRHk5lX9ak.png"
+        expected = "https://image.tmdb.org/t/p/w500/uP7bWcpzzjvo6Y0955zRHk5lX9ak.png"
+        self.assertEqual(sanitize_logo_url(url), expected)
+
+    def test_iptv_proxy_tmdb_hash_webp(self):
+        url = "http://proxy.iptvserver.net:8080/images/movies/pQWcpzzjvo6Y0955zRHk5lX9ak.webp"
+        expected = "https://image.tmdb.org/t/p/w500/pQWcpzzjvo6Y0955zRHk5lX9ak.webp"
+        self.assertEqual(sanitize_logo_url(url), expected)
+
+    def test_double_slash_removal_non_tmdb_url(self):
+        url = "http://provider.example.com/images/movies//poster_123.jpg"
+        expected = "http://provider.example.com/images/movies/poster_123.jpg"
+        self.assertEqual(sanitize_logo_url(url), expected)
+
+    def test_tmdb_url_with_double_slash_normalized(self):
+        url = "https://image.tmdb.org/t/p/w500//tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg"
+        expected = "https://image.tmdb.org/t/p/w500/tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg"
+        self.assertEqual(sanitize_logo_url(url), expected)
+
+    def test_valid_tmdb_url_unmodified(self):
+        url = "https://image.tmdb.org/t/p/original/tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg"
+        self.assertEqual(sanitize_logo_url(url), url)
+
+    def test_whitespace_trimming(self):
+        url = "  http://cmc.exchange-cdn.com:8080/images/movies//tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg  "
+        expected = "https://image.tmdb.org/t/p/w500/tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg"
+        self.assertEqual(sanitize_logo_url(url), expected)
+
+    def test_empty_or_invalid_inputs(self):
+        self.assertEqual(sanitize_logo_url(""), "")
+        self.assertEqual(sanitize_logo_url(None), None)
+
+
+class VODLogoModelSaveTests(TestCase):
+    def test_model_save_sanitizes_url(self):
+        logo = VODLogo.objects.create(
+            name="Test Movie",
+            url="http://cmc.exchange-cdn.com:8080/images/movies//tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg"
+        )
+        self.assertEqual(logo.url, "https://image.tmdb.org/t/p/w500/tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg")

--- a/apps/vod/utils.py
+++ b/apps/vod/utils.py
@@ -1,0 +1,31 @@
+import re
+
+def sanitize_logo_url(logo_url: str) -> str:
+    """
+    Sanitizes and cleans VOD logo URLs.
+    1. Normalizes duplicate slashes in URL paths (e.g., http://domain/movies//file.jpg -> http://domain/movies/file.jpg).
+    2. Detects TMDB image paths originating from broken IPTV CDN proxy domains (e.g., exchange-cdn, images/movies, images/series)
+       or TMDB hashes and remaps them to the official TMDB CDN (https://image.tmdb.org/t/p/w500/{filename}).
+    """
+    if not logo_url or not isinstance(logo_url, str):
+        return logo_url
+
+    logo_url = logo_url.strip()
+    if not logo_url:
+        return logo_url
+
+    # Normalize double slashes in URL path, preserving protocol http:// or https://
+    logo_url = re.sub(r'(?<!:)/{2,}', '/', logo_url)
+
+    # Check for image filename pattern at the end of the URL
+    match = re.search(r'/([^/]+\.(?:jpg|jpeg|png|webp))$', logo_url, re.IGNORECASE)
+    if match and "image.tmdb.org" not in logo_url:
+        filename = match.group(1)
+        # Check if URL comes from known broken IPTV CDNs or contains TMDB poster filename patterns
+        is_broken_cdn = "exchange-cdn" in logo_url or "images/movies" in logo_url or "images/series" in logo_url
+        is_tmdb_hash = len(filename) >= 20 or (len(filename) >= 15 and filename.startswith(('t', 'v', 'p', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'q', 'r', 's', 'u', 'w', 'x', 'y', 'z')))
+        
+        if is_broken_cdn and (is_tmdb_hash or len(filename) >= 15):
+            logo_url = f"https://image.tmdb.org/t/p/w500/{filename}"
+
+    return logo_url


### PR DESCRIPTION
# Fix VOD logo URLs with duplicate slashes and broken IPTV CDN proxy domains

## Description

This PR fixes broken or unresolvable VOD cover and logo URLs imported from IPTV providers (e.g. `http://cmc.exchange-cdn.com:8080/images/movies//tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg`).

Key improvements:
- **Duplicate slash normalization**: Automatically cleans redundant slashes in URL paths (e.g., `/images/movies//poster.jpg` -> `/images/movies/poster.jpg`).
- **TMDB CDN fallback**: Automatically detects TMDB poster hashes coming from broken/unreachable IPTV CDN proxy domains (e.g., `exchange-cdn` or `/images/movies/`) and remaps them to the official TMDB CDN (`https://image.tmdb.org/t/p/w500/{filename}`).
- **Import & Model Sanitization**: Applied `sanitize_logo_url` helper during movie and series batch imports (`apps/vod/tasks.py`) as well as in `VODLogo.save()` (`apps/vod/models.py`).

## Related Issue

<!-- Non-trivial changes should have a linked issue. If this is a small/obvious fix, you may leave this blank. -->

Closes #1174

## How was it tested?

Unit tests were added in `apps/vod/tests/test_logo_sanitization.py` covering:
1. Remapping of exchange-cdn URLs with duplicate slashes containing TMDB poster IDs (`http://cmc.exchange-cdn.com:8080/images/movies//tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg` -> `https://image.tmdb.org/t/p/w500/tMeWcpzzjvo6Y0955zRHk5lX9ak.jpg`).
2. Remapping of series covers (`.png`) and WebP images from IPTV proxies.
3. Path normalization (removing duplicate slashes) for non-TMDB custom domain URLs without affecting their origin domain.
4. Path normalization for TMDB URLs containing duplicate slashes (`https://image.tmdb.org/t/p/w500//...`).
5. `VODLogo.save()` model integration testing ensuring automatic sanitization when instances are created or updated.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change