### PR TITLE
test(logo): Add the LOGO_NAME_MAX_LENGTH export to the LogoUtils mock

### DIFF
--- a/frontend/src/components/forms/__tests__/Logo.test.jsx
+++ b/frontend/src/components/forms/__tests__/Logo.test.jsx
@@ -4,6 +4,7 @@ import LogoForm from '../Logo';
 
 // ── Utility mocks ──────────────────────────────────────────────────────────────
 vi.mock('../../../utils/forms/LogoUtils.js', () => ({
+  LOGO_NAME_MAX_LENGTH: 255, // keep in step with LogoUtils.js
   createLogo: vi.fn(),
   updateLogo: vi.fn(),
   uploadLogo: vi.fn(),


### PR DESCRIPTION
## Description

Restores the frontend test suite on `dev`, which has been failing since #1547 merged. That PR wired `LOGO_NAME_MAX_LENGTH` from `LogoUtils` into the logo form's name input, but `Logo.test.jsx` mocks that module with an explicit factory, so the new export was missing from the mock and every render in the suite crashed — 31 failures, and a red `test` check on every open PR based on current `dev`.

One-line fix: add the constant to the mock factory.

## Related Issue

Closes #

## How was it tested?

- `npx vitest run src/components/forms/__tests__/Logo.test.jsx`: 31/31 pass (all 31 failed before the fix, reproducing the CI failure exactly).
- Full frontend suite: 202 files, 6130 tests, all pass.
- Prettier and ESLint clean on the changed file.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
