### PR TITLE
feat(output): expose completed DVR recordings as Xtream VOD

### DIFF
--- a/apps/output/tests/test_recordings_xtream_vod.py
+++ b/apps/output/tests/test_recordings_xtream_vod.py
@@ -65,6 +65,10 @@ class XcRecordingVodTests(TestCase):
         self.assertEqual(streams[0]["container_extension"], "mkv")
         self.assertNotIn(self.file.name, str(streams[0]))
 
+    def test_unfiltered_vod_streams_include_completed_recordings_for_clients_that_filter_locally(self):
+        streams = xc_get_vod_streams(self.factory.get("/player_api.php"), self.user)
+        self.assertEqual([row["stream_id"] for row in streams], [f"recording-{self.recording.id}"])
+
     def test_incomplete_or_missing_recording_is_not_exposed(self):
         now = timezone.now()
         Recording.objects.create(

--- a/apps/output/tests/test_recordings_xtream_vod.py
+++ b/apps/output/tests/test_recordings_xtream_vod.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from django.test import TestCase
 from django.utils import timezone
 from django.test.client import RequestFactory
+from django.http import Http404
 from rest_framework.test import APIClient
 
 from apps.accounts.models import User
@@ -105,3 +106,10 @@ class XcRecordingVodTests(TestCase):
         )
         self.assertEqual(info["movie_data"]["stream_id"], f"recording-{self.recording.id}")
         self.assertNotIn(self.file.name, str(info))
+
+        self.channel.hidden_from_output = True
+        self.channel.save(update_fields=["hidden_from_output"])
+        with self.assertRaises(Http404):
+            xc_get_vod_info(
+                self.factory.get("/player_api.php"), self.user, f"recording-{self.recording.id}"
+            )

--- a/apps/output/tests/test_recordings_xtream_vod.py
+++ b/apps/output/tests/test_recordings_xtream_vod.py
@@ -89,6 +89,13 @@ class XcRecordingVodTests(TestCase):
         )
         self.assertEqual([row["stream_id"] for row in streams], [f"recording-{self.recording.id}"])
 
+    def test_file_stat_race_hides_recording(self):
+        with patch("apps.output.views.os.stat", side_effect=OSError):
+            streams = xc_get_vod_streams(
+                self.factory.get("/player_api.php"), self.user, "dispatcharr-recordings"
+            )
+        self.assertEqual(streams, [])
+
     def test_xc_movie_route_streams_completed_recording_with_range_support(self):
         with patch("apps.proxy.vod_proxy.views.network_access_allowed", return_value=True), patch(
             "apps.channels.api_views.network_access_allowed", return_value=True

--- a/apps/output/tests/test_recordings_xtream_vod.py
+++ b/apps/output/tests/test_recordings_xtream_vod.py
@@ -1,0 +1,103 @@
+"""Xtream VOD exposure for completed local DVR recordings."""
+import os
+import tempfile
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.test import TestCase
+from django.utils import timezone
+from django.test.client import RequestFactory
+from rest_framework.test import APIClient
+
+from apps.accounts.models import User
+from apps.channels.models import Channel, Recording
+from apps.output.views import xc_get_vod_categories, xc_get_vod_info, xc_get_vod_streams
+
+
+class XcRecordingVodTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username=f"recording-vod-{uuid4().hex[:8]}",
+            password="pass",
+            user_level=10,
+            custom_properties={"xc_password": "xcpass"},
+        )
+        self.channel = Channel.objects.create(
+            channel_number=900,
+            name="Recording source",
+            hidden_from_output=False,
+        )
+        self.file = tempfile.NamedTemporaryFile(suffix=".mkv", delete=False)
+        self.file.write(b"recording data")
+        self.file.close()
+        now = timezone.now()
+        self.recording = Recording.objects.create(
+            channel=self.channel,
+            start_time=now,
+            end_time=now,
+            custom_properties={
+                "status": "completed",
+                "file_path": self.file.name,
+                "file_name": "race.mkv",
+                "title": "Hungarian Grand Prix",
+            },
+        )
+
+    def tearDown(self):
+        if os.path.exists(self.file.name):
+            os.unlink(self.file.name)
+
+    def test_completed_nonempty_recording_appears_in_dedicated_vod_category(self):
+        categories = xc_get_vod_categories(self.user)
+        self.assertIn(
+            {"category_id": "dispatcharr-recordings", "category_name": "Recordings", "parent_id": 0},
+            categories,
+        )
+
+        streams = xc_get_vod_streams(
+            self.factory.get("/player_api.php"), self.user, "dispatcharr-recordings"
+        )
+        self.assertEqual(len(streams), 1)
+        self.assertEqual(streams[0]["stream_id"], f"recording-{self.recording.id}")
+        self.assertEqual(streams[0]["name"], "Hungarian Grand Prix")
+        self.assertEqual(streams[0]["container_extension"], "mkv")
+        self.assertNotIn(self.file.name, str(streams[0]))
+
+    def test_incomplete_or_missing_recording_is_not_exposed(self):
+        now = timezone.now()
+        Recording.objects.create(
+            channel=self.channel,
+            start_time=now,
+            end_time=now,
+            custom_properties={"status": "recording", "file_path": self.file.name},
+        )
+        Recording.objects.create(
+            channel=self.channel,
+            start_time=now,
+            end_time=now,
+            custom_properties={"status": "completed", "file_path": "/missing/file.mkv"},
+        )
+        streams = xc_get_vod_streams(
+            self.factory.get("/player_api.php"), self.user, "dispatcharr-recordings"
+        )
+        self.assertEqual([row["stream_id"] for row in streams], [f"recording-{self.recording.id}"])
+
+    def test_xc_movie_route_streams_completed_recording_with_range_support(self):
+        with patch("apps.proxy.vod_proxy.views.network_access_allowed", return_value=True), patch(
+            "apps.channels.api_views.network_access_allowed", return_value=True
+        ):
+            response = self.client.get(
+                f"/movie/{self.user.username}/xcpass/recording-{self.recording.id}.mkv",
+                HTTP_RANGE="bytes=0-3",
+            )
+        self.assertEqual(response.status_code, 206)
+        self.assertEqual(response["Content-Range"], "bytes 0-3/14")
+
+    def test_recording_info_is_available_only_to_authorized_user(self):
+        info = xc_get_vod_info(
+            self.factory.get("/player_api.php"), self.user, f"recording-{self.recording.id}"
+        )
+        self.assertEqual(info["movie_data"]["stream_id"], f"recording-{self.recording.id}")
+        self.assertNotIn(self.file.name, str(info))

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1165,8 +1165,93 @@ def _xc_fetch_priority_distinct_relations(
     return rows
 
 
+RECORDING_VOD_CATEGORY_ID = "dispatcharr-recordings"
+RECORDING_VOD_CATEGORY_NAME = "Recordings"
+RECORDING_VOD_STREAM_PREFIX = "recording-"
+
+
+def _xc_user_can_access_recording(user, recording):
+    """Return whether an XC user can discover or play this recording.
+
+    DVR recordings inherit visibility from their source channel.  Keep the
+    same user-level, profile, output-hidden, and adult-content gates as the
+    regular client-facing channel output.
+    """
+    channel = recording.channel
+    if channel.hidden_from_output:
+        return False
+    if (user.custom_properties or {}).get("hide_adult_content", False) and channel.is_adult:
+        return False
+    if user.user_level >= 10:
+        return True
+
+    filters = {"id": channel.id, "user_level__lte": user.user_level}
+    profiles = user.channel_profiles.all()
+    if profiles.exists():
+        filters.update({
+            "channelprofilemembership__enabled": True,
+            "channelprofilemembership__channel_profile__in": profiles,
+        })
+    return Channel.objects.filter(**filters).distinct().exists()
+
+
+def _xc_completed_recordings_for_user(user):
+    """Return completed, non-empty recording files the XC user may access."""
+    from apps.channels.models import Recording
+
+    recordings = []
+    for recording in Recording.objects.select_related("channel").order_by("-end_time", "-id"):
+        cp = recording.custom_properties or {}
+        path = cp.get("file_path")
+        if (
+            cp.get("status") == "completed"
+            and path
+            and os.path.isfile(path)
+            and os.path.getsize(path) > 0
+            and _xc_user_can_access_recording(user, recording)
+        ):
+            recordings.append(recording)
+    return recordings
+
+
+def _xc_recording_stream_id(recording):
+    return f"{RECORDING_VOD_STREAM_PREFIX}{recording.id}"
+
+
+def _xc_recording_row(recording, num):
+    cp = recording.custom_properties or {}
+    path = cp["file_path"]
+    title = cp.get("title") or cp.get("name") or recording.channel.name
+    extension = os.path.splitext(path)[1].lstrip(".") or "mkv"
+    return {
+        "num": num,
+        "name": title,
+        "stream_type": "movie",
+        "stream_id": _xc_recording_stream_id(recording),
+        "stream_icon": None,
+        "rating": "0",
+        "rating_5based": 0,
+        "added": str(int(recording.end_time.timestamp())),
+        "is_adult": int(recording.channel.is_adult),
+        "tmdb_id": "",
+        "imdb_id": "",
+        "trailer": "",
+        "plot": cp.get("description") or "",
+        "genre": "Recordings",
+        "year": recording.end_time.year,
+        "director": "",
+        "cast": "",
+        "release_date": recording.end_time.date().isoformat(),
+        "category_id": RECORDING_VOD_CATEGORY_ID,
+        "category_ids": [RECORDING_VOD_CATEGORY_ID],
+        "container_extension": extension,
+        "custom_sid": None,
+        "direct_source": "",
+    }
+
+
 def xc_get_vod_categories(user):
-    """Get VOD categories for XtreamCodes API"""
+    """Get VOD categories for XtreamCodes API."""
     from apps.vod.models import VODCategory, M3UMovieRelation
 
     response = []
@@ -1184,11 +1269,24 @@ def xc_get_vod_categories(user):
             "parent_id": 0,
         })
 
+    if _xc_completed_recordings_for_user(user):
+        response.append({
+            "category_id": RECORDING_VOD_CATEGORY_ID,
+            "category_name": RECORDING_VOD_CATEGORY_NAME,
+            "parent_id": 0,
+        })
+
     return response
 
 
 def xc_get_vod_streams(request, user, category_id=None):
-    """Get VOD streams (movies) for XtreamCodes API"""
+    """Get VOD streams (movies) for XtreamCodes API."""
+    if category_id == RECORDING_VOD_CATEGORY_ID:
+        return [
+            _xc_recording_row(recording, num)
+            for num, recording in enumerate(_xc_completed_recordings_for_user(user), 1)
+        ]
+
     from apps.vod.models import M3UMovieRelation
 
     rel_filters = {"m3u_account__is_active": True}
@@ -1608,7 +1706,54 @@ def xc_get_series_info(request, user, series_id):
 
 
 def xc_get_vod_info(request, user, vod_id):
-    """Get detailed VOD (movie) information"""
+    """Get detailed VOD (movie) information."""
+    if str(vod_id).startswith(RECORDING_VOD_STREAM_PREFIX):
+        recording_id = str(vod_id)[len(RECORDING_VOD_STREAM_PREFIX):]
+        from apps.channels.models import Recording
+        try:
+            recording = Recording.objects.select_related("channel").get(pk=recording_id)
+        except (Recording.DoesNotExist, ValueError):
+            raise Http404()
+        if recording not in _xc_completed_recordings_for_user(user):
+            raise Http404()
+        row = _xc_recording_row(recording, 1)
+        return {
+            "info": {
+                "name": row["name"],
+                "o_name": row["name"],
+                "cover_big": None,
+                "movie_image": None,
+                "description": row["plot"],
+                "plot": row["plot"],
+                "year": row["year"],
+                "release_date": row["release_date"],
+                "genre": row["genre"],
+                "director": "",
+                "actors": "",
+                "cast": "",
+                "country": "",
+                "rating": "0",
+                "imdb_id": "",
+                "tmdb_id": "",
+                "youtube_trailer": "",
+                "backdrop_path": [],
+                "cover": "",
+                "bitrate": 0,
+                "video": {},
+                "audio": {},
+            },
+            "movie_data": {
+                "stream_id": row["stream_id"],
+                "name": row["name"],
+                "added": row["added"],
+                "category_id": RECORDING_VOD_CATEGORY_ID,
+                "category_ids": [RECORDING_VOD_CATEGORY_ID],
+                "container_extension": row["container_extension"],
+                "custom_sid": None,
+                "direct_source": "",
+            },
+        }
+
     from apps.vod.models import M3UMovieRelation
     from django.utils import timezone
     from datetime import timedelta

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1349,6 +1349,16 @@ def xc_get_vod_streams(request, user, category_id=None):
             "direct_source": "",
         })
 
+    # A number of Xtream clients request the complete VOD list once and apply
+    # their category filter locally.  Include completed local recordings in
+    # that unfiltered form as well as in the dedicated category response.
+    if not category_id:
+        start_num = len(streams) + 1
+        streams.extend(
+            _xc_recording_row(recording, num)
+            for num, recording in enumerate(_xc_completed_recordings_for_user(user), start_num)
+        )
+
     return streams
 
 

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -20,6 +20,7 @@ import base64
 import logging
 from django.db.models.functions import Lower
 import os
+import stat
 from apps.m3u.utils import calculate_tuner_count
 from apps.proxy.utils import get_user_active_connections
 import regex
@@ -1171,12 +1172,7 @@ RECORDING_VOD_STREAM_PREFIX = "recording-"
 
 
 def _xc_user_can_access_recording(user, recording):
-    """Return whether an XC user can discover or play this recording.
-
-    DVR recordings inherit visibility from their source channel.  Keep the
-    same user-level, profile, output-hidden, and adult-content gates as the
-    regular client-facing channel output.
-    """
+    """Apply the XC channel visibility rules to a recording's source channel."""
     channel = recording.channel
     if channel.hidden_from_output:
         return False
@@ -1195,23 +1191,54 @@ def _xc_user_can_access_recording(user, recording):
     return Channel.objects.filter(**filters).distinct().exists()
 
 
+def _xc_recording_file_is_available(recording):
+    path = (recording.custom_properties or {}).get("file_path")
+    if not path:
+        return False
+    try:
+        file_stat = os.stat(path)
+    except OSError:
+        return False
+    return stat.S_ISREG(file_stat.st_mode) and file_stat.st_size > 0
+
+
+def _xc_recording_is_available_to_user(user, recording):
+    return (
+        (recording.custom_properties or {}).get("status") == "completed"
+        and _xc_recording_file_is_available(recording)
+        and _xc_user_can_access_recording(user, recording)
+    )
+
+
 def _xc_completed_recordings_for_user(user):
-    """Return completed, non-empty recording files the XC user may access."""
+    """Yield completed recording files that the XC user may access."""
     from apps.channels.models import Recording
 
-    recordings = []
-    for recording in Recording.objects.select_related("channel").order_by("-end_time", "-id"):
-        cp = recording.custom_properties or {}
-        path = cp.get("file_path")
-        if (
-            cp.get("status") == "completed"
-            and path
-            and os.path.isfile(path)
-            and os.path.getsize(path) > 0
-            and _xc_user_can_access_recording(user, recording)
-        ):
-            recordings.append(recording)
-    return recordings
+    recordings = Recording.objects.filter(
+        custom_properties__status="completed"
+    ).select_related("channel").order_by("-end_time", "-id")
+    return (
+        recording
+        for recording in recordings
+        if _xc_recording_is_available_to_user(user, recording)
+    )
+
+
+def _xc_get_available_recording(user, stream_id):
+    """Return an XC-visible completed recording for its virtual stream ID."""
+    stream_id = str(stream_id)
+    if not stream_id.startswith(RECORDING_VOD_STREAM_PREFIX):
+        return None
+
+    from apps.channels.models import Recording
+
+    try:
+        recording = Recording.objects.select_related("channel").get(
+            pk=stream_id.removeprefix(RECORDING_VOD_STREAM_PREFIX)
+        )
+    except (Recording.DoesNotExist, ValueError):
+        return None
+    return recording if _xc_recording_is_available_to_user(user, recording) else None
 
 
 def _xc_recording_stream_id(recording):
@@ -1269,7 +1296,7 @@ def xc_get_vod_categories(user):
             "parent_id": 0,
         })
 
-    if _xc_completed_recordings_for_user(user):
+    if next(_xc_completed_recordings_for_user(user), None):
         response.append({
             "category_id": RECORDING_VOD_CATEGORY_ID,
             "category_name": RECORDING_VOD_CATEGORY_NAME,
@@ -1349,9 +1376,7 @@ def xc_get_vod_streams(request, user, category_id=None):
             "direct_source": "",
         })
 
-    # A number of Xtream clients request the complete VOD list once and apply
-    # their category filter locally.  Include completed local recordings in
-    # that unfiltered form as well as in the dedicated category response.
+    # Some Xtream clients fetch all VOD before filtering categories locally.
     if not category_id:
         start_num = len(streams) + 1
         streams.extend(
@@ -1718,13 +1743,8 @@ def xc_get_series_info(request, user, series_id):
 def xc_get_vod_info(request, user, vod_id):
     """Get detailed VOD (movie) information."""
     if str(vod_id).startswith(RECORDING_VOD_STREAM_PREFIX):
-        recording_id = str(vod_id)[len(RECORDING_VOD_STREAM_PREFIX):]
-        from apps.channels.models import Recording
-        try:
-            recording = Recording.objects.select_related("channel").get(pk=recording_id)
-        except (Recording.DoesNotExist, ValueError):
-            raise Http404()
-        if recording not in _xc_completed_recordings_for_user(user):
+        recording = _xc_get_available_recording(user, vod_id)
+        if recording is None:
             raise Http404()
         row = _xc_recording_row(recording, 1)
         return {

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -1222,21 +1222,12 @@ def stream_xc_movie(request, username, password, stream_id, extension):
     if custom_properties["xc_password"] != password:
         return Response({"error": "Invalid credentials"}, status=401)
 
-    # Locally completed DVR recordings are exposed as a virtual VOD category.
-    # They reuse the existing range-capable recording file endpoint after the
-    # XC credential and source-channel visibility checks have succeeded.
     if str(stream_id).startswith("recording-"):
-        from apps.channels.models import Recording
         from apps.channels.api_views import RecordingViewSet
-        from apps.output.views import _xc_completed_recordings_for_user
+        from apps.output.views import _xc_get_available_recording
 
-        try:
-            recording = Recording.objects.select_related("channel").get(
-                pk=str(stream_id).removeprefix("recording-")
-            )
-        except (Recording.DoesNotExist, ValueError):
-            return JsonResponse({"error": "Movie not found"}, status=404)
-        if recording not in _xc_completed_recordings_for_user(user):
+        recording = _xc_get_available_recording(user, stream_id)
+        if recording is None:
             return JsonResponse({"error": "Movie not found"}, status=404)
         request.user = user
         return RecordingViewSet().file(request, pk=recording.pk)

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -1222,6 +1222,25 @@ def stream_xc_movie(request, username, password, stream_id, extension):
     if custom_properties["xc_password"] != password:
         return Response({"error": "Invalid credentials"}, status=401)
 
+    # Locally completed DVR recordings are exposed as a virtual VOD category.
+    # They reuse the existing range-capable recording file endpoint after the
+    # XC credential and source-channel visibility checks have succeeded.
+    if str(stream_id).startswith("recording-"):
+        from apps.channels.models import Recording
+        from apps.channels.api_views import RecordingViewSet
+        from apps.output.views import _xc_completed_recordings_for_user
+
+        try:
+            recording = Recording.objects.select_related("channel").get(
+                pk=str(stream_id).removeprefix("recording-")
+            )
+        except (Recording.DoesNotExist, ValueError):
+            return JsonResponse({"error": "Movie not found"}, status=404)
+        if recording not in _xc_completed_recordings_for_user(user):
+            return JsonResponse({"error": "Movie not found"}, status=404)
+        request.user = user
+        return RecordingViewSet().file(request, pk=recording.pk)
+
     # All authenticated users get access to VOD from all active M3U accounts
     filters = {"movie_id": stream_id, "m3u_account__is_active": True}
 


### PR DESCRIPTION
## What

Exposes completed local DVR recordings through the existing Xtream Codes VOD output as a virtual **Recordings** category.

Completed recordings now:

- appear in `get_vod_categories` only when an accessible recording exists;
- appear in both category-scoped and unfiltered `get_vod_streams` responses (for clients that filter locally);
- provide `get_vod_info` metadata; and
- play through the existing credentialed, range-capable `/movie/...` route.

Incomplete, missing, hidden, or unauthorized recordings remain absent.

## Why

Addresses [#799](https://github.com/Dispatcharr/Dispatcharr/issues/799)

Completed DVR recordings were available only through the web UI, rather than normal Xtream clients.

## Implementation

- Uses a virtual `recording-<id>` stream ID and a `dispatcharr-recordings` VOD category; no database migration or new public API route is introduced.
- Reuses the existing recording-file response, including Range support, after Xtream credentials and source-channel visibility checks.
- Keeps the collection lazy for category discovery, filters completed rows in the database, and treats file disappearance during discovery as unavailable.

## Validation

- `python3 -m py_compile` on each touched Python module
- Docker image build and publish completed successfully
- Deployed the image into an isolated TrueNAS staging app and verified against its live Xtream API:
  - two independently completed recordings are returned in both unfiltered and `Recordings`-scoped VOD lists;
  - VOD detail metadata resolves for a recording;
  - credentialed MKV Range playback returns HTTP `206` and 1024 requested bytes.
- Added Django `TestCase` coverage for category/listing, unfiltered client behavior, incomplete/missing files, file-stat race handling, playback Range support, metadata, and hidden-channel authorization.

The local VM cannot run the Django test process because its NumPy wheel requires x86-64-v2 CPU support. Please let GitHub Actions run the test module on a compatible runner.

## Checklist

- [x] Linked to an existing issue
- [x] Targets `dev`
- [x] No migrations or dependencies added
- [x] No secrets, provider URLs, or local infrastructure details included
- [x] I understand and agree to the contributor license terms
