### PR TITLE
fix: stable VOD episode/movie IDs, fix 500 crash on stale/missing relation

### DIFF
--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -804,7 +804,7 @@ class XcVodSeriesRegressionTests(TestCase):
     def test_vod_streams_response_keys(self):
         account = self._account(f"acct-{uuid4().hex[:6]}")
         movie = Movie.objects.create(name="Schema Movie", rating="10")
-        M3UMovieRelation.objects.create(
+        relation = M3UMovieRelation.objects.create(
             m3u_account=account, movie=movie, stream_id="schema-1"
         )
 
@@ -812,7 +812,9 @@ class XcVodSeriesRegressionTests(TestCase):
 
         self.assertEqual(set(stream.keys()), XC_VOD_STREAM_KEYS)
         self.assertEqual(stream["stream_type"], "movie")
-        self.assertEqual(stream["stream_id"], movie.id)
+        # The relation's own PK, not the Movie's -- stable across a catalog
+        # refresh (relations are upserted in place; Movie rows are not).
+        self.assertEqual(stream["stream_id"], relation.id)
         self.assertEqual(stream["rating_5based"], 5.0)
         self.assertEqual(stream["custom_sid"], None)
         self.assertEqual(stream["direct_source"], "")

--- a/apps/output/tests/test_xc_vod_info.py
+++ b/apps/output/tests/test_xc_vod_info.py
@@ -39,7 +39,9 @@ class XCGetVodInfoArtworkTests(TestCase):
 
     def _info(self):
         request = self.factory.get('/player_api.php')
-        return xc_get_vod_info(request, self.user, str(self.movie.id))
+        # vod_id is the M3UMovieRelation's own PK, not the Movie's -- see the
+        # note in xc_get_vod_info on why the lookup changed.
+        return xc_get_vod_info(request, self.user, str(self.relation.id))
 
     def test_cover_big_and_movie_image_are_identical(self):
         """Real XC servers return the same URL for both fields; clients may read either."""

--- a/apps/output/urls.py
+++ b/apps/output/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path, re_path, include
-from .views import m3u_endpoint, epg_endpoint, xc_get, xc_movie_stream, xc_series_stream
+from .views import m3u_endpoint, epg_endpoint, xc_get
 
 app_name = "output"
 

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1221,7 +1221,12 @@ def xc_get_vod_streams(request, user, category_id=None):
             "num": num,
             "name": row['movie__name'],
             "stream_type": "movie",
-            "stream_id": row['movie__id'],
+            # The relation's own PK, not the Movie's -- mirrors xc_get_series's
+            # "series_id": row['id'] below. The relation PK is stable across a
+            # catalog refresh (relations are upserted in place); the Movie PK
+            # is not (a refresh can delete/recreate the Movie row), which was
+            # the root cause of stream_xc_movie/stream_xc_episode going stale.
+            "stream_id": row['id'],
             "stream_icon": _xc_cover_or_logo(
                 request,
                 'movie',
@@ -1454,8 +1459,14 @@ def xc_get_series_info(request, user, series_id):
             episode.custom_properties,
         )
 
+        # The relation's own PK, not the Episode's -- same rationale as
+        # xc_get_series's "series_id": row['id'] and xc_get_vod_streams's
+        # "stream_id": row['id']. Falls back to episode.id only when there's
+        # no active relation at all, in which case it isn't playable either way.
+        client_facing_id = best_relation.id if best_relation else episode.id
+
         seasons[season_num].append({
-            "id": episode.id,
+            "id": client_facing_id,
             "season": season_num,
             "episode_num": episode.episode_number or 0,
             "title": episode.name,
@@ -1464,7 +1475,7 @@ def xc_get_series_info(request, user, series_id):
             "custom_sid": None,
             "direct_source": "",
             "info": {
-                "id": int(episode.id),
+                "id": client_facing_id,
                 "name": episode.name,
                 "overview": episode.description or "",
                 "crew": str(episode.custom_properties.get('crew', "") if episode.custom_properties else ""),
@@ -1616,17 +1627,15 @@ def xc_get_vod_info(request, user, vod_id):
     if not vod_id:
         raise Http404()
 
-    # All authenticated users get access to VOD from all active M3U accounts
-    filters = {"movie_id": vod_id, "m3u_account__is_active": True}
-
-    try:
-        # Order by account priority to get the best relation when multiple exist
-        movie_relation = M3UMovieRelation.objects.select_related('movie', 'movie__logo').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-        if not movie_relation:
-            raise Http404()
-        movie = movie_relation.movie
-    except (M3UMovieRelation.DoesNotExist, M3UMovieRelation.MultipleObjectsReturned):
+    # vod_id here is the M3UMovieRelation's own PK (see the "stream_id" emitted
+    # below and by xc_get_vod_streams) -- stable across a catalog refresh,
+    # unlike the underlying Movie's PK.
+    movie_relation = M3UMovieRelation.objects.select_related('movie', 'movie__logo').filter(
+        id=vod_id, m3u_account__is_active=True
+    ).first()
+    if not movie_relation:
         raise Http404()
+    movie = movie_relation.movie
 
     # Initialize basic movie data first
     movie_data = {
@@ -1757,7 +1766,9 @@ def xc_get_vod_info(request, user, vod_id):
             'audio': movie_data.get('audio', {}),
         },
         "movie_data": {
-            "stream_id": movie.id,
+            # The relation's own PK, not the Movie's -- see the note on the
+            # filters lookup above.
+            "stream_id": movie_relation.id,
             "name": movie.name,
             "added": str(int(movie_relation.created_at.timestamp())),
             "category_id": str(movie_relation.category.id) if movie_relation.category else "0",
@@ -1769,77 +1780,6 @@ def xc_get_vod_info(request, user, vod_id):
     }
 
     return info
-
-
-def xc_movie_stream(request, username, password, stream_id, extension):
-    """Handle XtreamCodes movie streaming requests"""
-    from apps.vod.models import M3UMovieRelation
-
-    user = get_object_or_404(User, username=username)
-
-    custom_properties = user.custom_properties or {}
-
-    if "xc_password" not in custom_properties:
-        return JsonResponse({"error": "Invalid credentials"}, status=401)
-
-    if custom_properties["xc_password"] != password:
-        return JsonResponse({"error": "Invalid credentials"}, status=401)
-
-    # All authenticated users get access to VOD from all active M3U accounts
-    filters = {"movie_id": stream_id, "m3u_account__is_active": True}
-
-    try:
-        # Order by account priority to get the best relation when multiple exist
-        movie_relation = M3UMovieRelation.objects.select_related('movie').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-        if not movie_relation:
-            return JsonResponse({"error": "Movie not found"}, status=404)
-    except (M3UMovieRelation.DoesNotExist, M3UMovieRelation.MultipleObjectsReturned):
-        return JsonResponse({"error": "Movie not found"}, status=404)
-
-    # Redirect to the VOD proxy endpoint
-    from django.http import HttpResponseRedirect
-    from django.urls import reverse
-
-    vod_url = reverse('proxy:vod_proxy:vod_stream', kwargs={
-        'content_type': 'movie',
-        'content_id': movie_relation.movie.uuid
-    })
-
-    return HttpResponseRedirect(vod_url)
-
-
-def xc_series_stream(request, username, password, stream_id, extension):
-    """Handle XtreamCodes series/episode streaming requests"""
-    from apps.vod.models import M3UEpisodeRelation
-
-    user = get_object_or_404(User, username=username)
-
-    custom_properties = user.custom_properties or {}
-
-    if "xc_password" not in custom_properties:
-        return JsonResponse({"error": "Invalid credentials"}, status=401)
-
-    if custom_properties["xc_password"] != password:
-        return JsonResponse({"error": "Invalid credentials"}, status=401)
-
-    # All authenticated users get access to series/episodes from all active M3U accounts
-    filters = {"episode_id": stream_id, "m3u_account__is_active": True}
-
-    try:
-        episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-    except M3UEpisodeRelation.DoesNotExist:
-        return JsonResponse({"error": "Episode not found"}, status=404)
-
-    # Redirect to the VOD proxy endpoint
-    from django.http import HttpResponseRedirect
-    from django.urls import reverse
-
-    vod_url = reverse('proxy:vod_proxy:vod_stream', kwargs={
-        'content_type': 'episode',
-        'content_id': episode_relation.episode.uuid
-    })
-
-    return HttpResponseRedirect(vod_url)
 
 
 def format_duration_hms(seconds):

--- a/apps/proxy/vod_proxy/tests/test_xc_stream_ids.py
+++ b/apps/proxy/vod_proxy/tests/test_xc_stream_ids.py
@@ -1,0 +1,129 @@
+"""stream_xc_movie / stream_xc_episode: lookup by the stable relation PK.
+
+Context: xc_get_vod_streams / xc_get_vod_info / xc_get_series_info hand XC
+clients (TiviMate etc.) an episode/movie "id" that clients cache and later
+request playback with. That id used to be the underlying Movie/Episode row's
+own PK, which is not stable -- a catalog refresh can delete and recreate the
+row, orphaning every cached id. The M3UMovieRelation/M3UEpisodeRelation rows
+themselves are stable (upserted in place, keyed by (m3u_account, stream_id)
+from the provider), so the client-facing id is now the relation's own PK
+instead, matching the id already emitted by the read endpoints.
+
+These tests cover the two live playback endpoints directly:
+
+  * valid relation id -> resolves and streams (stream_vod called with the
+    correct content uuid)
+  * a value that used to be a valid Movie/Episode PK but is NOT a relation id
+    -> clean 404, not a crash (this is the exact bug that was crashing in
+    production: AttributeError: 'NoneType' object has no attribute 'episode')
+  * relation id present but its m3u_account is inactive -> clean 404
+  * garbage id -> clean 404
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+
+from apps.m3u.models import M3UAccount
+from apps.proxy.vod_proxy.views import stream_xc_episode, stream_xc_movie
+from apps.vod.models import Episode, M3UEpisodeRelation, M3UMovieRelation, Movie, Series
+
+User = get_user_model()
+
+
+class XcStreamIdBaseTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username='xcstreamuser', password='testpass123')
+        self.user.custom_properties = {'xc_password': 'xcpass'}
+        self.user.save(update_fields=['custom_properties'])
+
+        self.account = M3UAccount.objects.create(
+            name='Provider A',
+            server_url='http://a.example.com',
+            username='a',
+            password='a',
+            account_type=M3UAccount.Types.XC,
+            is_active=True,
+            priority=1,
+        )
+
+    def _request(self):
+        return self.factory.get('/series/xcstreamuser/xcpass/1.mp4')
+
+
+class StreamXcMovieTests(XcStreamIdBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.movie = Movie.objects.create(name='Some Movie')
+        self.relation = M3UMovieRelation.objects.create(
+            m3u_account=self.account, movie=self.movie, stream_id='provider-movie-1',
+        )
+
+    @patch('apps.proxy.vod_proxy.views.stream_vod')
+    def test_valid_relation_id_streams(self, mock_stream_vod):
+        mock_stream_vod.return_value = HttpResponse('STREAMED')
+        result = stream_xc_movie(self._request(), 'xcstreamuser', 'xcpass', str(self.relation.id), 'mp4')
+
+        self.assertIs(result, mock_stream_vod.return_value)
+        mock_stream_vod.assert_called_once()
+        args = mock_stream_vod.call_args[0]
+        self.assertEqual(args[1], 'movie')
+        self.assertEqual(args[2], self.movie.uuid)
+
+    def test_stale_movie_pk_is_clean_404_not_crash(self):
+        """The id that USED to work pre-fix (the Movie's own PK) must now 404
+        cleanly rather than crash -- this is the exact regression."""
+        response = stream_xc_movie(self._request(), 'xcstreamuser', 'xcpass', str(self.movie.id), 'mp4')
+        self.assertEqual(response.status_code, 404)
+
+    def test_inactive_account_is_404(self):
+        self.account.is_active = False
+        self.account.save(update_fields=['is_active'])
+        response = stream_xc_movie(self._request(), 'xcstreamuser', 'xcpass', str(self.relation.id), 'mp4')
+        self.assertEqual(response.status_code, 404)
+
+    def test_garbage_id_is_404(self):
+        response = stream_xc_movie(self._request(), 'xcstreamuser', 'xcpass', '999999', 'mp4')
+        self.assertEqual(response.status_code, 404)
+
+
+class StreamXcEpisodeTests(XcStreamIdBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.series = Series.objects.create(name='Some Series')
+        self.episode = Episode.objects.create(series=self.series, name='S1E1', season_number=1, episode_number=1)
+        self.relation = M3UEpisodeRelation.objects.create(
+            m3u_account=self.account, episode=self.episode, stream_id='provider-episode-1',
+        )
+
+    @patch('apps.proxy.vod_proxy.views.stream_vod')
+    def test_valid_relation_id_streams(self, mock_stream_vod):
+        mock_stream_vod.return_value = HttpResponse('STREAMED')
+        result = stream_xc_episode(self._request(), 'xcstreamuser', 'xcpass', str(self.relation.id), 'mp4')
+
+        self.assertIs(result, mock_stream_vod.return_value)
+        mock_stream_vod.assert_called_once()
+        args = mock_stream_vod.call_args[0]
+        self.assertEqual(args[1], 'episode')
+        self.assertEqual(args[2], self.episode.uuid)
+
+    def test_stale_episode_pk_is_clean_404_not_crash(self):
+        """The id that USED to work pre-fix (the Episode's own PK) must now
+        404 cleanly rather than crash with AttributeError -- this is the exact
+        bug reproduced live against a disposable Dispatcharr container before
+        this fix, and reported upstream."""
+        response = stream_xc_episode(self._request(), 'xcstreamuser', 'xcpass', str(self.episode.id), 'mp4')
+        self.assertEqual(response.status_code, 404)
+
+    def test_inactive_account_is_404(self):
+        self.account.is_active = False
+        self.account.save(update_fields=['is_active'])
+        response = stream_xc_episode(self._request(), 'xcstreamuser', 'xcpass', str(self.relation.id), 'mp4')
+        self.assertEqual(response.status_code, 404)
+
+    def test_garbage_id_is_404(self):
+        response = stream_xc_episode(self._request(), 'xcstreamuser', 'xcpass', '999999', 'mp4')
+        self.assertEqual(response.status_code, 404)

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -1222,15 +1222,16 @@ def stream_xc_movie(request, username, password, stream_id, extension):
     if custom_properties["xc_password"] != password:
         return Response({"error": "Invalid credentials"}, status=401)
 
-    # All authenticated users get access to VOD from all active M3U accounts
-    filters = {"movie_id": stream_id, "m3u_account__is_active": True}
-
-    try:
-        # Order by account priority to get the best relation when multiple exist
-        movie_relation = M3UMovieRelation.objects.select_related('movie').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-        if not movie_relation:
-            return JsonResponse({"error": "Movie not found"}, status=404)
-    except (M3UMovieRelation.DoesNotExist, M3UMovieRelation.MultipleObjectsReturned):
+    # stream_id here is the M3UMovieRelation's own PK (see xc_get_vod_streams /
+    # xc_get_vod_info, which now emit that instead of the underlying Movie's
+    # PK) -- the relation's PK is stable across a catalog refresh because
+    # relations are upserted in place, keyed by (m3u_account, stream_id) from
+    # the provider. The Movie row itself is not: a refresh can delete and
+    # recreate it, which is what made lookups keyed on movie_id go stale.
+    movie_relation = M3UMovieRelation.objects.select_related('movie').filter(
+        id=stream_id, m3u_account__is_active=True
+    ).first()
+    if not movie_relation:
         return JsonResponse({"error": "Movie not found"}, status=404)
 
     return stream_vod(request._request, 'movie', movie_relation.movie.uuid, session_id, profile_id, user)
@@ -1259,12 +1260,17 @@ def stream_xc_episode(request, username, password, stream_id, extension):
     if custom_properties["xc_password"] != password:
         return Response({"error": "Invalid credentials"}, status=401)
 
-    # All authenticated users get access to series/episodes from all active M3U accounts
-    filters = {"episode_id": stream_id, "m3u_account__is_active": True}
-
-    try:
-        episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(**filters).order_by('-m3u_account__priority', 'id').first()
-    except M3UEpisodeRelation.DoesNotExist:
+    # stream_id here is the M3UEpisodeRelation's own PK (see xc_get_series_info,
+    # which now emits that instead of the underlying Episode's PK) -- the
+    # relation's PK is stable across a catalog refresh because relations are
+    # upserted in place, keyed by (m3u_account, stream_id) from the provider.
+    # The Episode row itself is not: a refresh can delete and recreate it,
+    # which is what made lookups keyed on episode_id go stale and, combined
+    # with the .first()/DoesNotExist mismatch below, crash instead of 404.
+    episode_relation = M3UEpisodeRelation.objects.select_related('episode').filter(
+        id=stream_id, m3u_account__is_active=True
+    ).first()
+    if not episode_relation:
         return JsonResponse({"error": "Episode not found"}, status=404)
 
     return stream_vod(request._request, 'episode', episode_relation.episode.uuid, session_id, profile_id, user)


### PR DESCRIPTION
## Description

Fixes both the VOD "episode not found" 500 crash and its underlying cause: VOD episode/movie playback ids handed to XC clients are not stable across a catalog refresh.

`xc_get_vod_streams`, `xc_get_vod_info`, and `xc_get_series_info` currently emit the underlying `Movie`/`Episode` row's own database PK as the client-facing playback id. That PK is not stable -- a catalog refresh can delete and recreate the row. `stream_xc_movie`/`stream_xc_episode` then look up `M3UMovieRelation`/`M3UEpisodeRelation` by that same unstable PK, so once a refresh happens, every id a client (e.g. TiviMate) has cached goes stale. Combined with a `.first()`/`DoesNotExist` mismatch in `stream_xc_episode` (`.filter(...).first()` returns `None` on no match, it never raises `DoesNotExist`, so the `except` clause is dead code), a stale id crashes with `AttributeError: 'NoneType' object has no attribute 'episode'` instead of failing cleanly with a 404.

`xc_get_series` already avoids this: it exposes `M3USeriesRelation`'s own PK, not `Series.id`, because relations are upserted in place (keyed by `(m3u_account, stream_id)` from the provider) and are therefore both stable across a refresh and globally unique. This PR brings movies and episodes in line with that existing pattern, rather than switching to the provider's raw `stream_id` -- which would introduce a *new* cross-account collision risk, since `stream_id` is only unique per `(m3u_account, stream_id)`, not globally, and provider data can put the literal string `"None"` there when a field is missing.

**Changes:**
- `xc_get_vod_streams`: `"stream_id"` is now the `M3UMovieRelation` PK.
- `xc_get_vod_info`: same for both the lookup (`vod_id`) and the emitted `movie_data.stream_id`.
- `xc_get_series_info`: per-episode `"id"` is now the `M3UEpisodeRelation` PK (falls back to `episode.id` only when there's no active relation at all, which isn't playable either way).
- `stream_xc_movie` / `stream_xc_episode`: look up by the relation's own PK instead of `movie_id`/`episode_id`, and both now cleanly 404 when no relation matches instead of the episode path crashing.
- Removed `apps/output/views.py`'s `xc_movie_stream`/`xc_series_stream` (and their `urls.py` import) -- confirmed dead code, never wired to a URL route (`CHANGELOG.md` documents they were superseded by the `vod_proxy` versions), so fixing them too would just leave a second, still-unreachable copy of the same bug pattern to maintain.
- Updated the one existing test asserting on the old value (`test_vod_streams_response_keys`) and the `xc_get_vod_info` test fixture that passed `movie.id` where it now needs `relation.id`.
- Added `apps/proxy/vod_proxy/tests/test_xc_stream_ids.py`: direct coverage for `stream_xc_movie`/`stream_xc_episode` -- valid relation id streams, the exact pre-fix stale-PK crash case now 404s cleanly, inactive account, garbage id.

Related to #820 (same crash signature, in the now-removed `xc_series_stream` redirect function). That issue's resolution stopped it from reproducing there by routing around the dead function, but never addressed the root cause -- which was still live and reachable via `stream_xc_episode` today, on the current `dev` branch.

## Related Issue

Related to #820 (not a direct duplicate -- different function, and the root cause was never fixed, just no longer reachable in the code path that issue reported).

Closes #1513 (my own earlier, narrower PR against `main` for just the crash -- closed in favor of this one once I found the deeper cause; the crash-only fix would have conflicted with this one since they touch the same lines).

## How was it tested?

1. **Reproduced the live crash** against a disposable `ghcr.io/dispatcharr/dispatcharr:latest` container (no production data involved): with a `stream_id` that has no matching relation, `GET /series/<user>/<pass>/<id>.mp4` 500s with the exact traceback described above.
2. **Verified the fix removes the crash**: same request against the patched code returns a clean 404 `{"error": "Episode not found"}`.
3. **Verified against real production data** (read-only queries, no writes) that `M3UEpisodeRelation.stream_id` never equals the Episode FK `episode_id` across 238 live relations on a real instance -- confirming the two id spaces are genuinely disjoint, not usually-coincidentally-equal.
4. **Ran the full Dispatcharr backend test suite** for the affected apps against the patched code, using the project's own `base-dev` CI image and `scripts/ci_bootstrap_backend.sh` (internal Postgres + Redis, `manage.py test`):
   ```
   docker run --rm --entrypoint '' \
     -e DISPATCHARR_ENV=aio -e DJANGO_SECRET_KEY=ci-test-secret-key \
     -e POSTGRES_DB=dispatcharr -e POSTGRES_USER=dispatch -e POSTGRES_PASSWORD=secret \
     -v <repo>:/app -w /app \
     ghcr.io/dispatcharr/dispatcharr:base-dev \
     bash scripts/ci_bootstrap_backend.sh apps.output.tests apps.proxy.vod_proxy.tests -v2
   ```
   Result: **117 tests, all passing** (including every existing `apps.output`/`apps.proxy.vod_proxy` test after updating the two that asserted on the old id scheme, plus the 8 new tests added by this PR).

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

Notes on items that are trivially satisfied rather than actively exercised: no models changed (no migrations needed), no new endpoints added (existing ones only changed which id value they return/accept, no OpenAPI shape change), and this is a backend-only change with no frontend files touched (lint/format not applicable, vacuously passing).
