### PR TITLE
fix: VOD episode stream 500 crash when episode relation is missing

### DIFF
--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1627,9 +1627,8 @@ def xc_series_stream(request, username, password, stream_id, extension):
     # All authenticated users get access to series/episodes from all active M3U accounts
     filters = {"episode_id": stream_id, "m3u_account__is_active": True}
 
-    try:
-        episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-    except M3UEpisodeRelation.DoesNotExist:
+    episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(**filters).order_by('-m3u_account__priority', 'id').first()
+    if not episode_relation:
         return JsonResponse({"error": "Episode not found"}, status=404)
 
     # Redirect to the VOD proxy endpoint

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -1256,9 +1256,8 @@ def stream_xc_episode(request, username, password, stream_id, extension):
     # All authenticated users get access to series/episodes from all active M3U accounts
     filters = {"episode_id": stream_id, "m3u_account__is_active": True}
 
-    try:
-        episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-    except M3UEpisodeRelation.DoesNotExist:
+    episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(**filters).order_by('-m3u_account__priority', 'id').first()
+    if not episode_relation:
         return JsonResponse({"error": "Episode not found"}, status=404)
 
     return stream_vod(request._request, 'episode', episode_relation.episode.uuid, session_id, profile_id, user)


### PR DESCRIPTION
`stream_xc_episode()` (`apps/proxy/vod_proxy/views.py`) and `xc_series_stream()` (`apps/output/views.py`) both wrap a `.filter(...).first()` lookup in `try/except M3UEpisodeRelation.DoesNotExist`, but `.first()` returns `None` on no match -- it never raises `DoesNotExist`. The except clause is dead code, so a missing/stale `episode_id` crashes with an unhandled `AttributeError` instead of returning the intended 404.

## Steps to reproduce

1. Have any active M3U/XC account with VOD series content.
2. Request `/series/{username}/{password}/{stream_id}.{ext}` using a `stream_id` with no matching `M3UEpisodeRelation` row -- e.g. an episode ID that existed before the account's catalog was refreshed and got reassigned new internal IDs, or any made-up numeric ID.
3. Observe a 500:
   ```
   AttributeError: 'NoneType' object has no attribute 'episode'
   File "apps/proxy/vod_proxy/views.py", line 1264, in stream_xc_episode
   ```
   instead of a 404 JSON response.

This is easy to hit in practice whenever a client (e.g. TiviMate) has cached an episode list and the backing account's VOD catalog is later refreshed with different internal episode IDs -- every subsequent request from that client's stale cache 500s instead of failing cleanly, and some clients can't recover from that without a manual reload/restart.

Related to #820, which reported the same crash signature in `xc_series_stream` -- that function is no longer wired to any URL route in current versions (imported in `apps/output/urls.py` but unused), so #820 stopped reproducing, but the underlying bug was never actually fixed, and the identical pattern is still live and reachable in `stream_xc_episode`.

## Fix

Replace the try/except with a direct `if not episode_relation` check before use, in both functions.

## Verification

Verified against a fresh, disposable `ghcr.io/dispatcharr/dispatcharr:latest` container (no production data involved): before the fix, `GET /series/<user>/<pass>/<bad_id>.mp4` 500s with the traceback above; after the fix, the same request returns a clean 404 `{"error": "Episode not found"}`.
