### PR TITLE
feat(streams): add {channelId} substitution token to StreamProfile pa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Type filter on the M3U and EPG source tables.** M3U & EPG Manager now has a filter dropdown on each table (M3U/XC for playlists, XMLTV/Schedules Direct/Dummy for EPG sources), matching the checklist-style filter menu already used on the Channels page, to narrow the list by type. All types are checked by default; the button highlights and a Reset option appears once anything is unchecked. The selection persists per table across reloads.
+- **`{channelId}` substitution token in Stream Profile parameters.** Stream Profile command-line parameters now support `{channelId}` alongside the existing `{streamUrl}` and `{userAgent}` tokens, letting a single profile embed the channel's primary key (the same ID used by the API) in its ffmpeg arguments. (Closes #1252)
 
 ### Security
 

--- a/apps/proxy/live_proxy/input/manager.py
+++ b/apps/proxy/live_proxy/input/manager.py
@@ -723,7 +723,7 @@ class StreamManager:
                     stream_profile = channel.get_stream_profile()
 
                 # Build and start transcode command
-                self.transcode_cmd = stream_profile.build_command(self.url, self.user_agent)
+                self.transcode_cmd = stream_profile.build_command(self.url, self.user_agent, channel.id)
 
                 # Store stream command for efficient log parser routing
                 self.stream_command = stream_profile.command

--- a/core/models.py
+++ b/core/models.py
@@ -55,7 +55,7 @@ class StreamProfile(models.Model):
         blank=True,
     )
     parameters = models.TextField(
-        help_text="Command-line parameters. Use {userAgent} and {streamUrl} as placeholders.",
+        help_text="Command-line parameters. Use {userAgent}, {streamUrl}, and {channelId} as placeholders.",
         blank=True,
     )
     locked = models.BooleanField(
@@ -134,7 +134,7 @@ class StreamProfile(models.Model):
             return True
         return False
 
-    def build_command(self, stream_url, user_agent):
+    def build_command(self, stream_url, user_agent, channel_id=None):
 
         if self.is_proxy():
             return []
@@ -142,6 +142,7 @@ class StreamProfile(models.Model):
         replacements = {
             "{streamUrl}": stream_url,
             "{userAgent}": user_agent,
+            "{channelId}": str(channel_id) if channel_id else "",
         }
 
         # Split the command and iterate through each part to apply replacements

--- a/core/tests/test_stream_profile_build_command.py
+++ b/core/tests/test_stream_profile_build_command.py
@@ -1,0 +1,45 @@
+from django.test import SimpleTestCase
+
+from core.models import StreamProfile
+
+
+class StreamProfileBuildCommandTests(SimpleTestCase):
+    def _profile(self, parameters):
+        return StreamProfile(
+            name="Test Profile",
+            command="ffmpeg",
+            parameters=parameters,
+            locked=False,
+        )
+
+    def test_substitutes_all_tokens(self):
+        profile = self._profile(
+            '-i {streamUrl} -user_agent {userAgent} -metadata channel={channelId}'
+        )
+        cmd = profile.build_command(
+            "http://example.com/stream.ts", "Mozilla/5.0", channel_id=42
+        )
+        self.assertEqual(
+            cmd,
+            [
+                "ffmpeg",
+                "-i",
+                "http://example.com/stream.ts",
+                "-user_agent",
+                "Mozilla/5.0",
+                "-metadata",
+                "channel=42",
+            ],
+        )
+
+    def test_channel_id_defaults_to_empty_string(self):
+        profile = self._profile('-metadata channel={channelId}')
+        cmd = profile.build_command("http://example.com/stream.ts", "Mozilla/5.0")
+        self.assertEqual(cmd, ["ffmpeg", "-metadata", "channel="])
+
+    def test_no_channel_id_placeholder_unaffected(self):
+        profile = self._profile('-i {streamUrl}')
+        cmd = profile.build_command(
+            "http://example.com/stream.ts", "Mozilla/5.0", channel_id=7
+        )
+        self.assertEqual(cmd, ["ffmpeg", "-i", "http://example.com/stream.ts"])

--- a/frontend/src/components/forms/StreamProfile.jsx
+++ b/frontend/src/components/forms/StreamProfile.jsx
@@ -133,8 +133,9 @@ const StreamProfile = ({ profile = null, isOpen, onClose }) => {
               <>
                 Command-line arguments passed to the command.
                 <br />
-                Use <strong>{'{streamUrl}'}</strong> and{' '}
-                <strong>{'{userAgent}'}</strong> as placeholders — they are
+                Use <strong>{'{streamUrl}'}</strong>,{' '}
+                <strong>{'{userAgent}'}</strong>, and{' '}
+                <strong>{'{channelId}'}</strong> as placeholders - they are
                 substituted at stream time.
                 {COMMAND_EXAMPLES[commandSelection] && (
                   <>


### PR DESCRIPTION
Adds {channelId} as a third substitution token for StreamProfile.build_command(), alongside the existing {streamUrl} and {userAgent}. This lets a single StreamProfile embed the channel's numeric ID directly in its ffmpeg parameters (e.g. for per-channel drawtext=textfile=... overlays), instead of requiring one cloned profile per channel.

- StreamProfile.build_command() now takes an optional channel_id arg; fully backwards-compatible (defaults to "" when omitted)
- Wired up in the live-proxy StreamManager at stream-start
- Updated the Parameters field help text/UI copy to document the new token
- Added unit tests covering substitution, default behavior, and profiles that don't use the token

Closes #1252