### PR TITLE
Fix needs_reconnect handling in stream loop

### DIFF
--- a/apps/proxy/live_proxy/input/manager.py
+++ b/apps/proxy/live_proxy/input/manager.py
@@ -1296,7 +1296,7 @@ class StreamManager:
         try:
             # Both transcode and HTTP now use the same subprocess/socket approach
             # This gives us perfect control: check flags between chunks, timeout just returns False
-            while self.running and self.connected and not self.stop_requested and not self.needs_stream_switch:
+            while self.running and self.connected and not self.stop_requested and not self.needs_stream_switch and not self.needs_reconnect:
                 if self.fetch_chunk():
                     self.last_data_time = time.time()
                 else:


### PR DESCRIPTION
## Description

`_process_stream_data()` does not currently exit when the health monitor sets `needs_reconnect`.

This can leave control inside the stream processing loop even though the main stream loop has existing handling for `needs_reconnect` and `_attempt_reconnect()`.

This change adds `needs_reconnect` to the `_process_stream_data()` loop conditions so the function yields back to the existing reconnect path when a health-monitor reconnect is requested.

## Related Issue

Closes #1493

## How was it tested?

I reproduced the issue with an HLS livestream that became unavailable after a period of stable playback.

The health monitor correctly set `needs_reconnect`, but stream processing continued instead of yielding to the reconnect path.

I tested the equivalent loop-exit behavior in my running Docker deployment. Once `needs_reconnect` caused the stream processing loop to exit, Dispatcharr reconnected the configured stream URL and preserved the client playback session.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [ ] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
