### PR TITLE
fix(vod): preserve Xtream category-specific movie and series sources

### DIFF
--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -14,6 +14,7 @@ from apps.output.views import (
     xc_get_live_streams,
     xc_get_series,
     xc_get_series_info,
+    xc_get_vod_info,
     xc_get_vod_streams,
 )
 from apps.vod.models import (
@@ -538,7 +539,7 @@ class XcVodSeriesDistinctTests(TestCase):
             stream_id="low-stream",
             container_extension="mkv",
         )
-        M3UMovieRelation.objects.create(
+        high_relation = M3UMovieRelation.objects.create(
             m3u_account=high,
             movie=movie,
             stream_id="high-stream",
@@ -549,7 +550,85 @@ class XcVodSeriesDistinctTests(TestCase):
 
         self.assertEqual(len(streams), 1)
         self.assertEqual(streams[0]["name"], "Shared Movie")
+        self.assertEqual(streams[0]["stream_id"], high_relation.id)
         self.assertEqual(streams[0]["container_extension"], "mp4")
+
+    def test_vod_global_list_keeps_one_item_per_category(self):
+        account = self._account(f"acct-{uuid4().hex[:6]}", priority=5)
+        categories = [
+            VODCategory.objects.create(name=name, category_type="movie")
+            for name in ("NETFLIX FILME", "GERMAN FILME", "KIDS FILME")
+        ]
+        movie = Movie.objects.create(
+            name="Shared Movie",
+            year=2025,
+            tmdb_id="12345",
+        )
+        relations = [
+            M3UMovieRelation.objects.create(
+                m3u_account=account,
+                movie=movie,
+                category=category,
+                stream_id=f"movie-{category.id}",
+            )
+            for category in categories
+        ]
+
+        results = xc_get_vod_streams(self.request, self.user)
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(
+            {row["stream_id"] for row in results},
+            {relation.id for relation in relations},
+        )
+        self.assertEqual(
+            {row["category_id"] for row in results},
+            {str(category.id) for category in categories},
+        )
+        self.assertTrue(all(row["tmdb_id"] == "12345" for row in results))
+
+    def test_vod_info_keeps_selected_category_relation(self):
+        account = self._account(f"acct-{uuid4().hex[:6]}", priority=5)
+        netflix = VODCategory.objects.create(
+            name="NETFLIX FILME", category_type="movie"
+        )
+        german = VODCategory.objects.create(
+            name="GERMAN FILME", category_type="movie"
+        )
+        movie = Movie.objects.create(
+            name="Canonical Movie",
+            custom_properties={"director": "Director"},
+        )
+        M3UMovieRelation.objects.create(
+            m3u_account=account,
+            movie=movie,
+            category=netflix,
+            stream_id="netflix-movie",
+            container_extension="mp4",
+            custom_properties={"detailed_info": {"name": "Netflix Movie"}},
+            last_advanced_refresh=timezone.now(),
+        )
+        german_relation = M3UMovieRelation.objects.create(
+            m3u_account=account,
+            movie=movie,
+            category=german,
+            stream_id="german-movie",
+            container_extension="mkv",
+            custom_properties={"detailed_info": {"name": "German Movie"}},
+            last_advanced_refresh=timezone.now(),
+        )
+
+        info = xc_get_vod_info(
+            self.request,
+            self.user,
+            german_relation.id,
+        )
+
+        self.assertEqual(info["info"]["name"], "German Movie")
+        self.assertEqual(info["movie_data"]["stream_id"], german_relation.id)
+        self.assertEqual(info["movie_data"]["category_id"], str(german.id))
+        self.assertEqual(info["movie_data"]["category_ids"], [german.id])
+        self.assertEqual(info["movie_data"]["container_extension"], "mkv")
 
     def test_vod_streams_excludes_inactive_accounts(self):
         active = self._account(f"active-{uuid4().hex[:6]}", priority=1)
@@ -681,6 +760,47 @@ class XcVodSeriesDistinctTests(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["name"], "Shared Series")
         self.assertEqual(results[0]["series_id"], high_rel.id)
+
+    def test_series_global_list_keeps_one_item_per_category(self):
+        account = self._account(f"acct-{uuid4().hex[:6]}", priority=5)
+        categories = [
+            VODCategory.objects.create(
+                name=name,
+                category_type="series",
+            )
+            for name in (
+                "NETFLIX ANIME",
+                "GERMANY KINDER",
+                "NICKELODEON",
+            )
+        ]
+        series = Series.objects.create(
+            name="DE - Avatar: Der Herr der Elemente (US)",
+            year=2005,
+            tmdb_id="246",
+        )
+        relations = [
+            M3USeriesRelation.objects.create(
+                m3u_account=account,
+                series=series,
+                category=category,
+                external_series_id=f"avatar-{category.id}",
+            )
+            for category in categories
+        ]
+
+        results = xc_get_series(self.request, self.user)
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(
+            {row["series_id"] for row in results},
+            {relation.id for relation in relations},
+        )
+        self.assertEqual(
+            {row["category_id"] for row in results},
+            {str(category.id) for category in categories},
+        )
+        self.assertTrue(all(row["tmdb_id"] == "246" for row in results))
 
     def test_series_category_selection_keeps_relation_specific_episodes(self):
         account = self._account(f"acct-{uuid4().hex[:6]}", priority=5)
@@ -891,7 +1011,7 @@ class XcVodSeriesRegressionTests(TestCase):
     def test_vod_streams_response_keys(self):
         account = self._account(f"acct-{uuid4().hex[:6]}")
         movie = Movie.objects.create(name="Schema Movie", rating="10")
-        M3UMovieRelation.objects.create(
+        relation = M3UMovieRelation.objects.create(
             m3u_account=account, movie=movie, stream_id="schema-1"
         )
 
@@ -899,7 +1019,7 @@ class XcVodSeriesRegressionTests(TestCase):
 
         self.assertEqual(set(stream.keys()), XC_VOD_STREAM_KEYS)
         self.assertEqual(stream["stream_type"], "movie")
-        self.assertEqual(stream["stream_id"], movie.id)
+        self.assertEqual(stream["stream_id"], relation.id)
         self.assertEqual(stream["rating_5based"], 5.0)
         self.assertEqual(stream["custom_sid"], None)
         self.assertEqual(stream["direct_source"], "")
@@ -925,30 +1045,29 @@ class XcVodSeriesRegressionTests(TestCase):
         self.assertEqual(stream["tmdb_id"], "")
         self.assertEqual(stream["imdb_id"], "")
 
-    def test_vod_streams_category_from_winning_relation(self):
-        """Category must come from the highest-priority relation, not any relation."""
+    def test_vod_streams_priority_is_applied_within_each_category(self):
         low = self._account(f"low-{uuid4().hex[:6]}", priority=1)
         high = self._account(f"high-{uuid4().hex[:6]}", priority=10)
         action = VODCategory.objects.create(name="Action", category_type="movie")
-        comedy = VODCategory.objects.create(name="Comedy", category_type="movie")
-        movie = Movie.objects.create(name="Dual Category Movie")
+        movie = Movie.objects.create(name="Shared Category Movie")
         M3UMovieRelation.objects.create(
             m3u_account=low,
             movie=movie,
             category=action,
             stream_id="low-cat",
         )
-        M3UMovieRelation.objects.create(
+        high_relation = M3UMovieRelation.objects.create(
             m3u_account=high,
             movie=movie,
-            category=comedy,
+            category=action,
             stream_id="high-cat",
         )
 
         stream = xc_get_vod_streams(self.request, self.user)[0]
 
-        self.assertEqual(stream["category_id"], str(comedy.id))
-        self.assertEqual(stream["category_ids"], [comedy.id])
+        self.assertEqual(stream["stream_id"], high_relation.id)
+        self.assertEqual(stream["category_id"], str(action.id))
+        self.assertEqual(stream["category_ids"], [action.id])
 
     def test_vod_streams_stream_icon_falls_back_to_relation_basic_data(self):
         """No synced VODLogo: fall back to the winning relation's own list-sync icon."""

--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -697,6 +697,7 @@ class XcVodSeriesDistinctTests(TestCase):
             "custom_properties": {
                 "episodes_fetched": True,
                 "detailed_fetched": True,
+                "detailed_info": {},
             },
             "last_episode_refresh": timezone.now(),
         }

--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -5,12 +5,20 @@ from unittest.mock import patch
 from uuid import uuid4
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 from apps.channels.models import Channel, ChannelGroup, ChannelOverride, ChannelProfile, ChannelProfileMembership
 from apps.epg.models import EPGData, EPGSource
 from apps.accounts.models import User
 from apps.m3u.models import M3UAccount
-from apps.output.views import xc_get_live_streams, xc_get_series, xc_get_vod_streams
+from apps.output.views import (
+    xc_get_live_streams,
+    xc_get_series,
+    xc_get_series_info,
+    xc_get_vod_streams,
+)
 from apps.vod.models import (
+    Episode,
+    M3UEpisodeRelation,
     M3UMovieRelation,
     M3USeriesRelation,
     Movie,
@@ -673,6 +681,84 @@ class XcVodSeriesDistinctTests(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["name"], "Shared Series")
         self.assertEqual(results[0]["series_id"], high_rel.id)
+
+    def test_series_category_selection_keeps_relation_specific_episodes(self):
+        account = self._account(f"acct-{uuid4().hex[:6]}", priority=5)
+        netflix = VODCategory.objects.create(
+            name="NETFLIX Kids", category_type="series"
+        )
+        german = VODCategory.objects.create(
+            name="German Kinder", category_type="series"
+        )
+        series = Series.objects.create(name="Avatar", year=2005)
+        relation_defaults = {
+            "m3u_account": account,
+            "series": series,
+            "custom_properties": {
+                "episodes_fetched": True,
+                "detailed_fetched": True,
+            },
+            "last_episode_refresh": timezone.now(),
+        }
+        netflix_series = M3USeriesRelation.objects.create(
+            **relation_defaults,
+            category=netflix,
+            external_series_id="netflix-avatar",
+        )
+        german_series = M3USeriesRelation.objects.create(
+            **relation_defaults,
+            category=german,
+            external_series_id="german-avatar",
+        )
+        episode = Episode.objects.create(
+            series=series,
+            season_number=1,
+            episode_number=1,
+            name="Canonical title",
+        )
+        M3UEpisodeRelation.objects.create(
+            m3u_account=account,
+            episode=episode,
+            series_relation=netflix_series,
+            stream_id="netflix-episode-1",
+            custom_properties={
+                "info": {
+                    "episode_num": 1,
+                    "title": "NF - The Boy in the Iceberg",
+                    "info": {"plot": "Netflix plot"},
+                }
+            },
+        )
+        german_episode = M3UEpisodeRelation.objects.create(
+            m3u_account=account,
+            episode=episode,
+            series_relation=german_series,
+            stream_id="german-episode-1",
+            container_extension="mkv",
+            custom_properties={
+                "info": {
+                    "episode_num": 1,
+                    "title": "DE - Der Junge im Eisberg",
+                    "info": {"plot": "German plot"},
+                }
+            },
+        )
+
+        category_results = xc_get_series(
+            self.request, self.user, category_id=german.id
+        )
+        info = xc_get_series_info(
+            self.request, self.user, category_results[0]["series_id"]
+        )
+        selected_episode = info["episodes"][1][0]
+
+        self.assertEqual(category_results[0]["series_id"], german_series.id)
+        self.assertEqual(info["info"]["category_id"], str(german.id))
+        self.assertEqual(selected_episode["id"], german_episode.id)
+        self.assertEqual(selected_episode["info"]["id"], german_episode.id)
+        self.assertEqual(selected_episode["title"], "DE - Der Junge im Eisberg")
+        self.assertEqual(selected_episode["info"]["overview"], "German plot")
+        self.assertEqual(selected_episode["container_extension"], "mkv")
 
     def test_series_excludes_inactive_accounts(self):
         active = self._account(f"active-{uuid4().hex[:6]}")

--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -564,14 +564,20 @@ class XcVodSeriesDistinctTests(TestCase):
             year=2025,
             tmdb_id="12345",
         )
+        source_names = (
+            "NF - Shared Movie",
+            "DE - Shared Movie",
+            "KIDS - Shared Movie",
+        )
         relations = [
             M3UMovieRelation.objects.create(
                 m3u_account=account,
                 movie=movie,
                 category=category,
                 stream_id=f"movie-{category.id}",
+                custom_properties={"basic_data": {"name": source_name}},
             )
-            for category in categories
+            for category, source_name in zip(categories, source_names)
         ]
 
         results = xc_get_vod_streams(self.request, self.user)
@@ -585,6 +591,7 @@ class XcVodSeriesDistinctTests(TestCase):
             {row["category_id"] for row in results},
             {str(category.id) for category in categories},
         )
+        self.assertEqual({row["name"] for row in results}, set(source_names))
         self.assertTrue(all(row["tmdb_id"] == "12345" for row in results))
 
     def test_vod_info_keeps_selected_category_relation(self):
@@ -605,7 +612,10 @@ class XcVodSeriesDistinctTests(TestCase):
             category=netflix,
             stream_id="netflix-movie",
             container_extension="mp4",
-            custom_properties={"detailed_info": {"name": "Netflix Movie"}},
+            custom_properties={
+                "basic_data": {"name": "NF - Canonical Movie"},
+                "detailed_info": {"name": "Netflix Movie"},
+            },
             last_advanced_refresh=timezone.now(),
         )
         german_relation = M3UMovieRelation.objects.create(
@@ -614,7 +624,10 @@ class XcVodSeriesDistinctTests(TestCase):
             category=german,
             stream_id="german-movie",
             container_extension="mkv",
-            custom_properties={"detailed_info": {"name": "German Movie"}},
+            custom_properties={
+                "basic_data": {"name": "DE - Canonical Movie"},
+                "detailed_info": {"name": "German Movie"},
+            },
             last_advanced_refresh=timezone.now(),
         )
 
@@ -624,7 +637,9 @@ class XcVodSeriesDistinctTests(TestCase):
             german_relation.id,
         )
 
-        self.assertEqual(info["info"]["name"], "German Movie")
+        self.assertEqual(info["info"]["name"], "DE - Canonical Movie")
+        self.assertEqual(info["info"]["o_name"], "German Movie")
+        self.assertEqual(info["movie_data"]["name"], "DE - Canonical Movie")
         self.assertEqual(info["movie_data"]["stream_id"], german_relation.id)
         self.assertEqual(info["movie_data"]["category_id"], str(german.id))
         self.assertEqual(info["movie_data"]["category_ids"], [german.id])
@@ -779,14 +794,25 @@ class XcVodSeriesDistinctTests(TestCase):
             year=2005,
             tmdb_id="246",
         )
+        source_names = (
+            "NF - Avatar: The Last Airbender",
+            "DE - Avatar: Der Herr der Elemente (US)",
+            "NICK - Avatar: The Last Airbender",
+        )
         relations = [
             M3USeriesRelation.objects.create(
                 m3u_account=account,
                 series=series,
                 category=category,
                 external_series_id=f"avatar-{category.id}",
+                custom_properties={
+                    "basic_data": {"name": source_name},
+                    "detailed_info": {
+                        "name": "Avatar: Der Herr der Elemente (US)"
+                    },
+                },
             )
-            for category in categories
+            for category, source_name in zip(categories, source_names)
         ]
 
         results = xc_get_series(self.request, self.user)
@@ -800,6 +826,7 @@ class XcVodSeriesDistinctTests(TestCase):
             {row["category_id"] for row in results},
             {str(category.id) for category in categories},
         )
+        self.assertEqual({row["name"] for row in results}, set(source_names))
         self.assertTrue(all(row["tmdb_id"] == "246" for row in results))
 
     def test_series_category_selection_keeps_relation_specific_episodes(self):
@@ -831,6 +858,18 @@ class XcVodSeriesDistinctTests(TestCase):
             category=german,
             external_series_id="german-avatar",
         )
+        netflix_series.custom_properties = {
+            **relation_defaults["custom_properties"],
+            "basic_data": {"name": "NF - Avatar"},
+            "detailed_info": {"name": "Avatar"},
+        }
+        netflix_series.save(update_fields=["custom_properties"])
+        german_series.custom_properties = {
+            **relation_defaults["custom_properties"],
+            "basic_data": {"name": "DE - Avatar"},
+            "detailed_info": {"name": "Avatar"},
+        }
+        german_series.save(update_fields=["custom_properties"])
         episode = Episode.objects.create(
             series=series,
             season_number=1,
@@ -874,6 +913,9 @@ class XcVodSeriesDistinctTests(TestCase):
         selected_episode = info["episodes"][1][0]
 
         self.assertEqual(category_results[0]["series_id"], german_series.id)
+        self.assertEqual(category_results[0]["name"], "DE - Avatar")
+        self.assertEqual(info["info"]["name"], "DE - Avatar")
+        self.assertEqual(info["info"]["o_name"], "Avatar")
         self.assertEqual(info["info"]["category_id"], str(german.id))
         self.assertEqual(selected_episode["id"], german_episode.id)
         self.assertEqual(selected_episode["info"]["id"], german_episode.id)

--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -615,6 +615,7 @@ class XcVodSeriesDistinctTests(TestCase):
             custom_properties={
                 "basic_data": {"name": "NF - Canonical Movie"},
                 "detailed_info": {"name": "Netflix Movie"},
+                "detailed_fetched": True,
             },
             last_advanced_refresh=timezone.now(),
         )
@@ -627,6 +628,7 @@ class XcVodSeriesDistinctTests(TestCase):
             custom_properties={
                 "basic_data": {"name": "DE - Canonical Movie"},
                 "detailed_info": {"name": "German Movie"},
+                "detailed_fetched": True,
             },
             last_advanced_refresh=timezone.now(),
         )

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1117,7 +1117,7 @@ def _xc_fetch_priority_distinct_relations(
     order_by_name_field,
 ):
     """
-    Return one row dict per distinct content ID (highest account priority wins).
+    Return one row per distinct content key (highest account priority wins).
 
     On PostgreSQL, dedupe on narrow relation rows first, then fetch display
     columns via values() (no ORM model instantiation). That avoids sorting
@@ -1127,6 +1127,11 @@ def _xc_fetch_priority_distinct_relations(
     from django.db import connection, transaction
 
     narrow_qs = manager.filter(**rel_filters)
+    distinct_fields = (
+        (distinct_field,)
+        if isinstance(distinct_field, str)
+        else tuple(distinct_field)
+    )
 
     def _fetch_by_ids(ids):
         return list(
@@ -1138,8 +1143,12 @@ def _xc_fetch_priority_distinct_relations(
     if connection.vendor == 'postgresql':
         winning_ids_qs = (
             narrow_qs
-            .order_by(distinct_field, '-m3u_account__priority', 'id')
-            .distinct(distinct_field)
+            .order_by(
+                *distinct_fields,
+                '-m3u_account__priority',
+                'id',
+            )
+            .distinct(*distinct_fields)
             .values('pk')
         )
         with transaction.atomic():
@@ -1156,7 +1165,7 @@ def _xc_fetch_priority_distinct_relations(
     for row in _xc_annotate_relation_artwork(narrow_qs).values(*value_fields).order_by(
         '-m3u_account__priority', 'id'
     ):
-        key = row[distinct_field]
+        key = tuple(row[field] for field in distinct_fields)
         if key not in seen:
             seen[key] = row
     rows = list(seen.values())
@@ -1200,7 +1209,9 @@ def xc_get_vod_streams(request, user, category_id=None):
     relations = _xc_fetch_priority_distinct_relations(
         manager=M3UMovieRelation.objects,
         rel_filters=rel_filters,
-        distinct_field='movie_id',
+        # Xtream assigns one category to each returned movie item. Keep one
+        # relation per canonical movie and category, matching the series list.
+        distinct_field=('movie_id', 'category_id'),
         value_fields=XC_MOVIE_VALUE_FIELDS,
         order_by_name_field='movie__name',
     )
@@ -1223,7 +1234,9 @@ def xc_get_vod_streams(request, user, category_id=None):
             "num": num,
             "name": row['movie__name'],
             "stream_type": "movie",
-            "stream_id": row['movie__id'],
+            # Expose the concrete relation ID so get_vod_info and playback can
+            # preserve the category/provider selected by the Xtream client.
+            "stream_id": row['id'],
             "stream_icon": _xc_cover_or_logo(
                 request,
                 'movie',
@@ -1289,7 +1302,10 @@ def xc_get_series(request, user, category_id=None):
     relations = _xc_fetch_priority_distinct_relations(
         manager=M3USeriesRelation.objects,
         rel_filters=rel_filters,
-        distinct_field='series_id',
+        # Xtream assigns one category to each returned series item. Keep one
+        # relation per canonical series and category so clients that fetch the
+        # global list can place the same show in every selected category.
+        distinct_field=('series_id', 'category_id'),
         value_fields=XC_SERIES_VALUE_FIELDS,
         order_by_name_field='series__name',
     )
@@ -1642,18 +1658,18 @@ def xc_get_vod_info(request, user, vod_id):
     if not vod_id:
         raise Http404()
 
-    # All authenticated users get access to VOD from all active M3U accounts
-    filters = {"movie_id": vod_id, "m3u_account__is_active": True}
+    # get_vod_streams exposes the concrete movie-relation ID. Resolve that
+    # exact row here, just as get_series_info resolves a series relation.
+    filters = {"id": vod_id, "m3u_account__is_active": True}
     if user.user_level < 10 and (user.custom_properties or {}).get('hide_adult_content', False):
         filters["movie__is_adult"] = False
 
     try:
-        # Order by account priority to get the best relation when multiple exist
-        movie_relation = M3UMovieRelation.objects.select_related('movie', 'movie__logo').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-        if not movie_relation:
-            raise Http404()
+        movie_relation = M3UMovieRelation.objects.select_related(
+            'movie', 'movie__logo'
+        ).get(**filters)
         movie = movie_relation.movie
-    except (M3UMovieRelation.DoesNotExist, M3UMovieRelation.MultipleObjectsReturned):
+    except M3UMovieRelation.DoesNotExist:
         raise Http404()
 
     # Initialize basic movie data first
@@ -1785,7 +1801,7 @@ def xc_get_vod_info(request, user, vod_id):
             'audio': movie_data.get('audio', {}),
         },
         "movie_data": {
-            "stream_id": movie.id,
+            "stream_id": movie_relation.id,
             "name": movie.name,
             "added": str(int(movie_relation.created_at.timestamp())),
             "category_id": str(movie_relation.category.id) if movie_relation.category else "0",

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1375,9 +1375,21 @@ def xc_get_series_info(request, user, series_id):
         custom_props = series_relation.custom_properties or {}
         episodes_fetched = custom_props.get('episodes_fetched', False)
         detailed_fetched = custom_props.get('detailed_fetched', False)
+        missing_episode_links = (
+            episodes_fetched
+            and series.episodes.exists()
+            and not M3UEpisodeRelation.objects.filter(
+                series_relation=series_relation
+            ).exists()
+        )
 
         # Force refresh if episodes/details have never been fetched or time interval exceeded
-        if not episodes_fetched or not detailed_fetched or should_refresh:
+        if (
+            not episodes_fetched
+            or not detailed_fetched
+            or missing_episode_links
+            or should_refresh
+        ):
             from apps.vod.tasks import refresh_series_episodes
             account = series_relation.m3u_account
             if account and account.is_active:
@@ -1389,96 +1401,96 @@ def xc_get_series_info(request, user, series_id):
     except Exception as e:
         logger.error(f"Error refreshing series data for relation {series_relation.id}: {str(e)}")
 
-    # Include episodes from any active provider for this shared Series (XC clients
-    # see a unified catalog). Prefer the highest-priority account's stream metadata.
-    from apps.vod.models import Episode, M3UEpisodeRelation
-
-    episodes = list(
-        Episode.objects.filter(
-            series=series,
-            m3u_relations__m3u_account__is_active=True,
-        ).distinct().order_by('season_number', 'episode_number')
+    # Keep the relation selected by get_series all the way through the episode
+    # list. A canonical Episode can be shared by several categories or providers,
+    # but each M3UEpisodeRelation identifies the actual upstream stream.
+    episode_relations = M3UEpisodeRelation.objects.filter(
+        series_relation=series_relation,
+        m3u_account__is_active=True
+    ).select_related('episode').order_by(
+        'episode__season_number', 'episode__episode_number', 'id'
     )
-
-    relations_by_episode_id = {}
-    for rel in M3UEpisodeRelation.objects.filter(
-        episode_id__in=[ep.id for ep in episodes],
-        m3u_account__is_active=True,
-    ).select_related('m3u_account').only(
-        'episode_id',
-        'container_extension',
-        'created_at',
-        'custom_properties',
-        'm3u_account__priority',
-    ).order_by('episode_id', '-m3u_account__priority', 'id'):
-        # First row per episode wins due to priority/id ordering.
-        if rel.episode_id not in relations_by_episode_id:
-            relations_by_episode_id[rel.episode_id] = rel
 
     # Group episodes by season
     seasons = {}
     # One reverse for all episode image rewrites in this response.
     _episode_image_parts = vod_image_url_parts(request, "episode")
-    for episode in episodes:
+    for episode_relation in episode_relations:
+        episode = episode_relation.episode
         season_num = (
             episode.season_number if episode.season_number is not None else 1
         )
         if season_num not in seasons:
             seasons[season_num] = []
 
-        best_relation = relations_by_episode_id.get(episode.id)
-
-        video = audio = bitrate = None
-        container_extension = "mp4"
-        added_timestamp = str(int(episode.created_at.timestamp()))
-
-        if best_relation:
-            container_extension = best_relation.container_extension or "mp4"
-            added_timestamp = str(int(best_relation.created_at.timestamp()))
-            if best_relation.custom_properties:
-                info = best_relation.custom_properties.get('info')
-                if info and isinstance(info, dict):
-                    info_info = info.get('info')
-                    if info_info and isinstance(info_info, dict):
-                        video = info_info.get('video', {})
-                        audio = info_info.get('audio', {})
-                        bitrate = info_info.get('bitrate', 0)
-
-        if video is None:
-            video = episode.custom_properties.get('video', {}) if episode.custom_properties else {}
-        if audio is None:
-            audio = episode.custom_properties.get('audio', {}) if episode.custom_properties else {}
-        if bitrate is None:
-            bitrate = episode.custom_properties.get('bitrate', 0) if episode.custom_properties else 0
+        relation_props = episode_relation.custom_properties or {}
+        provider_episode = relation_props.get('info') or {}
+        if not isinstance(provider_episode, dict):
+            provider_episode = {}
+        provider_info = provider_episode.get('info') or {}
+        if not isinstance(provider_info, dict):
+            provider_info = {}
+        episode_title = (
+            provider_episode.get('title')
+            or provider_info.get('name')
+            or episode.name
+        )
+        episode_description = (
+            provider_info.get('plot')
+            or provider_info.get('overview')
+            or episode.description
+            or ""
+        )
+        video = provider_info.get('video') or (
+            episode.custom_properties.get('video', {})
+            if episode.custom_properties else {}
+        )
+        audio = provider_info.get('audio') or (
+            episode.custom_properties.get('audio', {})
+            if episode.custom_properties else {}
+        )
+        bitrate = provider_info.get('bitrate') or (
+            episode.custom_properties.get('bitrate', 0)
+            if episode.custom_properties else 0
+        )
 
         episode_artwork = prefer_relation_artwork(
-            best_relation.custom_properties if best_relation else None,
+            relation_props,
             episode.custom_properties,
         )
 
         seasons[season_num].append({
-            "id": episode.id,
+            "id": episode_relation.id,
             "season": season_num,
-            "episode_num": episode.episode_number or 0,
-            "title": episode.name,
-            "container_extension": container_extension,
-            "added": added_timestamp,
+            "episode_num": provider_episode.get(
+                'episode_num', episode.episode_number or 0
+            ),
+            "title": episode_title,
+            "container_extension": episode_relation.container_extension or "mp4",
+            "added": str(int(episode_relation.created_at.timestamp())),
             "custom_sid": None,
             "direct_source": "",
             "info": {
-                "id": int(episode.id),
-                "name": episode.name,
-                "overview": episode.description or "",
-                "crew": str(episode.custom_properties.get('crew', "") if episode.custom_properties else ""),
-                "directed_by": episode.custom_properties.get('director', '') if episode.custom_properties else "",
-                "imdb_id": episode.imdb_id or "",
-                "air_date": f"{episode.air_date}" if episode.air_date else "",
+                "id": int(episode_relation.id),
+                "name": episode_title,
+                "overview": episode_description,
+                "crew": str(provider_info.get('crew') or (
+                    episode.custom_properties.get('crew', "")
+                    if episode.custom_properties else ""
+                )),
+                "directed_by": provider_info.get('directed_by') or (
+                    episode.custom_properties.get('director', '')
+                    if episode.custom_properties else ''
+                ),
+                "imdb_id": provider_info.get('imdb_id') or episode.imdb_id or "",
+                "air_date": str(provider_info.get('air_date') or episode.air_date or ""),
                 "backdrop_path": rewrite_backdrop_paths(
                     request,
                     'episode',
                     episode.id,
                     episode_artwork['backdrop_path'],
                     url_parts=_episode_image_parts,
+                    m3u_account_id=episode_relation.m3u_account_id,
                 ),
                 "movie_image": rewrite_single_image_url(
                     request,
@@ -1487,11 +1499,21 @@ def xc_get_series_info(request, user, series_id):
                     'movie_image',
                     episode_artwork['movie_image'],
                     url_parts=_episode_image_parts,
+                    m3u_account_id=episode_relation.m3u_account_id,
                 ),
-                "rating": float(episode.rating or 0),
-                "release_date": f"{episode.air_date}" if episode.air_date else "",
-                "duration_secs": (episode.duration_secs or 0),
-                "duration": format_duration_hms(episode.duration_secs),
+                "rating": float(provider_info.get('rating') or episode.rating or 0),
+                "release_date": str(
+                    provider_info.get('release_date')
+                    or provider_info.get('air_date')
+                    or episode.air_date
+                    or ""
+                ),
+                "duration_secs": provider_info.get(
+                    'duration_secs', episode.duration_secs or 0
+                ),
+                "duration": provider_info.get('duration') or format_duration_hms(
+                    episode.duration_secs
+                ),
                 "video": video,
                 "audio": audio,
                 "bitrate": bitrate,

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -25,6 +25,7 @@ from apps.proxy.utils import get_user_active_connections
 import regex
 from core.models import CoreSettings
 from core.utils import log_system_event, build_absolute_uri_with_port
+from apps.vod.utils import get_vod_source_name
 import hashlib
 from apps.output.epg import generate_epg, generate_dummy_programs
 from apps.vod.image_proxy import (
@@ -996,7 +997,7 @@ def xc_get_epg(request, user, short=False):
 
 
 XC_MOVIE_VALUE_FIELDS = (
-    'id', 'movie_id', 'category_id', 'container_extension',
+    'id', 'movie_id', 'category_id', 'container_extension', 'custom_properties',
     'movie__id', 'movie__name', 'movie__rating', 'movie__created_at',
     'movie__tmdb_id', 'movie__imdb_id', 'movie__description', 'movie__genre',
     'movie__year', 'movie__is_adult', 'movie__custom_properties', 'movie__logo_id',
@@ -1005,7 +1006,7 @@ XC_MOVIE_VALUE_FIELDS = (
 )
 
 XC_SERIES_VALUE_FIELDS = (
-    'id', 'series_id', 'category_id', 'updated_at',
+    'id', 'series_id', 'category_id', 'updated_at', 'custom_properties',
     'series__id', 'series__name', 'series__description', 'series__genre',
     'series__year', 'series__rating', 'series__custom_properties', 'series__logo_id',
     'series__tmdb_id', 'series__imdb_id',
@@ -1223,6 +1224,7 @@ def xc_get_vod_streams(request, user, category_id=None):
     streams = []
     append = streams.append
     for num, row in enumerate(relations, 1):
+        relation_props = row['custom_properties'] or {}
         custom_props = row['movie__custom_properties'] or {}
         category_id = row['category_id']
         category_id_str = str(category_id) if category_id else "0"
@@ -1232,7 +1234,10 @@ def xc_get_vod_streams(request, user, category_id=None):
 
         append({
             "num": num,
-            "name": row['movie__name'],
+            "name": get_vod_source_name(
+                relation_props,
+                row['movie__name'],
+            ),
             "stream_type": "movie",
             # Expose the concrete relation ID so get_vod_info and playback can
             # preserve the category/provider selected by the Xtream client.
@@ -1317,6 +1322,7 @@ def xc_get_series(request, user, category_id=None):
     series_list = []
     append = series_list.append
     for num, row in enumerate(relations, 1):
+        relation_props = row['custom_properties'] or {}
         custom_props = row['series__custom_properties'] or {}
         category_id = row['category_id']
         rating = row['series__rating']
@@ -1326,7 +1332,10 @@ def xc_get_series(request, user, category_id=None):
 
         append({
             "num": num,
-            "name": row['series__name'],
+            "name": get_vod_source_name(
+                relation_props,
+                row['series__name'],
+            ),
             "series_id": row['id'],
             "cover": _xc_cover_or_logo(
                 request,
@@ -1595,6 +1604,11 @@ def xc_get_series_info(request, user, series_id):
         {"season_number": int(season_num), "name": f"Season {season_num}"}
         for season_num in sorted(seasons.keys(), key=lambda x: int(x))
     ]
+    clean_series_name = series_data['name']
+    source_series_name = get_vod_source_name(
+        series_relation,
+        clean_series_name,
+    )
 
     series_artwork = prefer_relation_artwork(
         series_relation.custom_properties,
@@ -1619,7 +1633,8 @@ def xc_get_series_info(request, user, series_id):
     info = {
         'seasons': seasons_list,
         "info": {
-            "name": series_data['name'],
+            "name": source_series_name,
+            "o_name": clean_series_name,
             "cover": series_cover,
             "plot": series_data['description'],
             "cast": series_data['cast'],
@@ -1769,11 +1784,19 @@ def xc_get_vod_info(request, user, vod_id):
     else:
         movie_cover = None
 
+    # Keep the source-list title (including provider prefixes) separate from
+    # the cleaned detail title used as o_name.
+    clean_movie_name = movie_data.get('name', movie.name)
+    source_movie_name = get_vod_source_name(
+        movie_relation,
+        clean_movie_name,
+    )
+
     # Transform API response to XtreamCodes format
     info = {
         "info": {
-            "name": movie_data.get('name', movie.name),
-            "o_name": movie_data.get('name', movie.name),
+            "name": source_movie_name,
+            "o_name": clean_movie_name,
             "cover_big": movie_cover,
             "movie_image": movie_cover,
             'description': movie_data.get('description', ''),
@@ -1802,7 +1825,7 @@ def xc_get_vod_info(request, user, vod_id):
         },
         "movie_data": {
             "stream_id": movie_relation.id,
-            "name": movie.name,
+            "name": source_movie_name,
             "added": str(int(movie_relation.created_at.timestamp())),
             "category_id": str(movie_relation.category.id) if movie_relation.category else "0",
             "category_ids": [int(movie_relation.category.id)] if movie_relation.category else [],

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1375,6 +1375,7 @@ def xc_get_series_info(request, user, series_id):
         custom_props = series_relation.custom_properties or {}
         episodes_fetched = custom_props.get('episodes_fetched', False)
         detailed_fetched = custom_props.get('detailed_fetched', False)
+        detailed_info_stored = 'detailed_info' in custom_props
         missing_episode_links = (
             episodes_fetched
             and series.episodes.exists()
@@ -1387,6 +1388,7 @@ def xc_get_series_info(request, user, series_id):
         if (
             not episodes_fetched
             or not detailed_fetched
+            or not detailed_info_stored
             or missing_episode_links
             or should_refresh
         ):

--- a/apps/proxy/vod_proxy/multi_worker_connection_manager.py
+++ b/apps/proxy/vod_proxy/multi_worker_connection_manager.py
@@ -157,7 +157,8 @@ class SerializableConnectionState:
                  content_name: str = None, client_ip: str = None,
                  client_user_agent: str = None, utc_start: str = None,
                  utc_end: str = None, offset: str = None,
-                 worker_id: str = None, connection_type: str = "redis_backed", user_id: str = "unknown"):
+                 worker_id: str = None, connection_type: str = "redis_backed",
+                 user_id: str = "unknown", source_metadata: dict = None):
         self.session_id = session_id
         self.stream_url = stream_url
         self.headers = headers
@@ -181,6 +182,7 @@ class SerializableConnectionState:
         self.offset = offset or ""
         self.worker_id = worker_id
         self.connection_type = connection_type
+        self.source_metadata = source_metadata or {}
         self.created_at = time.time()
 
         # Additional tracking fields
@@ -217,6 +219,9 @@ class SerializableConnectionState:
             'offset': self.offset or '',
             'worker_id': self.worker_id or '',
             'connection_type': self.connection_type or 'redis_backed',
+            'source_metadata': json.dumps(
+                getattr(self, 'source_metadata', {}) or {}
+            ),
             'created_at': str(self.created_at),
             # Additional tracking fields
             'bytes_sent': str(self.bytes_sent),
@@ -251,7 +256,10 @@ class SerializableConnectionState:
             offset=data.get('offset') or '',
             worker_id=data.get('worker_id') or None,
             connection_type=data.get('connection_type', 'redis_backed'),
-            user_id=data.get('user_id', 'unknown')
+            user_id=data.get('user_id', 'unknown'),
+            source_metadata=cls._deserialize_source_metadata(
+                data.get('source_metadata')
+            ),
         )
         obj.last_activity = float(data.get('last_activity', time.time()))
         obj.request_count = int(data.get('request_count', 0))
@@ -266,6 +274,19 @@ class SerializableConnectionState:
         obj.total_content_size = int(data.get('total_content_size', 0))
         obj.last_seek_timestamp = float(data.get('last_seek_timestamp', 0.0))
         return obj
+
+    @staticmethod
+    def _deserialize_source_metadata(value):
+        """Read relation metadata while tolerating old or malformed sessions."""
+        if isinstance(value, dict):
+            return value
+        if not value:
+            return {}
+        try:
+            decoded = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
 
 
 class RedisBackedVODConnection:
@@ -402,7 +423,8 @@ class RedisBackedVODConnection:
                          content_name: str = None, client_ip: str = None,
                          client_user_agent: str = None, utc_start: str = None,
                          utc_end: str = None, offset: str = None,
-                         worker_id: str = None, user=None) -> bool:
+                         worker_id: str = None, user=None,
+                         source_metadata: dict = None) -> bool:
         """Create a new connection state in Redis with consolidated session metadata"""
         if not self._acquire_lock():
             logger.warning(f"[{self.session_id}] Could not acquire lock for connection creation")
@@ -431,7 +453,8 @@ class RedisBackedVODConnection:
                 utc_end=utc_end,
                 offset=offset,
                 worker_id=worker_id,
-                user_id=user.id if user else "unknown"
+                user_id=user.id if user else "unknown",
+                source_metadata=source_metadata,
             )
             # Seed active_streams=0 once; later mutations are Lua HINCRBY only.
             success = self._save_connection_state(state, include_active_streams=True)
@@ -733,6 +756,7 @@ class RedisBackedVODConnection:
                 'offset': state.offset,
                 'worker_id': state.worker_id,
                 'connection_type': state.connection_type,
+                'source_metadata': getattr(state, 'source_metadata', {}),
                 'created_at': state.created_at,
                 'last_activity': state.last_activity,
                 'm3u_profile_id': state.m3u_profile_id,
@@ -951,13 +975,19 @@ class MultiWorkerVODConnectionManager:
 
     def stream_content_with_session(self, session_id, content_obj, stream_url, m3u_profile,
                                   client_ip, client_user_agent, request,
-                                  utc_start=None, utc_end=None, offset=None, range_header=None, user=None):
+                                  utc_start=None, utc_end=None, offset=None,
+                                  range_header=None, user=None,
+                                  source_metadata=None):
         """Stream content with Redis-backed persistent connection"""
 
         # Generate client ID
         content_type = "movie" if isinstance(content_obj, Movie) else "episode"
         content_uuid = str(content_obj.uuid)
-        content_name = content_obj.name if hasattr(content_obj, 'name') else str(content_obj)
+        source_metadata = source_metadata or {}
+        content_name = (
+            source_metadata.get('episode_name')
+            or (content_obj.name if hasattr(content_obj, 'name') else str(content_obj))
+        )
         client_id = session_id
 
         # Track whether we incremented profile connections (for cleanup on error)
@@ -976,7 +1006,8 @@ class MultiWorkerVODConnectionManager:
                 client_user_agent=client_user_agent,
                 utc_start=utc_start,
                 utc_end=utc_end,
-                offset=offset
+                offset=offset,
+                source_key=source_metadata.get('source_key'),
             )
 
             # Use matching session if found, otherwise use the provided session_id
@@ -1043,7 +1074,8 @@ class MultiWorkerVODConnectionManager:
                     utc_end=utc_end,
                     offset=str(offset) if offset else None,
                     worker_id=self.worker_id,
-                    user=user
+                    user=user,
+                    source_metadata=source_metadata,
                 ):
                     logger.error(f"[{client_id}] Worker {self.worker_id} - Failed to create Redis connection")
                     # Roll back the profile slot reservation since connection failed
@@ -1657,7 +1689,8 @@ class MultiWorkerVODConnectionManager:
 
     def find_matching_idle_session(self, content_type: str, content_uuid: str,
                                  client_ip: str, client_user_agent: str,
-                                 utc_start=None, utc_end=None, offset=None) -> Optional[str]:
+                                 utc_start=None, utc_end=None, offset=None,
+                                 source_key=None) -> Optional[str]:
         """Find existing Redis-backed session that matches criteria using consolidated connection state"""
         if not self.redis_client:
             return None
@@ -1678,8 +1711,12 @@ class MultiWorkerVODConnectionManager:
                             continue
 
                         # Convert bytes keys/values to strings if needed
-                        if isinstance(list(connection_data.keys())[0], bytes):
-                            connection_data = {k: v for k, v in connection_data.items()}
+                        if isinstance(next(iter(connection_data)), bytes):
+                            connection_data = {
+                                k.decode() if isinstance(k, bytes) else k:
+                                v.decode() if isinstance(v, bytes) else v
+                                for k, v in connection_data.items()
+                            }
 
                         # Check if content matches (using consolidated data)
                         stored_content_type = connection_data.get('content_obj_type', '')
@@ -1688,8 +1725,26 @@ class MultiWorkerVODConnectionManager:
                         if stored_content_type != content_type or stored_content_uuid != content_uuid:
                             continue
 
+                        # The same canonical episode can have several upstream
+                        # category relations. Reuse is safe only for the exact
+                        # selected source.
+                        if source_key:
+                            try:
+                                stored_source = json.loads(
+                                    connection_data.get('source_metadata') or '{}'
+                                )
+                            except (TypeError, ValueError):
+                                stored_source = {}
+                            if stored_source.get('source_key') != source_key:
+                                continue
+
                         # Extract session ID
-                        session_id = key.replace('vod_persistent_connection:', '')
+                        key_text = (
+                            key.decode() if isinstance(key, bytes) else key
+                        )
+                        session_id = key_text.replace(
+                            'vod_persistent_connection:', ''
+                        )
 
                         # Check if Redis-backed connection exists and has no active streams
                         redis_connection = RedisBackedVODConnection(session_id, self.redis_client)

--- a/apps/proxy/vod_proxy/tests/test_vod_db_cleanup.py
+++ b/apps/proxy/vod_proxy/tests/test_vod_db_cleanup.py
@@ -28,12 +28,22 @@ class StreamVodDbCleanupTests(SimpleTestCase):
     ):
         movie = MagicMock()
         movie.name = "Test Movie"
+        movie.description = "Movie description"
+        movie.duration_secs = 7200
+        relation = MagicMock()
+        relation.id = 17
+        relation.stream_id = "movie-stream-17"
+        relation.category.id = 3
+        relation.category.name = "KIDS MOVIES"
+        relation.m3u_account.id = 9
+        relation.m3u_account.name = "Provider"
         profile = MagicMock()
         profile.id = 1
         profile.max_streams = 5
         mock_select.return_value = {
             "content_obj": movie,
-            "m3u_account": MagicMock(name="Provider"),
+            "relation": relation,
+            "m3u_account": relation.m3u_account,
             "m3u_profile": profile,
             "current_connections": 0,
             "final_stream_url": "http://example.com/movie.mp4",
@@ -54,16 +64,24 @@ class StreamVodDbCleanupTests(SimpleTestCase):
 
         from apps.proxy.vod_proxy.views import stream_vod
 
-        response = stream_vod(
-            request,
-            content_type="movie",
-            content_id="uuid",
-            session_id="session123",
-        )
+        with patch("core.utils.RedisClient.get_client", return_value=None):
+            response = stream_vod(
+                request,
+                content_type="movie",
+                content_id="uuid",
+                session_id="session123",
+            )
 
         self.assertIsInstance(response, StreamingHttpResponse)
         mock_close.assert_called_once()
         mock_manager.stream_content_with_session.assert_called_once()
+        source_metadata = mock_manager.stream_content_with_session.call_args.kwargs[
+            "source_metadata"
+        ]
+        self.assertEqual(source_metadata["source_key"], "movie:17")
+        self.assertEqual(source_metadata["stream_id"], "movie-stream-17")
+        self.assertEqual(source_metadata["m3u_account_name"], "Provider")
+        self.assertEqual(source_metadata["category_name"], "KIDS MOVIES")
 
 
 class BuildVodStatsDbCleanupTests(SimpleTestCase):

--- a/apps/proxy/vod_proxy/tests/test_vod_source_metadata.py
+++ b/apps/proxy/vod_proxy/tests/test_vod_source_metadata.py
@@ -1,0 +1,189 @@
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, TestCase
+
+from apps.m3u.models import M3UAccount
+from apps.vod.models import (
+    Episode,
+    M3UEpisodeRelation,
+    M3USeriesRelation,
+    Series,
+    VODCategory,
+)
+from apps.proxy.vod_proxy.multi_worker_connection_manager import (
+    MultiWorkerVODConnectionManager,
+    RedisBackedVODConnection,
+    SerializableConnectionState,
+)
+from apps.proxy.vod_proxy.views import (
+    _build_vod_source_metadata,
+    build_vod_stats_data,
+)
+
+
+class VODSourceMetadataStatsTests(TestCase):
+    def setUp(self):
+        self.account = M3UAccount.objects.create(
+            name="tivione-z2u",
+            server_url="http://example.com",
+            is_active=True,
+        )
+        category = VODCategory.objects.create(
+            name="NICKELODEON",
+            category_type="series",
+        )
+        series = Series.objects.create(
+            name="Avatar: Der Herr der Elemente",
+            tmdb_id="246",
+        )
+        series_relation = M3USeriesRelation.objects.create(
+            m3u_account=self.account,
+            series=series,
+            category=category,
+            external_series_id="nick-avatar",
+        )
+        self.episode = Episode.objects.create(
+            series=series,
+            season_number=3,
+            episode_number=1,
+            name="DE - Canonical title",
+            description="Canonical plot",
+            duration_secs=1475,
+        )
+        self.relation = M3UEpisodeRelation.objects.create(
+            m3u_account=self.account,
+            episode=self.episode,
+            series_relation=series_relation,
+            stream_id="686164",
+            custom_properties={
+                "info": {
+                    "title": "NICK - The Awakening",
+                    "info": {
+                        "plot": "Nickelodeon plot",
+                        "duration_secs": 1443,
+                    },
+                }
+            },
+        )
+
+    def test_stats_use_the_exact_episode_relation_metadata(self):
+        source_metadata = _build_vod_source_metadata(
+            "episode", self.episode, self.relation
+        )
+        redis_client = MagicMock()
+        redis_client.scan.return_value = (
+            0,
+            ["vod_persistent_connection:nick-session"],
+        )
+        redis_client.hgetall.return_value = {
+            "content_obj_type": "episode",
+            "content_uuid": str(self.episode.uuid),
+            "content_name": self.episode.name,
+            "client_ip": "127.0.0.1",
+            "client_user_agent": "UHF",
+            "created_at": str(time.time()),
+            "last_activity": str(time.time()),
+            "active_streams": "1",
+            "source_metadata": json.dumps(source_metadata),
+        }
+
+        stats = build_vod_stats_data(redis_client)
+
+        self.assertEqual(stats["total_connections"], 1)
+        vod = stats["vod_connections"][0]
+        connection = vod["connections"][0]
+        metadata = vod["content_metadata"]
+        self.assertEqual(metadata["episode_name"], "NICK - The Awakening")
+        self.assertEqual(metadata["description"], "Nickelodeon plot")
+        self.assertEqual(metadata["duration_secs"], 1443)
+        self.assertEqual(metadata["m3u_account_name"], "tivione-z2u")
+        self.assertEqual(metadata["category_name"], "NICKELODEON")
+        self.assertEqual(metadata["stream_id"], "686164")
+        self.assertEqual(metadata["relation_id"], self.relation.id)
+        self.assertEqual(
+            connection["source_metadata"]["source_key"],
+            f"episode:{self.relation.id}",
+        )
+
+
+class VODSourceSessionTests(SimpleTestCase):
+    def _manager_with_session(self, source_key):
+        redis_client = MagicMock()
+        redis_client.scan.return_value = (
+            0,
+            ["vod_persistent_connection:existing"],
+        )
+        redis_client.hgetall.return_value = {
+            "content_obj_type": "episode",
+            "content_uuid": "episode-uuid",
+            "source_metadata": json.dumps({"source_key": source_key}),
+            "client_ip": "127.0.0.1",
+            "client_user_agent": "UHF",
+            "utc_start": "",
+            "utc_end": "",
+            "offset": "",
+            "last_activity": "1000",
+        }
+        manager = MultiWorkerVODConnectionManager.__new__(
+            MultiWorkerVODConnectionManager
+        )
+        manager.redis_client = redis_client
+        return manager
+
+    @patch.object(
+        RedisBackedVODConnection,
+        "has_active_streams",
+        return_value=False,
+    )
+    def test_idle_session_is_not_reused_across_category_relations(
+        self, _has_active_streams
+    ):
+        manager = self._manager_with_session("episode:1")
+
+        match = manager.find_matching_idle_session(
+            "episode",
+            "episode-uuid",
+            "127.0.0.1",
+            "UHF",
+            source_key="episode:2",
+        )
+
+        self.assertIsNone(match)
+
+    @patch.object(
+        RedisBackedVODConnection,
+        "has_active_streams",
+        return_value=False,
+    )
+    def test_idle_session_can_be_reused_for_the_same_relation(
+        self, _has_active_streams
+    ):
+        manager = self._manager_with_session("episode:1")
+
+        match = manager.find_matching_idle_session(
+            "episode",
+            "episode-uuid",
+            "127.0.0.1",
+            "UHF",
+            source_key="episode:1",
+        )
+
+        self.assertEqual(match, "existing")
+
+    def test_source_metadata_survives_redis_serialization(self):
+        state = SerializableConnectionState(
+            session_id="session",
+            stream_url="http://example.com/episode.mkv",
+            headers={},
+            source_metadata={
+                "source_key": "episode:7",
+                "category_name": "NICKELODEON",
+            },
+        )
+
+        restored = SerializableConnectionState.from_dict(state.to_dict())
+
+        self.assertEqual(restored.source_metadata, state.source_metadata)
+

--- a/apps/proxy/vod_proxy/tests/test_vod_source_metadata.py
+++ b/apps/proxy/vod_proxy/tests/test_vod_source_metadata.py
@@ -19,6 +19,7 @@ from apps.proxy.vod_proxy.multi_worker_connection_manager import (
 )
 from apps.proxy.vod_proxy.views import (
     _build_vod_source_metadata,
+    _get_series_display_name,
     build_vod_stats_data,
 )
 
@@ -35,8 +36,9 @@ class VODSourceMetadataStatsTests(TestCase):
             category_type="series",
         )
         series = Series.objects.create(
-            name="Avatar: Der Herr der Elemente",
+            name="DE - Avatar: Der Herr der Elemente (US)",
             tmdb_id="246",
+            custom_properties={"original_name": "Avatar: The Last Airbender"},
         )
         series_relation = M3USeriesRelation.objects.create(
             m3u_account=self.account,
@@ -72,6 +74,10 @@ class VODSourceMetadataStatsTests(TestCase):
         source_metadata = _build_vod_source_metadata(
             "episode", self.episode, self.relation
         )
+        self.assertEqual(
+            source_metadata["series_display_name"],
+            "Avatar: The Last Airbender",
+        )
         redis_client = MagicMock()
         redis_client.scan.return_value = (
             0,
@@ -95,6 +101,14 @@ class VODSourceMetadataStatsTests(TestCase):
         vod = stats["vod_connections"][0]
         connection = vod["connections"][0]
         metadata = vod["content_metadata"]
+        self.assertEqual(
+            metadata["series_name"],
+            "DE - Avatar: Der Herr der Elemente (US)",
+        )
+        self.assertEqual(
+            metadata["series_display_name"],
+            "Avatar: The Last Airbender",
+        )
         self.assertEqual(metadata["episode_name"], "NICK - The Awakening")
         self.assertEqual(metadata["description"], "Nickelodeon plot")
         self.assertEqual(metadata["duration_secs"], 1443)
@@ -105,6 +119,19 @@ class VODSourceMetadataStatsTests(TestCase):
         self.assertEqual(
             connection["source_metadata"]["source_key"],
             f"episode:{self.relation.id}",
+        )
+
+    def test_clean_series_title_can_come_from_provider_relation(self):
+        series = self.episode.series
+        series.custom_properties = None
+        series_relation = self.relation.series_relation
+        series_relation.custom_properties = {
+            "basic_data": {"o_name": "Avatar: The Last Airbender"}
+        }
+
+        self.assertEqual(
+            _get_series_display_name(series, series_relation),
+            "Avatar: The Last Airbender",
         )
 
 
@@ -186,4 +213,3 @@ class VODSourceSessionTests(SimpleTestCase):
         restored = SerializableConnectionState.from_dict(state.to_dict())
 
         self.assertEqual(restored.source_metadata, state.source_metadata)
-

--- a/apps/proxy/vod_proxy/tests/test_vod_source_metadata.py
+++ b/apps/proxy/vod_proxy/tests/test_vod_source_metadata.py
@@ -45,6 +45,12 @@ class VODSourceMetadataStatsTests(TestCase):
             series=series,
             category=category,
             external_series_id="nick-avatar",
+            custom_properties={
+                "detailed_info": {
+                    "name": "Avatar: Der Herr der Elemente (US)",
+                    "o_name": "Avatar: The Last Airbender",
+                }
+            },
         )
         self.episode = Episode.objects.create(
             series=series,
@@ -76,7 +82,7 @@ class VODSourceMetadataStatsTests(TestCase):
         )
         self.assertEqual(
             source_metadata["series_display_name"],
-            "Avatar: The Last Airbender",
+            "Avatar: Der Herr der Elemente (US)",
         )
         redis_client = MagicMock()
         redis_client.scan.return_value = (
@@ -107,7 +113,7 @@ class VODSourceMetadataStatsTests(TestCase):
         )
         self.assertEqual(
             metadata["series_display_name"],
-            "Avatar: The Last Airbender",
+            "Avatar: Der Herr der Elemente (US)",
         )
         self.assertEqual(metadata["episode_name"], "NICK - The Awakening")
         self.assertEqual(metadata["description"], "Nickelodeon plot")

--- a/apps/proxy/vod_proxy/tests/test_xc_episode_selection.py
+++ b/apps/proxy/vod_proxy/tests/test_xc_episode_selection.py
@@ -5,7 +5,13 @@ from django.urls import reverse
 
 from apps.accounts.models import User
 from apps.m3u.models import M3UAccount
-from apps.vod.models import Episode, M3UEpisodeRelation, Series
+from apps.vod.models import (
+    Episode,
+    M3UEpisodeRelation,
+    M3UMovieRelation,
+    Movie,
+    Series,
+)
 
 
 class XCEpisodeSelectionTests(TestCase):
@@ -67,3 +73,58 @@ class XCEpisodeSelectionTests(TestCase):
         self.assertEqual(kwargs["preferred_stream_id"], "german-episode-1")
         self.assertIn(f"m3u_account_id={account.id}", response["Location"])
         self.assertIn("stream_id=german-episode-1", response["Location"])
+
+
+class XCMovieSelectionTests(TestCase):
+    def test_relation_id_selects_and_forwards_the_exact_upstream_stream(self):
+        from apps.proxy.vod_proxy.views import stream_vod as actual_stream_vod
+
+        user = User.objects.create_user(
+            username="xc-movie-viewer",
+            password="unused",
+            custom_properties={"xc_password": "xc-secret"},
+        )
+        account = M3UAccount.objects.create(
+            name="Movie provider",
+            server_url="http://example.com",
+            is_active=True,
+        )
+        movie = Movie.objects.create(name="Shared Movie")
+        selected_relation = M3UMovieRelation.objects.create(
+            m3u_account=account,
+            movie=movie,
+            stream_id="german-movie-1",
+            container_extension="mkv",
+        )
+        url = reverse(
+            "stream_xc_movie",
+            kwargs={
+                "username": user.username,
+                "password": "xc-secret",
+                "stream_id": str(selected_relation.id),
+                "extension": "mkv",
+            },
+        )
+
+        with (
+            patch(
+                "apps.proxy.vod_proxy.views.network_access_allowed",
+                return_value=True,
+            ),
+            patch("core.utils.RedisClient.get_client", return_value=None),
+            patch(
+                "apps.proxy.vod_proxy.views.stream_vod",
+                wraps=actual_stream_vod,
+            ) as stream_vod,
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        stream_vod.assert_called_once()
+        args, kwargs = stream_vod.call_args
+        self.assertEqual(args[1], "movie")
+        self.assertEqual(args[2], movie.uuid)
+        self.assertEqual(kwargs["preferred_m3u_account_id"], account.id)
+        self.assertEqual(kwargs["preferred_stream_id"], "german-movie-1")
+        self.assertIn(f"m3u_account_id={account.id}", response["Location"])
+        self.assertIn("stream_id=german-movie-1", response["Location"])

--- a/apps/proxy/vod_proxy/tests/test_xc_episode_selection.py
+++ b/apps/proxy/vod_proxy/tests/test_xc_episode_selection.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.accounts.models import User
+from apps.m3u.models import M3UAccount
+from apps.vod.models import Episode, M3UEpisodeRelation, Series
+
+
+class XCEpisodeSelectionTests(TestCase):
+    def test_relation_id_selects_and_forwards_the_exact_upstream_stream(self):
+        from apps.proxy.vod_proxy.views import stream_vod as actual_stream_vod
+
+        user = User.objects.create_user(
+            username="xc-viewer",
+            password="unused",
+            custom_properties={"xc_password": "xc-secret"},
+        )
+        account = M3UAccount.objects.create(
+            name="Shared provider",
+            server_url="http://example.com",
+            is_active=True,
+        )
+        series = Series.objects.create(name="Avatar")
+        episode = Episode.objects.create(
+            series=series,
+            season_number=1,
+            episode_number=1,
+            name="Der Junge im Eisberg",
+        )
+        selected_relation = M3UEpisodeRelation.objects.create(
+            m3u_account=account,
+            episode=episode,
+            stream_id="german-episode-1",
+            container_extension="mkv",
+        )
+        url = reverse(
+            "stream_xc_episode",
+            kwargs={
+                "username": user.username,
+                "password": "xc-secret",
+                "stream_id": str(selected_relation.id),
+                "extension": "mkv",
+            },
+        )
+
+        with (
+            patch(
+                "apps.proxy.vod_proxy.views.network_access_allowed",
+                return_value=True,
+            ),
+            patch("core.utils.RedisClient.get_client", return_value=None),
+            patch(
+                "apps.proxy.vod_proxy.views.stream_vod",
+                wraps=actual_stream_vod,
+            ) as stream_vod,
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 301)
+        stream_vod.assert_called_once()
+        args, kwargs = stream_vod.call_args
+        self.assertEqual(args[1], "episode")
+        self.assertEqual(args[2], episode.uuid)
+        self.assertEqual(kwargs["preferred_m3u_account_id"], account.id)
+        self.assertEqual(kwargs["preferred_stream_id"], "german-episode-1")
+        self.assertIn(f"m3u_account_id={account.id}", response["Location"])
+        self.assertIn("stream_id=german-episode-1", response["Location"])

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -6,6 +6,7 @@ Supports M3U profiles for authentication and URL transformation.
 import time
 import random
 import logging
+import json
 import requests
 from urllib.parse import urlencode
 from django.db import close_old_connections
@@ -77,11 +78,15 @@ def _find_idle_vod_session(
     omitted session_id can resume an existing proxy pool instead of starting
     a new provider hop.
     """
-    content_obj, _relation, _candidates = _get_content_and_relation(
+    content_obj, relation, _candidates = _get_content_and_relation(
         content_type, content_id, preferred_m3u_account_id, preferred_stream_id
     )
-    if not content_obj:
+    if not content_obj or not relation:
         return None
+
+    source_metadata = _build_vod_source_metadata(
+        content_type, content_obj, relation
+    )
 
     try:
         manager = MultiWorkerVODConnectionManager.get_instance()
@@ -93,6 +98,7 @@ def _find_idle_vod_session(
             utc_start=utc_start,
             utc_end=utc_end,
             offset=offset,
+            source_key=source_metadata["source_key"],
         )
     except Exception as e:
         logger.warning("[VOD-SESSION] Idle session match failed: %s", e)
@@ -219,6 +225,7 @@ def _select_vod_stream(
         )
         return {
             "content_obj": content_obj,
+            "relation": cand,
             "m3u_account": cand_account,
             "m3u_profile": m3u_profile,
             "current_connections": current_connections,
@@ -226,6 +233,55 @@ def _select_vod_stream(
         }
 
     return None
+def _build_vod_source_metadata(content_type, content_obj, relation):
+    """Describe the exact upstream relation selected for a VOD session."""
+    category = None
+    episode_name = getattr(content_obj, "name", "Unknown")
+    description = getattr(content_obj, "description", None)
+    duration_secs = getattr(content_obj, "duration_secs", None)
+
+    if content_type in ("episode", "series"):
+        series_relation = getattr(relation, "series_relation", None)
+        if series_relation:
+            category = getattr(series_relation, "category", None)
+
+        relation_props = getattr(relation, "custom_properties", None) or {}
+        provider_episode = relation_props.get("info") or {}
+        if not isinstance(provider_episode, dict):
+            provider_episode = {}
+        provider_info = provider_episode.get("info") or {}
+        if not isinstance(provider_info, dict):
+            provider_info = {}
+
+        episode_name = (
+            provider_episode.get("title")
+            or provider_info.get("name")
+            or episode_name
+        )
+        description = (
+            provider_info.get("plot")
+            or provider_info.get("overview")
+            or description
+        )
+        duration_secs = provider_info.get("duration_secs") or duration_secs
+    else:
+        category = getattr(relation, "category", None)
+
+    account = relation.m3u_account
+    relation_type = "episode" if content_type in ("episode", "series") else "movie"
+
+    return {
+        "source_key": f"{relation_type}:{relation.id}",
+        "relation_id": relation.id,
+        "stream_id": getattr(relation, "stream_id", None),
+        "m3u_account_id": account.id,
+        "m3u_account_name": account.name,
+        "category_id": getattr(category, "id", None),
+        "category_name": getattr(category, "name", None),
+        "episode_name": episode_name if relation_type == "episode" else None,
+        "description": description,
+        "duration_secs": duration_secs,
+    }
 
 
 def _get_content_and_relation(content_type, content_id, preferred_m3u_account_id=None, preferred_stream_id=None):
@@ -853,6 +909,7 @@ def stream_vod(
             return HttpResponse("No available stream", status=503)
 
         content_obj = selected["content_obj"]
+        relation = selected["relation"]
         m3u_account = selected["m3u_account"]
         m3u_profile = selected["m3u_profile"]
         current_connections = selected["current_connections"]
@@ -868,6 +925,9 @@ def stream_vod(
 
         # Get connection manager (Redis-backed for multi-worker support)
         connection_manager = MultiWorkerVODConnectionManager.get_instance()
+        source_metadata = _build_vod_source_metadata(
+            content_type, content_obj, relation
+        )
 
         # Release ORM checkout before returning a long-lived StreamingHttpResponse.
         close_old_connections()
@@ -887,6 +947,7 @@ def stream_vod(
             offset=offset,
             range_header=range_header,
             user=user,
+            source_metadata=source_metadata,
         )
 
         logger.info(f"[VOD-SUCCESS] Stream response created successfully, type: {type(response)}")
@@ -1126,13 +1187,32 @@ def build_vod_stats_data(redis_client):
                     connection_data = redis_client.hgetall(key)
 
                     if connection_data:
+                        key_text = (
+                            key.decode() if isinstance(key, bytes) else key
+                        )
                         # Extract session ID from key
-                        session_id = key.replace('vod_persistent_connection:', '')
+                        session_id = key_text.replace(
+                            'vod_persistent_connection:', ''
+                        )
 
                         # Decode Redis hash data
-                        combined_data = {}
-                        for k, v in connection_data.items():
-                            combined_data[k] = v
+                        combined_data = {
+                            k.decode() if isinstance(k, bytes) else k:
+                            v.decode() if isinstance(v, bytes) else v
+                            for k, v in connection_data.items()
+                        }
+
+                        raw_source_metadata = combined_data.get(
+                            'source_metadata', '{}'
+                        )
+                        try:
+                            source_metadata = (
+                                json.loads(raw_source_metadata)
+                                if isinstance(raw_source_metadata, str)
+                                else (raw_source_metadata or {})
+                            )
+                        except (TypeError, ValueError):
+                            source_metadata = {}
 
                         # Get content info from the connection data (using correct field names)
                         content_type = combined_data.get('content_obj_type', 'unknown')
@@ -1175,15 +1255,23 @@ def build_vod_stats_data(redis_client):
                                     'description': content_obj.description,
                                     'logo_url': content_obj.logo.url if content_obj.logo else None,
                                     'tmdb_id': content_obj.tmdb_id,
-                                    'imdb_id': content_obj.imdb_id
+                                    'imdb_id': content_obj.imdb_id,
+                                    'm3u_account_name': source_metadata.get('m3u_account_name'),
+                                    'category_name': source_metadata.get('category_name'),
+                                    'stream_id': source_metadata.get('stream_id'),
+                                    'relation_id': source_metadata.get('relation_id'),
                                 }
                             elif content_type == 'episode':
                                 content_obj = Episode.objects.select_related('series', 'series__logo').get(uuid=content_uuid)
-                                content_name = f"{content_obj.series.name} - {content_obj.name}"
+                                episode_name = (
+                                    source_metadata.get('episode_name')
+                                    or content_obj.name
+                                )
+                                content_name = f"{content_obj.series.name} - {episode_name}"
 
                                 # Get duration from content object
-                                duration_secs = None
-                                if hasattr(content_obj, 'duration_secs') and content_obj.duration_secs:
+                                duration_secs = source_metadata.get('duration_secs')
+                                if not duration_secs and hasattr(content_obj, 'duration_secs') and content_obj.duration_secs:
                                     duration_secs = content_obj.duration_secs
 
                                 # If we don't have duration_secs, estimate for episodes
@@ -1193,18 +1281,22 @@ def build_vod_stats_data(redis_client):
 
                                 content_metadata = {
                                     'series_name': content_obj.series.name,
-                                    'episode_name': content_obj.name,
+                                    'episode_name': episode_name,
                                     'season_number': content_obj.season_number,
                                     'episode_number': content_obj.episode_number,
                                     'air_date': content_obj.air_date.isoformat() if content_obj.air_date else None,
                                     'rating': content_obj.rating,
                                     'duration_secs': duration_secs,
-                                    'description': content_obj.description,
+                                    'description': source_metadata.get('description') or content_obj.description,
                                     'logo_url': content_obj.series.logo.url if content_obj.series.logo else None,
                                     'series_year': content_obj.series.year,
                                     'series_genre': content_obj.series.genre,
                                     'tmdb_id': content_obj.tmdb_id,
-                                    'imdb_id': content_obj.imdb_id
+                                    'imdb_id': content_obj.imdb_id,
+                                    'm3u_account_name': source_metadata.get('m3u_account_name'),
+                                    'category_name': source_metadata.get('category_name'),
+                                    'stream_id': source_metadata.get('stream_id'),
+                                    'relation_id': source_metadata.get('relation_id'),
                                 }
                         except:
                             pass
@@ -1296,7 +1388,8 @@ def build_vod_stats_data(redis_client):
                             'last_seek_byte': int(combined_data.get('last_seek_byte', 0)),
                             'last_seek_percentage': float(combined_data.get('last_seek_percentage', 0.0)),
                             'total_content_size': int(combined_data.get('total_content_size', 0)),
-                            'last_seek_timestamp': float(combined_data.get('last_seek_timestamp', 0.0))
+                            'last_seek_timestamp': float(combined_data.get('last_seek_timestamp', 0.0)),
+                            'source_metadata': source_metadata,
                         }
 
                         # Calculate connection duration
@@ -1341,7 +1434,10 @@ def build_vod_stats_data(redis_client):
         # Group connections by content
         content_stats = {}
         for conn in connections:
-            content_key = f"{conn['content_type']}:{conn['content_uuid']}"
+            source_key = conn.get('source_metadata', {}).get('source_key', '')
+            content_key = (
+                f"{conn['content_type']}:{conn['content_uuid']}:{source_key}"
+            )
             if content_key not in content_stats:
                 content_stats[content_key] = {
                     'content_type': conn['content_type'],

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -14,6 +14,7 @@ from django.http import JsonResponse, Http404, HttpResponse, HttpResponseRedirec
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from apps.vod.models import Movie, Series, Episode, M3UMovieRelation, M3UEpisodeRelation
+from apps.vod.utils import get_series_display_name as _get_series_display_name
 from apps.m3u.models import M3UAccountProfile
 from apps.proxy.vod_proxy.multi_worker_connection_manager import MultiWorkerVODConnectionManager, infer_content_type_from_url, get_vod_client_stop_key
 from .utils import get_client_info
@@ -233,33 +234,6 @@ def _select_vod_stream(
         }
 
     return None
-
-
-def _get_series_display_name(series, series_relation=None):
-    """Return the clean metadata title while preserving the provider title."""
-    metadata_sources = [getattr(series, "custom_properties", None)]
-    relation_properties = (
-        getattr(series_relation, "custom_properties", None) or {}
-    )
-    if isinstance(relation_properties, dict):
-        metadata_sources.extend([
-            relation_properties.get("detailed_info"),
-            relation_properties.get("basic_data"),
-        ])
-
-    for metadata in metadata_sources:
-        if not isinstance(metadata, dict):
-            continue
-        for field in ("original_name", "o_name"):
-            value = metadata.get(field)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-            if isinstance(value, (list, tuple)):
-                for item in value:
-                    if isinstance(item, str) and item.strip():
-                        return item.strip()
-
-    return series.name
 
 
 def _build_vod_source_metadata(content_type, content_obj, relation):

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -99,7 +99,14 @@ def _find_idle_vod_session(
         return None
 
 
-def _vod_session_path_redirect(request, session_id, profile_id=None, user=None):
+def _vod_session_path_redirect(
+    request,
+    session_id,
+    profile_id=None,
+    user=None,
+    preferred_m3u_account_id=None,
+    preferred_stream_id=None,
+):
     """
     301 to the same VOD URL with session_id in the path (or XC query string).
 
@@ -109,6 +116,10 @@ def _vod_session_path_redirect(request, session_id, profile_id=None, user=None):
     query_params = dict(request.GET)
     query_params.pop("session_id", None)
     query_params.pop("token", None)
+    if preferred_m3u_account_id is not None:
+        query_params["m3u_account_id"] = preferred_m3u_account_id
+    if preferred_stream_id is not None:
+        query_params["stream_id"] = preferred_stream_id
 
     is_vod_proxy_path = request.path.startswith("/proxy/vod/")
 
@@ -284,7 +295,16 @@ def _get_content_and_relation(content_type, content_id, preferred_m3u_account_id
 
             if preferred_stream_id:
                 specific_relation = next(
-                    (r for r in candidates if str(r.stream_id) == str(preferred_stream_id)), None)
+                    (
+                        r for r in candidates
+                        if str(r.stream_id) == str(preferred_stream_id)
+                        and (
+                            not preferred_m3u_account_id
+                            or r.m3u_account_id == preferred_m3u_account_id
+                        )
+                    ),
+                    None,
+                )
                 if specific_relation:
                     logger.info(f"[STREAM-SELECTED] Using specific stream: {specific_relation.stream_id} from provider: {specific_relation.m3u_account.name}")
                     return content_obj, specific_relation, candidates
@@ -359,7 +379,16 @@ def _get_content_and_relation(content_type, content_id, preferred_m3u_account_id
 
             if preferred_stream_id:
                 specific_relation = next(
-                    (r for r in candidates if str(r.stream_id) == str(preferred_stream_id)), None)
+                    (
+                        r for r in candidates
+                        if str(r.stream_id) == str(preferred_stream_id)
+                        and (
+                            not preferred_m3u_account_id
+                            or r.m3u_account_id == preferred_m3u_account_id
+                        )
+                    ),
+                    None,
+                )
                 if specific_relation:
                     logger.info(f"[STREAM-SELECTED] Using specific stream: {specific_relation.stream_id} from provider: {specific_relation.m3u_account.name}")
                     return content_obj, specific_relation, candidates
@@ -610,7 +639,16 @@ def _transform_url(original_url, m3u_profile):
 @api_view(["GET"])
 @authentication_classes([JWTAuthentication, ApiKeyAuthentication, QueryParamJWTAuthentication])
 @permission_classes([AllowAny])
-def stream_vod(request, content_type, content_id, session_id=None, profile_id=None, user=None):
+def stream_vod(
+    request,
+    content_type,
+    content_id,
+    session_id=None,
+    profile_id=None,
+    user=None,
+    preferred_m3u_account_id=None,
+    preferred_stream_id=None,
+):
     """
     Stream VOD content (movies or series episodes) with session-based connection reuse
 
@@ -619,6 +657,8 @@ def stream_vod(request, content_type, content_id, session_id=None, profile_id=No
         content_id: ID of the content
         session_id: Optional session ID from URL path (for persistent connections)
         profile_id: Optional M3U profile ID for authentication
+        preferred_m3u_account_id: Optional exact upstream account selection
+        preferred_stream_id: Optional exact upstream stream selection
     """
     if not network_access_allowed(request, "STREAMS"):
         return JsonResponse({"error": "Forbidden"}, status=403)
@@ -698,9 +738,11 @@ def stream_vod(request, content_type, content_id, session_id=None, profile_id=No
 
         from core.models import CoreSettings
 
-        preferred_m3u_account_id, preferred_stream_id = _parse_preferred_vod_params(
-            request
-        )
+        request_account_id, request_stream_id = _parse_preferred_vod_params(request)
+        if preferred_m3u_account_id is None:
+            preferred_m3u_account_id = request_account_id
+        if preferred_stream_id is None:
+            preferred_stream_id = request_stream_id
 
         # First request (no session_id): decide Redirect vs mint. The idle
         # fingerprint match (ip/user-agent/content, same as the connection
@@ -731,7 +773,12 @@ def stream_vod(request, content_type, content_id, session_id=None, profile_id=No
                         matched_session_id,
                     )
                     return _vod_session_path_redirect(
-                        request, matched_session_id, profile_id=profile_id, user=user
+                        request,
+                        matched_session_id,
+                        profile_id=profile_id,
+                        user=user,
+                        preferred_m3u_account_id=preferred_m3u_account_id,
+                        preferred_stream_id=preferred_stream_id,
                     )
 
                 # 301 to provider (no session mint, no slot hold, no probe).
@@ -760,7 +807,12 @@ def stream_vod(request, content_type, content_id, session_id=None, profile_id=No
             new_session_id = f"vod_{int(time.time() * 1000)}_{random.randint(1000, 9999)}"
             logger.info(f"[VOD-SESSION] Creating new session: {new_session_id}")
             return _vod_session_path_redirect(
-                request, new_session_id, profile_id=profile_id, user=user
+                request,
+                new_session_id,
+                profile_id=profile_id,
+                user=user,
+                preferred_m3u_account_id=preferred_m3u_account_id,
+                preferred_stream_id=preferred_stream_id,
             )
 
         # Resolve user from Redis session mapping when the streaming request
@@ -1443,12 +1495,24 @@ def stream_xc_episode(request, username, password, stream_id, extension):
     if custom_properties["xc_password"] != password:
         return Response({"error": "Invalid credentials"}, status=401)
 
-    # All authenticated users get access to series/episodes from all active M3U accounts
-    filters = {"episode_id": stream_id, "m3u_account__is_active": True}
-
-    try:
-        episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-    except M3UEpisodeRelation.DoesNotExist:
+    # xc_get_series_info exposes the concrete episode-relation ID. Resolving
+    # that same row here preserves the category/provider selected by the player.
+    episode_relation = M3UEpisodeRelation.objects.select_related(
+        'episode', 'm3u_account'
+    ).filter(
+        id=stream_id,
+        m3u_account__is_active=True
+    ).first()
+    if not episode_relation:
         return JsonResponse({"error": "Episode not found"}, status=404)
 
-    return stream_vod(request._request, 'episode', episode_relation.episode.uuid, session_id, profile_id, user)
+    return stream_vod(
+        request._request,
+        'episode',
+        episode_relation.episode.uuid,
+        session_id,
+        profile_id,
+        user,
+        preferred_m3u_account_id=episode_relation.m3u_account_id,
+        preferred_stream_id=episode_relation.stream_id,
+    )

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -1572,18 +1572,27 @@ def stream_xc_movie(request, username, password, stream_id, extension):
     if custom_properties["xc_password"] != password:
         return Response({"error": "Invalid credentials"}, status=401)
 
-    # All authenticated users get access to VOD from all active M3U accounts
-    filters = {"movie_id": stream_id, "m3u_account__is_active": True}
-
-    try:
-        # Order by account priority to get the best relation when multiple exist
-        movie_relation = M3UMovieRelation.objects.select_related('movie').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-        if not movie_relation:
-            return JsonResponse({"error": "Movie not found"}, status=404)
-    except (M3UMovieRelation.DoesNotExist, M3UMovieRelation.MultipleObjectsReturned):
+    # xc_get_vod_streams exposes the concrete movie-relation ID. Resolving
+    # that same row here preserves the category/provider selected by the player.
+    movie_relation = M3UMovieRelation.objects.select_related(
+        'movie', 'm3u_account'
+    ).filter(
+        id=stream_id,
+        m3u_account__is_active=True,
+    ).first()
+    if not movie_relation:
         return JsonResponse({"error": "Movie not found"}, status=404)
 
-    return stream_vod(request._request, 'movie', movie_relation.movie.uuid, session_id, profile_id, user)
+    return stream_vod(
+        request._request,
+        'movie',
+        movie_relation.movie.uuid,
+        session_id,
+        profile_id,
+        user,
+        preferred_m3u_account_id=movie_relation.m3u_account_id,
+        preferred_stream_id=movie_relation.stream_id,
+    )
 
 @api_view(["GET"])
 @permission_classes([AllowAny])

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -233,17 +233,52 @@ def _select_vod_stream(
         }
 
     return None
+
+
+def _get_series_display_name(series, series_relation=None):
+    """Return the clean metadata title while preserving the provider title."""
+    metadata_sources = [getattr(series, "custom_properties", None)]
+    relation_properties = (
+        getattr(series_relation, "custom_properties", None) or {}
+    )
+    if isinstance(relation_properties, dict):
+        metadata_sources.extend([
+            relation_properties.get("detailed_info"),
+            relation_properties.get("basic_data"),
+        ])
+
+    for metadata in metadata_sources:
+        if not isinstance(metadata, dict):
+            continue
+        for field in ("original_name", "o_name"):
+            value = metadata.get(field)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if isinstance(value, (list, tuple)):
+                for item in value:
+                    if isinstance(item, str) and item.strip():
+                        return item.strip()
+
+    return series.name
+
+
 def _build_vod_source_metadata(content_type, content_obj, relation):
     """Describe the exact upstream relation selected for a VOD session."""
     category = None
     episode_name = getattr(content_obj, "name", "Unknown")
     description = getattr(content_obj, "description", None)
     duration_secs = getattr(content_obj, "duration_secs", None)
+    series_display_name = None
 
     if content_type in ("episode", "series"):
         series_relation = getattr(relation, "series_relation", None)
         if series_relation:
             category = getattr(series_relation, "category", None)
+        series = getattr(content_obj, "series", None)
+        if series:
+            series_display_name = _get_series_display_name(
+                series, series_relation
+            )
 
         relation_props = getattr(relation, "custom_properties", None) or {}
         provider_episode = relation_props.get("info") or {}
@@ -279,6 +314,7 @@ def _build_vod_source_metadata(content_type, content_obj, relation):
         "category_id": getattr(category, "id", None),
         "category_name": getattr(category, "name", None),
         "episode_name": episode_name if relation_type == "episode" else None,
+        "series_display_name": series_display_name,
         "description": description,
         "duration_secs": duration_secs,
     }
@@ -1267,7 +1303,14 @@ def build_vod_stats_data(redis_client):
                                     source_metadata.get('episode_name')
                                     or content_obj.name
                                 )
-                                content_name = f"{content_obj.series.name} - {episode_name}"
+                                series_display_name = _get_series_display_name(
+                                    content_obj.series
+                                )
+                                series_display_name = (
+                                    source_metadata.get('series_display_name')
+                                    or series_display_name
+                                )
+                                content_name = f"{series_display_name} - {episode_name}"
 
                                 # Get duration from content object
                                 duration_secs = source_metadata.get('duration_secs')
@@ -1281,6 +1324,7 @@ def build_vod_stats_data(redis_client):
 
                                 content_metadata = {
                                     'series_name': content_obj.series.name,
+                                    'series_display_name': series_display_name,
                                     'episode_name': episode_name,
                                     'season_number': content_obj.season_number,
                                     'episode_number': content_obj.episode_number,

--- a/apps/vod/api_views.py
+++ b/apps/vod/api_views.py
@@ -366,7 +366,9 @@ class SeriesViewSet(viewsets.ReadOnlyModelViewSet):
         relations = M3USeriesRelation.objects.filter(
             series=series,
             m3u_account__is_active=True
-        ).select_related('m3u_account', 'category')
+        ).select_related('m3u_account', 'category').order_by(
+            '-m3u_account__priority', 'id'
+        )
 
         serializer = M3USeriesRelationSerializer(relations, many=True)
         return Response(serializer.data)
@@ -445,9 +447,21 @@ class SeriesViewSet(viewsets.ReadOnlyModelViewSet):
             custom_props = relation.custom_properties or {}
             episodes_fetched = custom_props.get('episodes_fetched', False)
             detailed_fetched = custom_props.get('detailed_fetched', False)
+            missing_episode_links = (
+                episodes_fetched
+                and series.episodes.exists()
+                and not M3UEpisodeRelation.objects.filter(
+                    series_relation=relation
+                ).exists()
+            )
 
             # Force refresh if episodes have never been fetched or if forced
-            if not episodes_fetched or not detailed_fetched or force_refresh:
+            if (
+                not episodes_fetched
+                or not detailed_fetched
+                or missing_episode_links
+                or force_refresh
+            ):
                 force_refresh = True
                 logger.debug(f"Series {series.id} needs detailed/episode refresh, forcing refresh")
             elif last_refreshed is None or (now - last_refreshed) > timedelta(hours=refresh_interval_hours):
@@ -531,50 +545,70 @@ class SeriesViewSet(viewsets.ReadOnlyModelViewSet):
             include_episodes = request.query_params.get('include_episodes', 'true').lower() == 'true'
             if include_episodes and custom_props.get('episodes_fetched', False):
                 logger.debug(f"Including episodes for series {series.id}")
-                # Only episodes this provider actually has streams for. Shared Series
-                # rows can include specials/seasons from another account.
-                relations_by_episode_id = {
-                    rel.episode_id: rel
-                    for rel in M3UEpisodeRelation.objects.filter(
-                        m3u_account_id=relation.m3u_account_id,
-                        episode__series_id=series.id,
-                    ).only('episode_id', 'container_extension', 'custom_properties')
-                }
-                episodes = list(
-                    Episode.objects.filter(
-                        id__in=relations_by_episode_id.keys()
-                    ).order_by('season_number', 'episode_number')
-                )
-
                 episodes_by_season = {}
                 episode_image_parts = vod_image_url_parts(request, 'episode')
-                for episode in episodes:
+                # A shared Series may contain episodes from several providers or
+                # categories. Keep the selected series relation all the way through
+                # the episode list so only its actual upstream streams are returned.
+                episode_relations = M3UEpisodeRelation.objects.filter(
+                    series_relation=relation,
+                    m3u_account__is_active=True
+                ).select_related('episode').order_by(
+                    'episode__season_number', 'episode__episode_number', 'id'
+                )
+
+                for episode_relation in episode_relations:
+                    episode = episode_relation.episode
                     season_key = str(
-                        episode.season_number if episode.season_number is not None else 0
+                        episode.season_number
+                        if episode.season_number is not None else 0
                     )
                     if season_key not in episodes_by_season:
                         episodes_by_season[season_key] = []
 
-                    episode_relation = relations_by_episode_id.get(episode.id)
+                    relation_props = episode_relation.custom_properties or {}
+                    provider_episode = relation_props.get('info') or {}
+                    if not isinstance(provider_episode, dict):
+                        provider_episode = {}
+                    provider_info = provider_episode.get('info') or {}
+                    if not isinstance(provider_info, dict):
+                        provider_info = {}
+                    episode_title = (
+                        provider_episode.get('title')
+                        or provider_info.get('name')
+                        or episode.name
+                    )
+                    episode_description = (
+                        provider_info.get('plot')
+                        or provider_info.get('overview')
+                        or episode.description
+                    )
+
                     episode_artwork = prefer_relation_artwork(
-                        episode_relation.custom_properties if episode_relation else None,
+                        relation_props,
                         episode.custom_properties,
                     )
                     raw_episode_image = episode_artwork['movie_image']
                     episode_data = {
                         'id': episode.id,
+                        'relation_id': episode_relation.id,
+                        'stream_id': episode_relation.stream_id,
                         'uuid': episode.uuid,
-                        'name': episode.name,
-                        'title': episode.name,
-                        'episode_number': episode.episode_number,
+                        'name': episode_title,
+                        'title': episode_title,
+                        'episode_number': provider_episode.get(
+                            'episode_num', episode.episode_number
+                        ),
                         'season_number': episode.season_number,
-                        'description': episode.description,
-                        'air_date': episode.air_date,
-                        'plot': episode.description,
-                        'duration_secs': episode.duration_secs,
-                        'rating': episode.rating,
-                        'tmdb_id': episode.tmdb_id,
-                        'imdb_id': episode.imdb_id,
+                        'description': episode_description,
+                        'air_date': provider_info.get('air_date') or episode.air_date,
+                        'plot': episode_description,
+                        'duration_secs': provider_info.get(
+                            'duration_secs', episode.duration_secs
+                        ),
+                        'rating': provider_info.get('rating') or episode.rating,
+                        'tmdb_id': provider_info.get('tmdb_id') or episode.tmdb_id,
+                        'imdb_id': provider_info.get('imdb_id') or episode.imdb_id,
                         'movie_image': rewrite_single_image_url(
                             request,
                             'episode',
@@ -584,10 +618,7 @@ class SeriesViewSet(viewsets.ReadOnlyModelViewSet):
                             url_parts=episode_image_parts,
                             m3u_account_id=account_id,
                         ),
-                        'container_extension': (
-                            episode_relation.container_extension
-                            if episode_relation else 'mp4'
-                        ),
+                        'container_extension': episode_relation.container_extension or 'mp4',
                         'type': 'episode',
                         'series': {
                             'id': series.id,

--- a/apps/vod/api_views.py
+++ b/apps/vod/api_views.py
@@ -38,6 +38,7 @@ from .image_proxy import (
     vodlogo_cache_url,
 )
 from .tasks import refresh_series_episodes, refresh_movie_advanced_data
+from .utils import get_series_display_name, get_series_original_name
 from django.utils import timezone
 from datetime import timedelta
 
@@ -447,6 +448,7 @@ class SeriesViewSet(viewsets.ReadOnlyModelViewSet):
             custom_props = relation.custom_properties or {}
             episodes_fetched = custom_props.get('episodes_fetched', False)
             detailed_fetched = custom_props.get('detailed_fetched', False)
+            detailed_info_stored = 'detailed_info' in custom_props
             missing_episode_links = (
                 episodes_fetched
                 and series.episodes.exists()
@@ -459,6 +461,7 @@ class SeriesViewSet(viewsets.ReadOnlyModelViewSet):
             if (
                 not episodes_fetched
                 or not detailed_fetched
+                or not detailed_info_stored
                 or missing_episode_links
                 or force_refresh
             ):
@@ -513,7 +516,8 @@ class SeriesViewSet(viewsets.ReadOnlyModelViewSet):
             response_data = {
                 'id': series.id,
                 'series_id': relation.external_series_id,
-                'name': series.name,
+                'name': get_series_display_name(series, relation),
+                'o_name': get_series_original_name(series, relation) or '',
                 'description': series.description,
                 'year': series.year,
                 'genre': series.genre,

--- a/apps/vod/tasks.py
+++ b/apps/vod/tasks.py
@@ -1324,6 +1324,7 @@ def parse_date(date_string):
 def refresh_series_episodes(account, series, external_series_id, episodes_data=None):
     """Refresh episodes for a series - only called on-demand"""
     try:
+        detailed_info = None
         if not episodes_data:
             # Fetch detailed series info including episodes
             with XtreamCodesClient(
@@ -1335,7 +1336,17 @@ def refresh_series_episodes(account, series, external_series_id, episodes_data=N
                 series_info = client.get_series_info(external_series_id)
                 if series_info:
                     # Update series with detailed info
-                    info = series_info.get('info', {})
+                    info = series_info.get('info') or {}
+                    if isinstance(info, list):
+                        info = (
+                            info[0]
+                            if info and isinstance(info[0], dict)
+                            else {}
+                        )
+                    elif not isinstance(info, dict):
+                        info = {}
+
+                    detailed_info = clean_custom_properties(info) or {}
                     if info:
                         # Only update fields if new value is non-empty and either no existing value or existing value is empty
                         updated = False
@@ -1374,6 +1385,8 @@ def refresh_series_episodes(account, series, external_series_id, episodes_data=N
 
         if series_relation:
             custom_props = series_relation.custom_properties or {}
+            if detailed_info is not None:
+                custom_props['detailed_info'] = detailed_info
             custom_props['episodes_fetched'] = True
             custom_props['detailed_fetched'] = True
             series_relation.custom_properties = custom_props

--- a/apps/vod/tests.py
+++ b/apps/vod/tests.py
@@ -1,0 +1,114 @@
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.accounts.models import User
+from apps.m3u.models import M3UAccount
+from apps.vod.api_views import SeriesViewSet
+from apps.vod.models import (
+    Episode,
+    M3UEpisodeRelation,
+    M3USeriesRelation,
+    Series,
+    VODCategory,
+)
+
+
+class SeriesProviderInfoTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(
+            username="series-api-user",
+            password="password",
+        )
+        self.account = M3UAccount.objects.create(
+            name="Shared provider",
+            server_url="http://example.com",
+            is_active=True,
+        )
+        self.netflix = VODCategory.objects.create(
+            name="NETFLIX Kids", category_type="series"
+        )
+        self.german = VODCategory.objects.create(
+            name="German Kinder", category_type="series"
+        )
+        self.series = Series.objects.create(name="Avatar", year=2005)
+        relation_defaults = {
+            "m3u_account": self.account,
+            "series": self.series,
+            "custom_properties": {
+                "episodes_fetched": True,
+                "detailed_fetched": True,
+            },
+            "last_episode_refresh": timezone.now(),
+        }
+        self.netflix_series = M3USeriesRelation.objects.create(
+            **relation_defaults,
+            category=self.netflix,
+            external_series_id="netflix-avatar",
+        )
+        self.german_series = M3USeriesRelation.objects.create(
+            **relation_defaults,
+            category=self.german,
+            external_series_id="german-avatar",
+        )
+        episode = Episode.objects.create(
+            series=self.series,
+            season_number=1,
+            episode_number=1,
+            name="Canonical title",
+        )
+        M3UEpisodeRelation.objects.create(
+            m3u_account=self.account,
+            episode=episode,
+            series_relation=self.netflix_series,
+            stream_id="netflix-episode-1",
+            custom_properties={
+                "info": {
+                    "episode_num": 1,
+                    "title": "NF - The Boy in the Iceberg",
+                    "info": {"plot": "Netflix plot"},
+                }
+            },
+        )
+        self.german_episode = M3UEpisodeRelation.objects.create(
+            m3u_account=self.account,
+            episode=episode,
+            series_relation=self.german_series,
+            stream_id="german-episode-1",
+            custom_properties={
+                "info": {
+                    "episode_num": 1,
+                    "title": "DE - Der Junge im Eisberg",
+                    "info": {"plot": "German plot"},
+                }
+            },
+        )
+
+    def _get(self, action, params=None):
+        request = self.factory.get("/api/vod/series/1/", params or {})
+        force_authenticate(request, user=self.user)
+        view = SeriesViewSet.as_view({"get": action})
+        return view(request, pk=self.series.id)
+
+    def test_provider_info_uses_selected_series_relation_for_episode_data(self):
+        response = self._get(
+            "series_info", {"relation_id": self.german_series.id}
+        )
+        selected_episode = response.data["episodes"]["1"][0]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["category_name"], "German Kinder")
+        self.assertEqual(selected_episode["relation_id"], self.german_episode.id)
+        self.assertEqual(selected_episode["stream_id"], "german-episode-1")
+        self.assertEqual(selected_episode["title"], "DE - Der Junge im Eisberg")
+        self.assertEqual(selected_episode["plot"], "German plot")
+
+    def test_provider_list_includes_category_for_each_relation(self):
+        response = self._get("get_providers")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [provider["category"]["name"] for provider in response.data],
+            ["NETFLIX Kids", "German Kinder"],
+        )

--- a/apps/vod/tests.py
+++ b/apps/vod/tests.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIRequestFactory, force_authenticate
@@ -12,6 +15,7 @@ from apps.vod.models import (
     Series,
     VODCategory,
 )
+from apps.vod.tasks import refresh_series_episodes
 
 
 class SeriesProviderInfoTests(TestCase):
@@ -32,7 +36,10 @@ class SeriesProviderInfoTests(TestCase):
         self.german = VODCategory.objects.create(
             name="German Kinder", category_type="series"
         )
-        self.series = Series.objects.create(name="Avatar", year=2005)
+        self.series = Series.objects.create(
+            name="DE - Avatar: Der Herr der Elemente (US)",
+            year=2005,
+        )
         relation_defaults = {
             "m3u_account": self.account,
             "series": self.series,
@@ -52,6 +59,24 @@ class SeriesProviderInfoTests(TestCase):
             category=self.german,
             external_series_id="german-avatar",
         )
+        self.netflix_series.custom_properties = {
+            "episodes_fetched": True,
+            "detailed_fetched": True,
+            "detailed_info": {
+                "name": "Avatar: The Last Airbender",
+                "o_name": "Avatar: The Last Airbender",
+            },
+        }
+        self.netflix_series.save(update_fields=["custom_properties"])
+        self.german_series.custom_properties = {
+            "episodes_fetched": True,
+            "detailed_fetched": True,
+            "detailed_info": {
+                "name": "Avatar: Der Herr der Elemente (US)",
+                "o_name": "Avatar: The Last Airbender",
+            },
+        }
+        self.german_series.save(update_fields=["custom_properties"])
         episode = Episode.objects.create(
             series=self.series,
             season_number=1,
@@ -99,6 +124,11 @@ class SeriesProviderInfoTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["category_name"], "German Kinder")
+        self.assertEqual(
+            response.data["name"],
+            "Avatar: Der Herr der Elemente (US)",
+        )
+        self.assertEqual(response.data["o_name"], "Avatar: The Last Airbender")
         self.assertEqual(selected_episode["relation_id"], self.german_episode.id)
         self.assertEqual(selected_episode["stream_id"], "german-episode-1")
         self.assertEqual(selected_episode["title"], "DE - Der Junge im Eisberg")
@@ -112,3 +142,116 @@ class SeriesProviderInfoTests(TestCase):
             [provider["category"]["name"] for provider in response.data],
             ["NETFLIX Kids", "German Kinder"],
         )
+
+    def test_provider_info_preserves_raw_series_name_as_final_fallback(self):
+        self.german_series.custom_properties = {
+            "episodes_fetched": True,
+            "detailed_fetched": True,
+            "detailed_info": {},
+        }
+        self.german_series.save(update_fields=["custom_properties"])
+
+        response = self._get(
+            "series_info", {"relation_id": self.german_series.id}
+        )
+
+        self.assertEqual(
+            response.data["name"],
+            "DE - Avatar: Der Herr der Elemente (US)",
+        )
+
+    def test_provider_info_backfills_details_missing_from_older_relations(self):
+        self.german_series.custom_properties = {
+            "episodes_fetched": True,
+            "detailed_fetched": True,
+        }
+        self.german_series.save(update_fields=["custom_properties"])
+
+        def store_details(_account, _series, _external_series_id):
+            self.german_series.custom_properties = {
+                "episodes_fetched": True,
+                "detailed_fetched": True,
+                "detailed_info": {
+                    "name": "Avatar: Der Herr der Elemente (US)"
+                },
+            }
+            self.german_series.save(update_fields=["custom_properties"])
+
+        with patch(
+            "apps.vod.tasks.refresh_series_episodes",
+            side_effect=store_details,
+        ) as refresh:
+            response = self._get(
+                "series_info", {"relation_id": self.german_series.id}
+            )
+
+        refresh.assert_called_once()
+        self.assertEqual(
+            response.data["name"],
+            "Avatar: Der Herr der Elemente (US)",
+        )
+
+
+class SeriesRefreshDetailsTests(TestCase):
+    def setUp(self):
+        self.account = M3UAccount.objects.create(
+            name="Series detail provider",
+            server_url="http://example.com",
+            username="user",
+            password="password",
+            account_type=M3UAccount.Types.XC,
+            is_active=True,
+        )
+        self.series = Series.objects.create(
+            name="NF - Avatar: The Last Airbender",
+            year=2005,
+        )
+        self.relation = M3USeriesRelation.objects.create(
+            m3u_account=self.account,
+            series=self.series,
+            external_series_id="avatar-netflix",
+            custom_properties={"basic_data": {"name": self.series.name}},
+        )
+
+    def test_refresh_stores_relation_specific_series_details(self):
+        client = MagicMock()
+        client.get_series_info.return_value = {
+            "info": {
+                "name": "Avatar: The Last Airbender",
+                "o_name": "Avatar: The Last Airbender",
+                "plot": "Provider plot",
+            },
+            "episodes": {},
+        }
+        client_context = MagicMock()
+        client_context.__enter__.return_value = client
+
+        with (
+            patch.object(
+                self.account,
+                "get_user_agent",
+                return_value=SimpleNamespace(user_agent="Test Agent"),
+            ),
+            patch(
+                "apps.vod.tasks.XtreamCodesClient",
+                return_value=client_context,
+            ),
+            patch("apps.vod.tasks.batch_process_episodes"),
+        ):
+            refresh_series_episodes(
+                self.account,
+                self.series,
+                self.relation.external_series_id,
+            )
+
+        self.relation.refresh_from_db()
+        self.assertEqual(
+            self.relation.custom_properties["detailed_info"]["name"],
+            "Avatar: The Last Airbender",
+        )
+        self.assertEqual(
+            self.relation.custom_properties["detailed_info"]["o_name"],
+            "Avatar: The Last Airbender",
+        )
+        self.assertTrue(self.relation.custom_properties["episodes_fetched"])
+        self.assertTrue(self.relation.custom_properties["detailed_fetched"])

--- a/apps/vod/tests/test_series_category_selection.py
+++ b/apps/vod/tests/test_series_category_selection.py
@@ -1,3 +1,5 @@
+"""Regression tests for relation-specific series selection."""
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 

--- a/apps/vod/utils.py
+++ b/apps/vod/utils.py
@@ -1,0 +1,49 @@
+def _first_text(*values):
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                if isinstance(item, str) and item.strip():
+                    return item.strip()
+    return None
+
+
+def _relation_metadata(series_relation):
+    properties = getattr(series_relation, "custom_properties", None) or {}
+    if not isinstance(properties, dict):
+        return {}, {}
+
+    detailed_info = properties.get("detailed_info") or {}
+    basic_data = properties.get("basic_data") or {}
+    return (
+        detailed_info if isinstance(detailed_info, dict) else {},
+        basic_data if isinstance(basic_data, dict) else {},
+    )
+
+
+def get_series_original_name(series, series_relation=None):
+    """Return provider metadata's original title without guessing prefixes."""
+    detailed_info, basic_data = _relation_metadata(series_relation)
+    series_properties = getattr(series, "custom_properties", None) or {}
+    if not isinstance(series_properties, dict):
+        series_properties = {}
+
+    return _first_text(
+        detailed_info.get("original_name"),
+        detailed_info.get("o_name"),
+        basic_data.get("original_name"),
+        basic_data.get("o_name"),
+        series_properties.get("original_name"),
+        series_properties.get("o_name"),
+    )
+
+
+def get_series_display_name(series, series_relation=None):
+    """Mirror movie title selection using relation-specific provider details."""
+    detailed_info, _basic_data = _relation_metadata(series_relation)
+    return (
+        _first_text(detailed_info.get("name"))
+        or get_series_original_name(series, series_relation)
+        or series.name
+    )

--- a/apps/vod/utils.py
+++ b/apps/vod/utils.py
@@ -9,8 +9,20 @@ def _first_text(*values):
     return None
 
 
-def _relation_metadata(series_relation):
-    properties = getattr(series_relation, "custom_properties", None) or {}
+def _relation_properties(relation_or_properties):
+    if isinstance(relation_or_properties, dict):
+        return relation_or_properties
+
+    properties = getattr(
+        relation_or_properties,
+        "custom_properties",
+        None,
+    ) or {}
+    return properties if isinstance(properties, dict) else {}
+
+
+def _relation_metadata(relation_or_properties):
+    properties = _relation_properties(relation_or_properties)
     if not isinstance(properties, dict):
         return {}, {}
 
@@ -19,6 +31,32 @@ def _relation_metadata(series_relation):
     return (
         detailed_info if isinstance(detailed_info, dict) else {},
         basic_data if isinstance(basic_data, dict) else {},
+    )
+
+
+def get_vod_source_name(relation_or_properties, fallback_name):
+    """Return the exact provider-list title for a movie or series relation.
+
+    ``basic_data.name`` is captured from the provider's get_vod_streams or
+    get_series response and therefore retains source prefixes such as NF, DE,
+    or NICK. Detailed metadata is only a fallback because providers commonly
+    return a cleaned title there.
+    """
+    properties = _relation_properties(relation_or_properties)
+    detailed_info, basic_data = _relation_metadata(properties)
+    movie_data = properties.get("movie_data") or {}
+    if not isinstance(movie_data, dict):
+        movie_data = {}
+
+    return _first_text(
+        basic_data.get("name"),
+        movie_data.get("name"),
+        detailed_info.get("name"),
+        detailed_info.get("original_name"),
+        detailed_info.get("o_name"),
+        basic_data.get("original_name"),
+        basic_data.get("o_name"),
+        fallback_name,
     )
 
 

--- a/frontend/src/components/SeriesModal.jsx
+++ b/frontend/src/components/SeriesModal.jsx
@@ -654,7 +654,9 @@ const SeriesModal = ({ series, opened, onClose }) => {
                           <TableTr>
                             <TableTh style={{ width: '60px' }}>Ep</TableTh>
                             <TableTh>Title</TableTh>
-                            <TableTh style={{ width: '80px' }}>Duration</TableTh>
+                            <TableTh style={{ width: '80px' }}>
+                              Duration
+                            </TableTh>
                             <TableTh style={{ width: '60px' }}>Date</TableTh>
                             <TableTh style={{ width: '80px' }}>Action</TableTh>
                           </TableTr>

--- a/frontend/src/components/SeriesModal.jsx
+++ b/frontend/src/components/SeriesModal.jsx
@@ -359,16 +359,21 @@ const SeriesModal = ({ series, opened, onClose }) => {
 
   useEffect(() => {
     if (opened && series) {
+      let cancelled = false;
       const requestId = ++detailsRequestIdRef.current;
+
+      setDetailedSeries(null);
+      setProviders([]);
+      setSelectedProvider(null);
       // Fetch detailed series info which now includes episodes
       setLoadingDetails(true);
       fetchSeriesInfo(series.id)
         .then((details) => {
-          if (detailsRequestIdRef.current !== requestId) return;
+          if (cancelled || requestId !== detailsRequestIdRef.current) return;
           setDetailedSeries(details);
         })
         .catch((error) => {
-          if (detailsRequestIdRef.current !== requestId) return;
+          if (cancelled || requestId !== detailsRequestIdRef.current) return;
           console.warn(
             'Failed to fetch series details, using basic info:',
             error
@@ -376,7 +381,7 @@ const SeriesModal = ({ series, opened, onClose }) => {
           setDetailedSeries(series); // Fallback to basic data
         })
         .finally(() => {
-          if (detailsRequestIdRef.current === requestId) {
+          if (!cancelled && requestId === detailsRequestIdRef.current) {
             setLoadingDetails(false);
           }
         });
@@ -385,18 +390,25 @@ const SeriesModal = ({ series, opened, onClose }) => {
       setLoadingProviders(true);
       fetchSeriesProviders(series.id)
         .then((providersData) => {
+          if (cancelled) return;
           setProviders(providersData);
+          // The backend returns providers in the same priority order used by
+          // the default provider-info request.
           if (providersData.length > 0) {
             setSelectedProvider(providersData[0]);
           }
         })
         .catch((error) => {
           console.error('Failed to fetch series providers:', error);
-          setProviders([]);
+          if (!cancelled) setProviders([]);
         })
         .finally(() => {
-          setLoadingProviders(false);
+          if (!cancelled) setLoadingProviders(false);
         });
+
+      return () => {
+        cancelled = true;
+      };
     }
   }, [opened, series, fetchSeriesInfo, fetchSeriesProviders]);
 
@@ -476,7 +488,7 @@ const SeriesModal = ({ series, opened, onClose }) => {
   };
 
   const onChangeSelectedProvider = (value) => {
-    const provider = providers.find((p) => p.id.toString() === value);
+    const provider = providers.find((p) => p.id.toString() === value) || null;
     setSelectedProvider(provider);
     if (provider) {
       const requestId = ++detailsRequestIdRef.current;
@@ -583,12 +595,15 @@ const SeriesModal = ({ series, opened, onClose }) => {
                   <Group spacing="md">
                     <Badge color="blue" variant="light">
                       {displaySeries.m3u_account.name}
+                      {displaySeries.category_name
+                        ? ` — ${displaySeries.category_name}`
+                        : ''}
                     </Badge>
                   </Group>
                 ) : providers.length === 1 ? (
                   <Group spacing="md">
                     <Badge color="blue" variant="light">
-                      {providers[0].m3u_account.name}
+                      {formatStreamLabel(providers[0])}
                     </Badge>
                     {providers[0].stream_id && (
                       <Badge color="orange" variant="outline" size="xs">

--- a/frontend/src/components/__tests__/SeriesModal.test.jsx
+++ b/frontend/src/components/__tests__/SeriesModal.test.jsx
@@ -212,6 +212,7 @@ describe('SeriesModal', () => {
   const mockEpisode = {
     id: 1,
     uuid: 'episode-uuid-1',
+    stream_id: 'episode-stream-100',
     series_id: 1,
     season_number: 1,
     episode_number: 1,
@@ -234,7 +235,8 @@ describe('SeriesModal', () => {
       id: 1,
       stream_id: 100,
       account_id: 5,
-      m3u_account: { name: 'Provider 1' },
+      m3u_account: { id: 5, name: 'Provider 1' },
+      category: { id: 10, name: 'NETFLIX Kids' },
       stream_name: 'Test Series 1080p',
       quality_info: { quality: '1080p' },
     },
@@ -242,7 +244,8 @@ describe('SeriesModal', () => {
       id: 2,
       stream_id: 101,
       account_id: 5,
-      m3u_account: { name: 'Provider 2' },
+      m3u_account: { id: 5, name: 'Provider 2' },
+      category: { id: 11, name: 'German Kinder' },
       stream_name: 'Test Series 720p',
       quality_info: null,
     },
@@ -461,7 +464,9 @@ describe('SeriesModal', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/Provider 1 - 1080p/)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Provider 1 — NETFLIX Kids - 1080p/)
+        ).toBeInTheDocument();
       });
     });
 
@@ -594,7 +599,7 @@ describe('SeriesModal', () => {
       );
     });
 
-    it('should include provider stream_id in URL when provider selected', async () => {
+    it('should include the selected episode stream_id in the URL', async () => {
       render(
         <SeriesModal series={mockSeries} opened={true} onClose={vi.fn()} />
       );
@@ -610,7 +615,7 @@ describe('SeriesModal', () => {
       });
 
       expect(mockVideoStore.showVideo).toHaveBeenCalledWith(
-        expect.stringContaining('stream_id=100'),
+        expect.stringContaining('stream_id=episode-stream-100'),
         'vod',
         mockEpisode
       );
@@ -764,7 +769,9 @@ describe('SeriesModal', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/Provider 1 - 1080p/)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Provider 1 — NETFLIX Kids - 1080p/)
+        ).toBeInTheDocument();
       });
     });
 
@@ -788,7 +795,9 @@ describe('SeriesModal', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/Provider 1 - 1080p/)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Provider 1 — NETFLIX Kids - 1080p/)
+        ).toBeInTheDocument();
       });
     });
 
@@ -808,7 +817,9 @@ describe('SeriesModal', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/Provider 1 - 720p/)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Provider 1 — NETFLIX Kids - 720p/)
+        ).toBeInTheDocument();
       });
     });
 
@@ -832,7 +843,9 @@ describe('SeriesModal', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/Provider 1 - 4K/)).toBeInTheDocument();
+        expect(
+          screen.getByText(/Provider 1 — NETFLIX Kids - 4K/)
+        ).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/components/__tests__/SeriesModal.test.jsx
+++ b/frontend/src/components/__tests__/SeriesModal.test.jsx
@@ -43,7 +43,7 @@ vi.mock('@mantine/core', async () => {
 
   return {
     ...actual,
-    Modal: ({ opened, onClose, title, children, size, ...props }) => {
+    Modal: ({ opened, onClose, title, children, size }) => {
       if (!opened) return null;
       return (
         <div data-testid="modal" data-title={title} data-size={size}>

--- a/frontend/src/components/cards/VodConnectionCard.jsx
+++ b/frontend/src/components/cards/VodConnectionCard.jsx
@@ -204,6 +204,17 @@ const VodConnectionCard = ({ vodContent, stopVODClient }) => {
   const connection =
     vodContent.individual_connection ||
     (vodContent.connections && vodContent.connections[0]);
+  const sourceMetadata = connection?.source_metadata || {};
+  const sourceAccountName =
+    metadata.m3u_account_name ||
+    sourceMetadata.m3u_account_name ||
+    connection?.m3u_profile?.account_name;
+  const sourceCategoryName =
+    metadata.category_name || sourceMetadata.category_name;
+  const sourceStreamId = metadata.stream_id || sourceMetadata.stream_id;
+  const sourceLabel = [sourceAccountName, sourceCategoryName]
+    .filter(Boolean)
+    .join(' — ');
 
   // Get poster/logo URL
   const posterUrl = metadata.logo_url || logo;
@@ -329,25 +340,36 @@ const VodConnectionCard = ({ vodContent, stopVODClient }) => {
           </Tooltip>
         </Flex>
 
-        {/* Display M3U profile information - matching channel card style */}
+        {/* Display the exact upstream VOD source and connection profile */}
         {connection &&
-          connection.m3u_profile &&
-          (connection.m3u_profile.profile_name ||
-            connection.m3u_profile.account_name) && (
+          (sourceLabel ||
+            sourceStreamId ||
+            connection.m3u_profile?.profile_name) && (
             <Flex justify="flex-end" align="flex-start" mt={-8}>
               <Group gap={5} align="flex-start">
                 <HardDriveUpload size="18" mt={2} />
                 <Stack gap={0}>
-                  <Tooltip label="M3U Account">
-                    <Text size="xs" fw={500}>
-                      {connection.m3u_profile.account_name || 'Unknown Account'}
-                    </Text>
-                  </Tooltip>
-                  <Tooltip label="M3U Profile">
-                    <Text size="xs" c="dimmed">
-                      {connection.m3u_profile.profile_name || 'Default Profile'}
-                    </Text>
-                  </Tooltip>
+                  {sourceLabel && (
+                    <Tooltip label="M3U Account — VOD Category">
+                      <Text size="xs" fw={500}>
+                        {sourceLabel}
+                      </Text>
+                    </Tooltip>
+                  )}
+                  {connection.m3u_profile?.profile_name && (
+                    <Tooltip label="M3U Profile">
+                      <Text size="xs" c="dimmed">
+                        {connection.m3u_profile.profile_name}
+                      </Text>
+                    </Tooltip>
+                  )}
+                  {sourceStreamId && (
+                    <Tooltip label="Upstream Stream ID">
+                      <Text size="xs" c="dimmed">
+                        Stream ID: {sourceStreamId}
+                      </Text>
+                    </Tooltip>
+                  )}
                 </Stack>
               </Group>
             </Flex>

--- a/frontend/src/components/cards/__tests__/VodConnectionCard.test.jsx
+++ b/frontend/src/components/cards/__tests__/VodConnectionCard.test.jsx
@@ -608,6 +608,25 @@ describe('VodConnectionCard', () => {
       );
       expect(screen.queryByText('Main M3U')).not.toBeInTheDocument();
     });
+
+    it('renders the exact VOD account, category, and stream ID', () => {
+      const vodContent = makeEpisodeContent({
+        content_metadata: {
+          ...makeEpisodeContent().content_metadata,
+          m3u_account_name: 'tivione-z2u',
+          category_name: 'NICKELODEON',
+          stream_id: '686164',
+        },
+      });
+
+      render(
+        <VodConnectionCard vodContent={vodContent} stopVODClient={vi.fn()} />
+      );
+
+      expect(screen.getByText('tivione-z2u — NICKELODEON')).toBeInTheDocument();
+      expect(screen.getByText('Main M3U')).toBeInTheDocument();
+      expect(screen.getByText('Stream ID: 686164')).toBeInTheDocument();
+    });
   });
 
   // ── Stop client ────────────────────────────────────────────────────────────

--- a/frontend/src/store/useVODStore.jsx
+++ b/frontend/src/store/useVODStore.jsx
@@ -90,6 +90,8 @@ const getSeriesDetails = (response, seriesId) => {
     o_name: response.o_name || '',
     age: response.age || '',
     m3u_account: response.m3u_account || '',
+    category_id: response.category_id || null,
+    category_name: response.category_name || '',
     youtube_trailer: response.custom_properties?.youtube_trailer || '',
   };
 };
@@ -97,7 +99,8 @@ const getSeriesDetails = (response, seriesId) => {
 const getEpisodeDetails = (episode, seasonNumber, seriesInfo) => {
   return {
     id: episode.id,
-    stream_id: episode.id,
+    stream_id: episode.stream_id || episode.id,
+    relation_id: episode.relation_id || null,
     name: episode.title || '',
     description: episode.plot || '',
     season_number: parseInt(seasonNumber) || 0,

--- a/frontend/src/utils/cards/VodConnectionCardUtils.js
+++ b/frontend/src/utils/cards/VodConnectionCardUtils.js
@@ -11,7 +11,8 @@ export const getEpisodeDisplayTitle = (metadata) => {
   const episode = metadata.episode_number
     ? `E${metadata.episode_number.toString().padStart(2, '0')}`
     : 'E??';
-  return `${metadata.series_name} - ${season}${episode}`;
+  const seriesName = metadata.series_display_name || metadata.series_name;
+  return `${seriesName} - ${season}${episode}`;
 };
 
 export const getMovieSubtitle = (metadata) => {

--- a/frontend/src/utils/cards/__tests__/VodConnectionCardUtils.test.js
+++ b/frontend/src/utils/cards/__tests__/VodConnectionCardUtils.test.js
@@ -22,6 +22,17 @@ describe('VodConnectionCardUtils', () => {
   });
 
   describe('getEpisodeDisplayTitle', () => {
+    it('should prefer the clean metadata series title', () => {
+      const metadata = {
+        series_name: 'DE - Avatar: Der Herr der Elemente (US)',
+        series_display_name: 'Avatar: The Last Airbender',
+        season_number: 3,
+        episode_number: 1,
+      };
+      const result = VodConnectionCardUtils.getEpisodeDisplayTitle(metadata);
+      expect(result).toBe('Avatar: The Last Airbender - S03E01');
+    });
+
     it('should format title with season and episode numbers', () => {
       const metadata = {
         series_name: 'Breaking Bad',

--- a/frontend/src/utils/components/SeriesModalUtils.js
+++ b/frontend/src/utils/components/SeriesModalUtils.js
@@ -16,10 +16,12 @@ export const formatDuration = (seconds) => {
 
 export const formatStreamLabel = (relation) => {
   const provider = relation.m3u_account.name;
+  const category = relation.category?.name || relation.category_name;
   const streamId = relation.stream_id;
   const quality = extractQuality(relation);
+  const source = category ? `${provider} — ${category}` : provider;
 
-  return `${provider}${quality ?? ''}${streamId ? ` (Stream ${streamId})` : ''}`;
+  return `${source}${quality ?? ''}${streamId ? ` (Stream ${streamId})` : ''}`;
 };
 
 const extractQuality = (relation) => {
@@ -132,13 +134,11 @@ export const getEpisodeStreamUrl = (episode, selectedProvider, env_mode) => {
   let streamUrl = `/proxy/vod/episode/${episode.uuid}`;
 
   const params = new URLSearchParams();
-  if (selectedProvider) {
-    if (selectedProvider.stream_id) {
-      params.set('stream_id', selectedProvider.stream_id);
-    } else {
-      params.set('m3u_account_id', selectedProvider.m3u_account.id);
-    }
-  }
+  const streamId = episode.stream_id || selectedProvider?.stream_id;
+  const accountId = selectedProvider?.m3u_account?.id;
+  if (streamId) params.set('stream_id', streamId);
+  if (accountId) params.set('m3u_account_id', accountId);
+
   const token = useAuthStore.getState().accessToken;
   if (token) params.set('token', token);
   if (params.toString())

--- a/frontend/src/utils/components/__tests__/SeriesModalUtils.test.js
+++ b/frontend/src/utils/components/__tests__/SeriesModalUtils.test.js
@@ -78,6 +78,16 @@ describe('SeriesModalUtils', () => {
       expect(formatStreamLabel(relation)).toBe('Provider 1 - 1080p (Stream 100)');
     });
 
+    it('should include the category to distinguish relations from one provider', () => {
+      const relation = {
+        ...baseRelation,
+        category: { id: 7, name: 'German Kinder' }
+      };
+      expect(formatStreamLabel(relation)).toBe(
+        'Provider 1 — German Kinder (Stream 100)'
+      );
+    });
+
     it('should format label with quality from resolution', () => {
       const relation = {
         ...baseRelation,
@@ -310,7 +320,23 @@ describe('SeriesModalUtils', () => {
         m3u_account: { id: 1 }
       };
       const url = getEpisodeStreamUrl(episode, provider, 'prod');
-      expect(url).toBe('https://example.com/proxy/vod/episode/episode-123?stream_id=stream-456');
+      expect(url).toBe(
+        'https://example.com/proxy/vod/episode/episode-123?stream_id=stream-456&m3u_account_id=1'
+      );
+    });
+
+    it('should prefer the selected episode relation stream over the series relation', () => {
+      const episode = {
+        uuid: 'episode-123',
+        stream_id: 'german-episode-456'
+      };
+      const provider = {
+        stream_id: 'series-stream',
+        m3u_account: { id: 1 }
+      };
+      const url = getEpisodeStreamUrl(episode, provider, 'prod');
+      expect(url).toContain('stream_id=german-episode-456');
+      expect(url).toContain('m3u_account_id=1');
     });
 
     it('should generate stream URL with m3u_account_id when no stream_id', () => {


### PR DESCRIPTION
## Description

Preserves the selected Xtream account/category relation when the same movie or
series is imported from multiple enabled VOD categories.

The change:

- exposes one Xtream entry per canonical movie/series and category relation
- uses relation-specific IDs for Xtream list, information and playback requests
- resolves playback against the exact selected account, category and upstream stream
- keeps shared TMDB/IMDB metadata while preserving provider-specific titles
- shows the M3U account and category in the series source selector
- refreshes the episode inventory when another series source is selected
- reports the selected account, category and stream ID in VOD connection statistics

No database models, migrations, dependencies or new API endpoints are introduced.

Changes are done with the support of AI (ChatGPT 5.6 Sol)

## Related Issue

Closes #1443

## How was it tested?

- Tested one canonical series present in three enabled Xtream categories.
- Verified that the Dispatcharr series modal shows all three account/category sources.
- Verified that switching sources in a select series or movie in the VOD Menu changes the provider-specific episode inventory.
- Verified that playback uses the stream ID belonging to the selected category.
- Verified that external player (in my case UHF) receives separate category entries with their provider-specific names.
- Verified movie and series playback through external player (UHF).
- Verified the selected M3U account, category and stream ID in VOD connection statistics.

Automated checks:

- Targeted frontend tests: 171 passed.
- Full frontend Vitest suite completed successfully.
- Vite production build completed successfully.
- ESLint passed for all changed frontend files.
- Prettier passed for the changed production and support files.
- Targeted Django regression suite: 40 passed, 2 PostgreSQL-specific tests skipped under SQLite.
- Python syntax and Git whitespace checks passed.

The current `dev` branch has existing repository-wide ESLint errors and formatting
drift in `SeriesModalUtils.test.js`; unrelated whole-file formatting changes were
deliberately excluded from this PR.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
