### PR TITLE
fix(epg): stop Schedules Direct guide refresh from silently dropping …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schedules Direct guide refresh no longer silently drops channels on transient API failures.** A failed `/schedules/md5` check was treated as "no changes," reporting a false "guide data is up to date" instead of an error, and a failed `/programs` metadata batch wrote a placeholder "No Title" entry instead of retrying. The batched `/schedules/md5`, `/schedules`, and `/programs` requests now retry with backoff on network errors, HTTP errors, and Schedules Direct's own embedded error codes (e.g. `SERVICE_OFFLINE`/`SERVICE_BUSY`) returned with HTTP 200.
+
 ## [0.29.0] - 2026-08-09
 
 ### Added

--- a/apps/epg/sd_tasks.py
+++ b/apps/epg/sd_tasks.py
@@ -22,7 +22,13 @@ from django.utils import timezone
 
 from apps.channels.models import Channel
 from apps.epg.models import EPGData, EPGSource, ProgramData, SDProgramMD5, SDScheduleMD5
-from apps.epg.sd_utils import SD_BASE_URL, sd_authorized_request, sd_obtain_token
+from apps.epg.sd_utils import (
+    SD_AUTH_SOFT_CODES,
+    SD_BASE_URL,
+    sd_authorized_request,
+    sd_obtain_token,
+    sd_parse_response_payload,
+)
 from apps.epg.utils import send_epg_update
 from core.utils import (
     acquire_task_lock,
@@ -40,6 +46,15 @@ SD_PROGRAM_BATCH_SIZE = 5000
 SD_BULK_GUIDE_FETCH_THRESHOLD = 3
 SD_MAPPED_GUIDE_BATCH_DEFER_SECONDS = 90
 SD_MAPPED_GUIDE_FETCH_DEFER_MAX_RETRIES = 2
+
+
+class SDResponsePayloadError(requests.exceptions.RequestException):
+    """SD returned HTTP 200 with an embedded JSON error code instead of data."""
+
+    def __init__(self, code, message, response=None):
+        self.sd_code = code
+        super().__init__(f"SD API returned error code {code}: {message}", response=response)
+
 
 def _sd_compute_schedule_changes_from_md5(server_md5s, cached_md5s, date_list):
     """Return station_id -> [date_str] for dates whose schedule MD5 differs from cache."""
@@ -813,6 +828,33 @@ def fetch_schedules_direct(
         )
         return resp
 
+    def _sd_req_with_retry(method, url, *, max_attempts=3, backoff_seconds=2, **kwargs):
+        """
+        Call _sd_req with retry/backoff on network errors, HTTP errors, and
+        SD's own embedded JSON error codes returned with HTTP 200 (e.g.
+        SERVICE_OFFLINE/SERVICE_BUSY).
+        """
+        last_exc = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                resp = _sd_req(method, url, **kwargs)
+                resp.raise_for_status()
+                code, data = sd_parse_response_payload(resp)
+                if code is not None and code != 0:
+                    message = (data or {}).get('message') or (data or {}).get('response') or ''
+                    raise SDResponsePayloadError(code, message, response=resp)
+                return resp
+            except requests.exceptions.RequestException as e:
+                last_exc = e
+                if isinstance(e, SDResponsePayloadError) and e.sd_code not in SD_AUTH_SOFT_CODES:
+                    raise
+                if attempt < max_attempts:
+                    logger.debug(
+                        f"SD request to {url} failed (attempt {attempt}/{max_attempts}): {e}, retrying..."
+                    )
+                    time.sleep(backoff_seconds * attempt)
+        raise last_exc
+
     # -------------------------------------------------------------------------
     # Step 2: Check account status (respect OFFLINE system status)
     # -------------------------------------------------------------------------
@@ -1116,15 +1158,15 @@ def fetch_schedules_direct(
         mapped_station_ids[i:i + STATION_BATCH_SIZE]
         for i in range(0, len(mapped_station_ids), STATION_BATCH_SIZE)
     ]
+    md5_fetch_failed = False
     for batch in station_batches:
         try:
-            md5_response = _sd_req(
+            md5_response = _sd_req_with_retry(
                 'POST',
                 f"{SD_BASE_URL}/schedules/md5",
                 json=[{'stationID': sid, 'date': date_list} for sid in batch],
                 timeout=120,
             )
-            md5_response.raise_for_status()
             md5_data = md5_response.json()
             for sid, dates in md5_data.items():
                 for date_str, info in dates.items():
@@ -1135,6 +1177,7 @@ def fetch_schedules_direct(
                         }
         except requests.exceptions.RequestException as e:
             logger.warning(f"Failed to fetch schedule MD5s: {e}")
+            md5_fetch_failed = True
 
     # Load our cached MD5s from DB (mapped stations only)
     cached_md5s = {
@@ -1147,6 +1190,16 @@ def fetch_schedules_direct(
     changed_by_station = _sd_compute_schedule_changes_from_md5(
         server_md5s, cached_md5s, date_list,
     )
+
+    if md5_fetch_failed and not changed_by_station:
+        # The MD5 check failed for every batch, don't report a false "up to date".
+        msg = "Failed to fetch schedule MD5s from Schedules Direct, guide was not refreshed this cycle."
+        logger.warning(msg)
+        source.status = EPGSource.STATUS_ERROR
+        source.last_message = msg
+        source.save(update_fields=['status', 'last_message'])
+        send_epg_update(source.id, "parsing_programs", 100, status="error", error=msg)
+        return
 
     window_start = datetime(today.year, today.month, today.day, tzinfo=dt_timezone.utc)
     window_end = window_start + timedelta(days=SD_DAYS_TO_FETCH)
@@ -1245,13 +1298,12 @@ def fetch_schedules_direct(
         if not request_body:
             continue
         try:
-            sched_response = _sd_req(
+            sched_response = _sd_req_with_retry(
                 'POST',
                 f"{SD_BASE_URL}/schedules",
                 json=request_body,
                 timeout=120,
             )
-            sched_response.raise_for_status()
             sched_data = sched_response.json()
 
             for station_sched in sched_data:
@@ -1362,6 +1414,7 @@ def fetch_schedules_direct(
         f"{len(programs_to_fetch)} need downloading ({len(program_ids_needed) - len(programs_to_fetch)} unchanged).")
 
     program_metadata = {}
+    fetch_failed_pids = set()
     program_id_list = list(programs_to_fetch)
     total_batches = max(1, (len(program_id_list) + SD_PROGRAM_BATCH_SIZE - 1) // SD_PROGRAM_BATCH_SIZE)
 
@@ -1380,13 +1433,12 @@ def fetch_schedules_direct(
                 pass
             batch = program_id_list[batch_idx * SD_PROGRAM_BATCH_SIZE:(batch_idx + 1) * SD_PROGRAM_BATCH_SIZE]
             try:
-                prog_response = _sd_req(
+                prog_response = _sd_req_with_retry(
                     'POST',
                     f"{SD_BASE_URL}/programs",
                     json=batch,
                     timeout=120,
                 )
-                prog_response.raise_for_status()
                 prog_data = prog_response.json()
                 for prog in prog_data:
                     pid = prog.get('programID')
@@ -1400,6 +1452,7 @@ def fetch_schedules_direct(
 
             except requests.exceptions.RequestException as e:
                 logger.warning(f"Failed to fetch program metadata batch {batch_idx + 1}: {e}")
+                fetch_failed_pids.update(batch)
     else:
         logger.info("All program metadata unchanged - skipping program download.")
         send_epg_update(source.id, "parsing_programs", 80, message="Program metadata unchanged - using cached data.")
@@ -1471,6 +1524,11 @@ def fetch_schedules_direct(
 
             meta = program_metadata.get(pid, {})
             cached_prog = existing_program_cache.get(pid) if not meta else None
+
+            if not meta and not cached_prog and pid in fetch_failed_pids:
+                # Metadata fetch failed and there's no prior data to fall back
+                # on, skip instead of writing a placeholder "No Title" row.
+                continue
 
             if cached_prog:
                 # Unchanged program — reuse cached data from before surgical delete

--- a/apps/epg/tests/test_schedules_direct.py
+++ b/apps/epg/tests/test_schedules_direct.py
@@ -8,12 +8,14 @@ Covers:
 - fetch_schedules_direct: SHA1 password hashing and token exchange
 - fetch_schedules_direct: graceful error handling on auth failure
 - fetch_schedules_direct: schedule MD5 delta, backfill, and cache invalidation
+- fetch_schedules_direct: batch request retry/backoff and failure handling
 - parse_schedules_direct_time: correct UTC parsing
 - fetch_sd_guide_for_epg: per-channel guide fetch on map
 - EPG signals: SD sources queue guide fetch when a channel is mapped
 """
 
 import hashlib
+import json
 import time
 from datetime import date, datetime, timedelta, timezone as dt_timezone
 from unittest.mock import MagicMock, patch
@@ -1088,6 +1090,347 @@ class SDScheduleDeltaIntegrationTests(TestCase):
             {'EP0001'},
         )
         self.assertEqual(needed, set())
+
+
+# ---------------------------------------------------------------------------
+# Batch request retry/backoff and failure handling
+# ---------------------------------------------------------------------------
+
+class SDBatchFailureHandlingTests(TestCase):
+    """
+    _sd_req_with_retry must retry transient failures (network errors and SD's
+    own embedded JSON error codes on HTTP 200), and a batch that still fails
+    after retries must not be mistaken for "nothing changed" or silently
+    produce placeholder guide data.
+    """
+
+    MAPPED_STATION = '10001'
+
+    def _make_sd_source(self):
+        return EPGSource.objects.create(
+            name='SD Batch Failure',
+            source_type='schedules_direct',
+            username='sduser',
+            password='sdpass',
+        )
+
+    def _lineup_get_side_effect(self, url, **kwargs):
+        if url.endswith('/status'):
+            return MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={'systemStatus': [{'status': 'Online'}]}),
+            )
+        if url.endswith('/lineups'):
+            return MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={'lineups': [{'lineupID': 'USA-TEST-X'}]}),
+            )
+        if '/lineups/USA-TEST-X' in url:
+            return MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={
+                    'stations': [{
+                        'stationID': self.MAPPED_STATION,
+                        'name': 'Mapped Station',
+                        'callsign': 'MAP',
+                    }],
+                }),
+            )
+        raise AssertionError(f'Unexpected GET URL: {url}')
+
+    def _build_date_list(self, days=3):
+        today = date.today()
+        return [(today + timedelta(days=i)).strftime('%Y-%m-%d') for i in range(days)]
+
+    def _seed_full_window_program_data(self, epg, days=3):
+        today = date.today()
+        for i in range(days):
+            day = today + timedelta(days=i)
+            start = datetime(day.year, day.month, day.day, 12, 0, tzinfo=dt_timezone.utc)
+            ProgramData.objects.create(
+                epg=epg,
+                start_time=start,
+                end_time=start + timedelta(hours=1),
+                title='Show',
+                tvg_id=epg.tvg_id,
+            )
+
+    @staticmethod
+    def _json_mock(payload, status_code=200):
+        """A response mock that both response.json() and sd_parse_response_payload
+        (which sniffs Content-Type/body to decide whether to look for an
+        embedded SD error code) will recognize as a real JSON body."""
+        return MagicMock(
+            status_code=status_code,
+            json=MagicMock(return_value=payload),
+            content=json.dumps(payload).encode('utf-8'),
+            headers={'Content-Type': 'application/json'},
+        )
+
+    @patch('apps.epg.tasks.SD_DAYS_TO_FETCH', 3)
+    @patch('apps.epg.sd_tasks.time.sleep')
+    @patch('apps.epg.sd_tasks.send_epg_update')
+    @patch('apps.epg.sd_tasks.requests.get')
+    @patch('apps.epg.sd_tasks.requests.post')
+    def test_md5_fetch_failure_sets_error_instead_of_false_success(
+        self, mock_post, mock_get, mock_send_epg_update, mock_sleep,
+    ):
+        """Every /schedules/md5 attempt failing must not fall through to the
+        "no schedule changes detected" success path."""
+        import requests as req_lib
+        from apps.epg.tasks import fetch_schedules_direct
+
+        source = self._make_sd_source()
+        mapped_epg = EPGData.objects.create(
+            tvg_id=self.MAPPED_STATION,
+            name='Mapped',
+            epg_source=source,
+        )
+        Channel.objects.create(name='Mapped Ch', epg_data=mapped_epg)
+        mock_get.side_effect = self._lineup_get_side_effect
+
+        def post_side_effect(url, **kwargs):
+            if url.endswith('/token'):
+                return self._json_mock({'code': 0, 'token': 'tok'})
+            if url.endswith('/schedules/md5'):
+                raise req_lib.exceptions.ConnectionError('SD unreachable')
+            raise AssertionError(f'Unexpected POST URL: {url}')
+
+        mock_post.side_effect = post_side_effect
+
+        fetch_schedules_direct(source, force=True)
+
+        md5_calls = [c for c in mock_post.call_args_list if c[0][0].endswith('/schedules/md5')]
+        self.assertEqual(len(md5_calls), 3)  # retried twice, then gave up
+
+        source.refresh_from_db()
+        self.assertEqual(source.status, EPGSource.STATUS_ERROR)
+        self.assertIn('not refreshed this cycle', source.last_message.lower())
+
+    @patch('apps.epg.tasks.SD_DAYS_TO_FETCH', 3)
+    @patch('apps.epg.sd_tasks.time.sleep')
+    @patch('apps.epg.sd_tasks.send_epg_update')
+    @patch('apps.epg.sd_tasks.requests.get')
+    @patch('apps.epg.sd_tasks.requests.post')
+    def test_md5_fetch_retries_and_recovers_from_transient_errors(
+        self, mock_post, mock_get, mock_send_epg_update, mock_sleep,
+    ):
+        """A blip on the first two attempts must not fail the refresh if the
+        third attempt succeeds."""
+        import requests as req_lib
+        from apps.epg.tasks import fetch_schedules_direct
+
+        source = self._make_sd_source()
+        mapped_epg = EPGData.objects.create(
+            tvg_id=self.MAPPED_STATION,
+            name='Mapped',
+            epg_source=source,
+        )
+        Channel.objects.create(name='Mapped Ch', epg_data=mapped_epg)
+
+        date_list = self._build_date_list(3)
+        self._seed_full_window_program_data(mapped_epg, days=3)
+        today = date.today()
+        for i, ds in enumerate(date_list):
+            SDScheduleMD5.objects.create(
+                epg_source=source,
+                station_id=self.MAPPED_STATION,
+                date=today + timedelta(days=i),
+                md5=f'md5-{ds}',
+                last_modified=timezone.now(),
+            )
+        mock_get.side_effect = self._lineup_get_side_effect
+
+        md5_attempts = {'count': 0}
+        good_payload = {
+            self.MAPPED_STATION: {
+                ds: {'code': 0, 'md5': f'md5-{ds}', 'lastModified': '2026-06-11T00:00:00Z'}
+                for ds in date_list
+            },
+        }
+
+        def post_side_effect(url, **kwargs):
+            if url.endswith('/token'):
+                return self._json_mock({'code': 0, 'token': 'tok'})
+            if url.endswith('/schedules/md5'):
+                md5_attempts['count'] += 1
+                if md5_attempts['count'] < 3:
+                    raise req_lib.exceptions.ConnectionError('transient blip')
+                return self._json_mock(good_payload)
+            raise AssertionError(f'Unexpected POST URL: {url}')
+
+        mock_post.side_effect = post_side_effect
+
+        fetch_schedules_direct(source, force=True)
+
+        self.assertEqual(md5_attempts['count'], 3)
+        source.refresh_from_db()
+        self.assertEqual(source.status, EPGSource.STATUS_SUCCESS)
+
+    @patch('apps.epg.tasks.SD_DAYS_TO_FETCH', 3)
+    @patch('apps.epg.sd_tasks.time.sleep')
+    @patch('apps.epg.sd_tasks.send_epg_update')
+    @patch('apps.epg.sd_tasks.requests.get')
+    @patch('apps.epg.sd_tasks.requests.post')
+    def test_md5_embedded_service_offline_code_retries_then_succeeds(
+        self, mock_post, mock_get, mock_send_epg_update, mock_sleep,
+    ):
+        """SD's embedded {"code": 3000} (SERVICE_OFFLINE) on an HTTP 200
+        response must be retried like a network error, not treated as data."""
+        from apps.epg.tasks import fetch_schedules_direct
+
+        source = self._make_sd_source()
+        mapped_epg = EPGData.objects.create(
+            tvg_id=self.MAPPED_STATION,
+            name='Mapped',
+            epg_source=source,
+        )
+        Channel.objects.create(name='Mapped Ch', epg_data=mapped_epg)
+
+        date_list = self._build_date_list(3)
+        self._seed_full_window_program_data(mapped_epg, days=3)
+        today = date.today()
+        for i, ds in enumerate(date_list):
+            SDScheduleMD5.objects.create(
+                epg_source=source,
+                station_id=self.MAPPED_STATION,
+                date=today + timedelta(days=i),
+                md5=f'md5-{ds}',
+                last_modified=timezone.now(),
+            )
+        mock_get.side_effect = self._lineup_get_side_effect
+
+        md5_attempts = {'count': 0}
+        good_payload = {
+            self.MAPPED_STATION: {
+                ds: {'code': 0, 'md5': f'md5-{ds}', 'lastModified': '2026-06-11T00:00:00Z'}
+                for ds in date_list
+            },
+        }
+
+        def post_side_effect(url, **kwargs):
+            if url.endswith('/token'):
+                return self._json_mock({'code': 0, 'token': 'tok'})
+            if url.endswith('/schedules/md5'):
+                md5_attempts['count'] += 1
+                if md5_attempts['count'] < 3:
+                    return self._json_mock({
+                        'code': 3000,
+                        'message': 'Server offline for maintenance.',
+                    })
+                return self._json_mock(good_payload)
+            raise AssertionError(f'Unexpected POST URL: {url}')
+
+        mock_post.side_effect = post_side_effect
+
+        fetch_schedules_direct(source, force=True)
+
+        self.assertEqual(md5_attempts['count'], 3)
+        source.refresh_from_db()
+        self.assertEqual(source.status, EPGSource.STATUS_SUCCESS)
+
+    @patch('apps.epg.tasks.SD_DAYS_TO_FETCH', 3)
+    @patch('apps.epg.sd_tasks.time.sleep')
+    @patch('apps.epg.sd_tasks.send_epg_update')
+    @patch('apps.epg.sd_tasks.requests.get')
+    @patch('apps.epg.sd_tasks.requests.post')
+    def test_md5_embedded_non_retryable_code_fails_without_extra_attempts(
+        self, mock_post, mock_get, mock_send_epg_update, mock_sleep,
+    ):
+        """A non-soft embedded error code (e.g. 4001 ACCOUNT_EXPIRED) must not
+        waste retries, retrying it won't fix an account problem."""
+        from apps.epg.tasks import fetch_schedules_direct
+
+        source = self._make_sd_source()
+        mapped_epg = EPGData.objects.create(
+            tvg_id=self.MAPPED_STATION,
+            name='Mapped',
+            epg_source=source,
+        )
+        Channel.objects.create(name='Mapped Ch', epg_data=mapped_epg)
+        mock_get.side_effect = self._lineup_get_side_effect
+
+        md5_attempts = {'count': 0}
+
+        def post_side_effect(url, **kwargs):
+            if url.endswith('/token'):
+                return self._json_mock({'code': 0, 'token': 'tok'})
+            if url.endswith('/schedules/md5'):
+                md5_attempts['count'] += 1
+                return self._json_mock({'code': 4001, 'message': 'Account expired.'})
+            raise AssertionError(f'Unexpected POST URL: {url}')
+
+        mock_post.side_effect = post_side_effect
+
+        fetch_schedules_direct(source, force=True)
+
+        self.assertEqual(md5_attempts['count'], 1)
+        source.refresh_from_db()
+        self.assertEqual(source.status, EPGSource.STATUS_ERROR)
+
+    @patch('apps.epg.tasks.SD_DAYS_TO_FETCH', 3)
+    @patch('apps.epg.sd_tasks.time.sleep')
+    @patch('apps.epg.sd_tasks.send_epg_update')
+    @patch('apps.epg.sd_tasks.requests.get')
+    @patch('apps.epg.sd_tasks.requests.post')
+    def test_program_metadata_failure_skips_row_instead_of_placeholder(
+        self, mock_post, mock_get, mock_send_epg_update, mock_sleep,
+    ):
+        """A /programs batch that fails for a brand-new program (no prior
+        ProgramData to fall back on) must not write a "No Title" placeholder."""
+        import requests as req_lib
+        from apps.epg.tasks import fetch_schedules_direct
+
+        source = self._make_sd_source()
+        mapped_epg = EPGData.objects.create(
+            tvg_id=self.MAPPED_STATION,
+            name='Mapped',
+            epg_source=source,
+        )
+        Channel.objects.create(name='Mapped Ch', epg_data=mapped_epg)
+
+        date_list = self._build_date_list(3)
+        mock_get.side_effect = self._lineup_get_side_effect
+
+        schedule_payload = [{
+            'stationID': self.MAPPED_STATION,
+            'metadata': {
+                'startDate': date_list[0],
+                'md5': 'md5-' + date_list[0],
+                'modified': '2026-06-11T00:00:00Z',
+            },
+            'programs': [{
+                'programID': 'EP000000000099',
+                'airDateTime': f'{date_list[0]}T12:00:00Z',
+                'duration': 3600,
+                'md5': 'prog-md5-99',
+            }],
+        }]
+
+        def post_side_effect(url, **kwargs):
+            if url.endswith('/token'):
+                return self._json_mock({'code': 0, 'token': 'tok'})
+            if url.endswith('/schedules/md5'):
+                return self._json_mock({
+                    self.MAPPED_STATION: {
+                        ds: {'code': 0, 'md5': f'md5-{ds}', 'lastModified': '2026-06-11T00:00:00Z'}
+                        for ds in date_list
+                    },
+                })
+            if url.endswith('/schedules'):
+                return self._json_mock(schedule_payload)
+            if url.endswith('/programs'):
+                raise req_lib.exceptions.ConnectionError('SD unreachable')
+            raise AssertionError(f'Unexpected POST URL: {url}')
+
+        mock_post.side_effect = post_side_effect
+
+        fetch_schedules_direct(source, force=True)
+
+        self.assertEqual(ProgramData.objects.filter(epg=mapped_epg).count(), 0)
+        self.assertFalse(
+            ProgramData.objects.filter(epg=mapped_epg, title='No Title').exists()
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
What: Adds retry-with-backoff and proper failure handling to Schedules Direct's batched /schedules/md5, /schedules, and /programs requests.

Why: A failed MD5 batch was treated as "zero changes" and reported false success, a failed program metadata batch wrote placeholder "No Title" rows instead of retrying, and transient failures (timeouts, 5xx, SD's own embedded error codes on HTTP 200) weren't retried at all, so channels could silently end up with no guide data.