### PR TITLE
test(timeshift): mock is_catchup_enabled in the catchup redirect tests

### DIFF
--- a/apps/timeshift/tests/test_catchup_redirect.py
+++ b/apps/timeshift/tests/test_catchup_redirect.py
@@ -92,6 +92,9 @@ class CatchupRedirectViewTests(SimpleTestCase):
             patch.object(views, "get_channel_catchup_streams", return_value=[stream])
         )
         stack.enter_context(
+            patch.object(views, "is_catchup_enabled", return_value=True)
+        )
+        stack.enter_context(
             patch.object(views, "resolve_catchup_duration", return_value=40)
         )
         stack.enter_context(


### PR DESCRIPTION
## Description

Fixes a hidden database dependency in `apps/timeshift/tests/test_catchup_redirect.py` that makes six of its tests fail in a single-process full-suite run, as discussed in #1510.

`CatchupRedirectViewTests` is a `SimpleTestCase` that patches `is_default_stream_profile_redirect` but not `is_catchup_enabled`, so `_serve_catchup` reads `CoreSettings.get_system_settings()` on every request. That read is normally absorbed by the Redis-backed settings group cache, which an earlier test happens to have filled — so the missing mock is invisible in the sharded CI jobs and only surfaces when something invalidates the group first. Any test that saves a settings row does exactly that, because the invalidation is not rolled back with the test transaction. With the cache cold the query trips `DatabaseOperationForbidden` in six tests.

The fix patches `is_catchup_enabled` alongside the other view collaborators the class already mocks — three lines, no production code touched.

## Related Issue

Discussed in #1510 (the settings coercion test there exposed it; its locmem override avoids triggering this, this PR removes the fragility itself).

## How was it tested?

Single-process full-suite runs (`scripts/ci_bootstrap_backend.sh` with the 16 CI labels, in `ghcr.io/dispatcharr/dispatcharr:base-dev`):

- `7931c3bd` (before #1446, where the failure reproduces): 6 failures + 1 error without this fix → **1 error with it** (the six are cured).
- Current `dev` (`f7d87b4d`) with this fix: 1823 tests, same single pre-existing error, no regressions.

The remaining error in both runs is `CatchupProxyTests.test_missing_session_id_redirects` (`psycopg.OperationalError: the connection is closed`), which is unrelated, pre-existing on `dev`, and only occurs in full-suite runs.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed (none changed)
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema (no endpoints added)
- [x] Frontend: ESLint and Prettier pass cleanly (no frontend changes)
- [x] Tests are included for new functionality (test-only change)
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
