### PR TITLE
feat: auto-fallback to AAC output profile on live-player MediaError

### DIFF
--- a/frontend/src/components/FloatingVideo.jsx
+++ b/frontend/src/components/FloatingVideo.jsx
@@ -516,17 +516,24 @@ export default function FloatingVideo() {
       if (typeof savedMuted === 'boolean') videoRef.current.muted = savedMuted;
 
       player.on(mpegts.Events.LOADING_COMPLETE, () => {
+        // mpegts.js can emit events asynchronously from a player instance
+        // that has since been destroyed and replaced (e.g. by our own
+        // reconnect below) -- ignore anything from a stale, no-longer-active
+        // player rather than let it mutate shared state.
+        if (playerRef.current !== player) return;
         setIsLoading(false);
         // Data is flowing again -- give future errors a fresh retry budget.
         reconnectAttemptsRef.current = 0;
       });
 
       player.on(mpegts.Events.METADATA_ARRIVED, () => {
+        if (playerRef.current !== player) return;
         setIsLoading(false);
         reconnectAttemptsRef.current = 0;
       });
 
       player.on(mpegts.Events.ERROR, (errorType, errorDetail) => {
+        if (playerRef.current !== player) return;
         setIsLoading(false);
 
         if (errorType === 'NetworkError' && errorDetail?.includes('aborted')) {
@@ -570,9 +577,15 @@ export default function FloatingVideo() {
       player.load();
 
       player.on(mpegts.Events.MEDIA_INFO, () => {
+        if (playerRef.current !== player) return;
         setIsLoading(false);
         try {
           player.play().catch((e) => {
+            // This player may have already been replaced by the time the
+            // play() promise settles (e.g. a reconnect fired in the
+            // meantime) -- a rejection from a now-stale player must not
+            // stomp the current, possibly-successful player's state.
+            if (playerRef.current !== player) return;
             console.log('Auto-play prevented:', e);
             setLoadError('Auto-play was prevented. Click play to start.');
           });

--- a/frontend/src/components/FloatingVideo.jsx
+++ b/frontend/src/components/FloatingVideo.jsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Draggable from 'react-draggable';
 import useVideoStore from '../store/useVideoStore';
 import useAuthStore from '../store/auth';
+import useOutputProfilesStore from '../store/outputProfiles';
 import mpegts from 'mpegts.js';
 import Hls from 'hls.js';
 import { CloseButton, Flex, Loader, Text, Box } from '@mantine/core';
@@ -14,7 +15,16 @@ import {
   getVODPlayerErrorMessage,
   getPlayerPrefs,
   savePlayerPrefs,
+  getOutputProfileParam,
+  setOutputProfileParam,
 } from '../utils/components/FloatingVideoUtils.js';
+
+// Locked, seeded-on-install OutputProfile (core/migrations/0024_outputprofile.py)
+// that transcodes to AAC audio -- the one profile guaranteed to be playable by
+// browser MediaSource Extensions. Used as a one-shot automatic fallback when
+// the live player hits a MediaError (e.g. a source using AC3 audio, which no
+// browser can decode via MSE).
+const WEB_PLAYER_AAC_PROFILE_NAME = 'Web Player (AAC Audio)';
 
 // Native <video src> cannot send Authorization headers. Append ?token= at playback
 // time (not when building the URL in cards/modals) so the JWT is fresh. hls.js
@@ -149,6 +159,10 @@ export default function FloatingVideo() {
   // mpegts.js live-player reconnect bookkeeping (see initializeLivePlayer).
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef(null);
+  // Tracks whether we've already tried the one-shot AAC output-profile
+  // fallback for the current stream (see initializeLivePlayer).
+  const mediaFallbackAttemptedRef = useRef(false);
+  const mediaFallbackTimeoutRef = useRef(null);
 
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState(null);
@@ -233,6 +247,12 @@ export default function FloatingVideo() {
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current);
       reconnectTimeoutRef.current = null;
+    }
+
+    // Clear any pending AAC-profile fallback attempt
+    if (mediaFallbackTimeoutRef.current) {
+      clearTimeout(mediaFallbackTimeoutRef.current);
+      mediaFallbackTimeoutRef.current = null;
     }
   };
 
@@ -453,9 +473,13 @@ export default function FloatingVideo() {
     };
   };
 
-  // Initialize live stream player (mpegts.js)
-  const initializeLivePlayer = () => {
-    if (!videoRef.current || !streamUrl) return;
+  // Initialize live stream player (mpegts.js). `overrideUrl`, when passed,
+  // is used instead of the store's `streamUrl` -- e.g. the AAC-profile
+  // fallback below reconnects to the same channel with a different
+  // `output_profile` query param baked in.
+  const initializeLivePlayer = (overrideUrl) => {
+    const effectiveStreamUrl = overrideUrl || streamUrl;
+    if (!videoRef.current || !effectiveStreamUrl) return;
 
     setIsLoading(true);
     setLoadError(null);
@@ -473,9 +497,9 @@ export default function FloatingVideo() {
       // mpegts.js workers run in WorkerGlobalScope where relative URLs are
       // not resolved against the page origin. Always pass an absolute URL.
       const absoluteStreamUrl =
-        streamUrl.startsWith('/') && typeof window !== 'undefined'
-          ? `${window.location.origin}${streamUrl}`
-          : streamUrl;
+        effectiveStreamUrl.startsWith('/') && typeof window !== 'undefined'
+          ? `${window.location.origin}${effectiveStreamUrl}`
+          : effectiveStreamUrl;
 
       // Read the JWT from the auth store at player-creation time rather than
       // relying on the closure-captured `accessToken` value.  mpegts.js has
@@ -524,12 +548,14 @@ export default function FloatingVideo() {
         setIsLoading(false);
         // Data is flowing again -- give future errors a fresh retry budget.
         reconnectAttemptsRef.current = 0;
+        mediaFallbackAttemptedRef.current = false;
       });
 
       player.on(mpegts.Events.METADATA_ARRIVED, () => {
         if (playerRef.current !== player) return;
         setIsLoading(false);
         reconnectAttemptsRef.current = 0;
+        mediaFallbackAttemptedRef.current = false;
       });
 
       player.on(mpegts.Events.ERROR, (errorType, errorDetail) => {
@@ -569,6 +595,41 @@ export default function FloatingVideo() {
             safeDestroyPlayer();
             initializeLivePlayer();
           }, delay);
+        } else if (
+          errorType === 'MediaError' &&
+          !mediaFallbackAttemptedRef.current
+        ) {
+          // A MediaError means the browser can't decode a codec in this
+          // stream (most commonly AC3 audio, which no browser supports via
+          // MediaSource Extensions). Unlike a NetworkError, this is
+          // deterministic against the *current* output profile -- but a
+          // one-shot switch to the locked "Web Player (AAC Audio)" profile
+          // (core/migrations/0024_outputprofile.py, guaranteed to exist and
+          // can't be deleted) transcodes the audio into something every
+          // browser can play. Only attempted once per stream, and skipped
+          // entirely if we're already on that profile, to avoid ever looping.
+          const aacProfile = useOutputProfilesStore
+            .getState()
+            .profiles.find((p) => p.name === WEB_PLAYER_AAC_PROFILE_NAME);
+          const currentProfileId = getOutputProfileParam(effectiveStreamUrl);
+
+          if (aacProfile && String(aacProfile.id) !== currentProfileId) {
+            mediaFallbackAttemptedRef.current = true;
+            const fallbackUrl = setOutputProfileParam(
+              effectiveStreamUrl,
+              aacProfile.id
+            );
+            setLoadError(
+              'Audio format not supported -- retrying with a compatible profile...'
+            );
+            mediaFallbackTimeoutRef.current = setTimeout(() => {
+              mediaFallbackTimeoutRef.current = null;
+              safeDestroyPlayer();
+              initializeLivePlayer(fallbackUrl);
+            }, 0);
+          } else {
+            setLoadError(getLivePlayerErrorMessage(errorType, errorDetail));
+          }
         } else {
           setLoadError(getLivePlayerErrorMessage(errorType, errorDetail));
         }
@@ -624,6 +685,7 @@ export default function FloatingVideo() {
     // Fresh stream selection -- give it a full reconnect budget, independent
     // of whatever a previously viewed channel had used up.
     reconnectAttemptsRef.current = 0;
+    mediaFallbackAttemptedRef.current = false;
 
     // Initialize the appropriate player based on content type
     if (contentType === 'vod') {

--- a/frontend/src/components/FloatingVideo.jsx
+++ b/frontend/src/components/FloatingVideo.jsx
@@ -146,6 +146,9 @@ export default function FloatingVideo() {
   // Ref kept in sync with videoSize state for use inside event handlers
   // where closures over state would be stale.
   const videoSizeRef = useRef(null);
+  // mpegts.js live-player reconnect bookkeeping (see initializeLivePlayer).
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimeoutRef = useRef(null);
 
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState(null);
@@ -180,6 +183,9 @@ export default function FloatingVideo() {
   const VISIBLE_MARGIN = 48; // keep part of the window visible when dragging
   const HEADER_HEIGHT = 38; // height of the close button header area
   const ERROR_HEIGHT = 45; // approximate height of error message area when displayed
+  const MAX_LIVE_RECONNECT_ATTEMPTS = 5;
+  const LIVE_RECONNECT_BASE_DELAY_MS = 1000;
+  const LIVE_RECONNECT_MAX_DELAY_MS = 10000;
 
   // Safely destroy the mpegts player to prevent errors
   const safeDestroyPlayer = () => {
@@ -221,6 +227,12 @@ export default function FloatingVideo() {
     if (overlayTimeoutRef.current) {
       clearTimeout(overlayTimeoutRef.current);
       overlayTimeoutRef.current = null;
+    }
+
+    // Clear any pending live-player reconnect attempt
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
     }
   };
 
@@ -505,18 +517,52 @@ export default function FloatingVideo() {
 
       player.on(mpegts.Events.LOADING_COMPLETE, () => {
         setIsLoading(false);
+        // Data is flowing again -- give future errors a fresh retry budget.
+        reconnectAttemptsRef.current = 0;
       });
 
       player.on(mpegts.Events.METADATA_ARRIVED, () => {
         setIsLoading(false);
+        reconnectAttemptsRef.current = 0;
       });
 
       player.on(mpegts.Events.ERROR, (errorType, errorDetail) => {
         setIsLoading(false);
 
-        if (errorType !== 'NetworkError' || !errorDetail?.includes('aborted')) {
-          console.error('Player error:', errorType, errorDetail);
+        if (errorType === 'NetworkError' && errorDetail?.includes('aborted')) {
+          return;
+        }
 
+        console.error('Player error:', errorType, errorDetail);
+
+        // Only retry NetworkError -- it's the one error class that's actually
+        // transient (dropped connection, backend hiccup the backend itself
+        // recovers from). MediaError (unsupported codec) and other error
+        // types are deterministic: retrying would just fail identically
+        // every time and delay showing the user an actionable message.
+        //
+        // Unlike hls.js (startLoad()/recoverMediaError()), mpegts.js has no
+        // partial-recovery API -- a fatal error leaves the underlying player
+        // unusable, so the only way to self-heal is a full destroy + rebuild.
+        if (
+          errorType === 'NetworkError' &&
+          reconnectAttemptsRef.current < MAX_LIVE_RECONNECT_ATTEMPTS
+        ) {
+          reconnectAttemptsRef.current += 1;
+          const attempt = reconnectAttemptsRef.current;
+          const delay = Math.min(
+            LIVE_RECONNECT_BASE_DELAY_MS * 2 ** (attempt - 1),
+            LIVE_RECONNECT_MAX_DELAY_MS
+          );
+          setLoadError(
+            `Connection lost, reconnecting... (attempt ${attempt}/${MAX_LIVE_RECONNECT_ATTEMPTS})`
+          );
+          reconnectTimeoutRef.current = setTimeout(() => {
+            reconnectTimeoutRef.current = null;
+            safeDestroyPlayer();
+            initializeLivePlayer();
+          }, delay);
+        } else {
           setLoadError(getLivePlayerErrorMessage(errorType, errorDetail));
         }
       });
@@ -562,6 +608,9 @@ export default function FloatingVideo() {
 
     // Clean up any existing player
     safeDestroyPlayer();
+    // Fresh stream selection -- give it a full reconnect budget, independent
+    // of whatever a previously viewed channel had used up.
+    reconnectAttemptsRef.current = 0;
 
     // Initialize the appropriate player based on content type
     if (contentType === 'vod') {

--- a/frontend/src/components/__tests__/FloatingVideo.test.jsx
+++ b/frontend/src/components/__tests__/FloatingVideo.test.jsx
@@ -419,6 +419,134 @@ describe('FloatingVideo', () => {
     });
   });
 
+  describe('Live stream stale-player-instance guards', () => {
+    beforeEach(() => {
+      useVideoStore.mockImplementation((selector) => {
+        const state = {
+          isVisible: true,
+          streamUrl: 'http://example.com/stream.ts',
+          contentType: 'live',
+          metadata: null,
+          hideVideo: mockHideVideo,
+        };
+        return selector ? selector(state) : state;
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Every other test in this file reuses one shared mockPlayer instance
+    // across destroy+recreate cycles, so `playerRef.current !== player`
+    // (the guard under test here) can never actually be true there -- it's
+    // trivially the same object. These tests give each createPlayer() call
+    // its own distinct instance instead, so a "stale" callback captured
+    // from an earlier, since-replaced instance is meaningfully different
+    // from the current one, the way it is in a real browser.
+    const mockDistinctPlayerInstances = () => {
+      const instances = [];
+      mpegts.createPlayer.mockImplementation(() => {
+        const instance = {
+          attachMediaElement: vi.fn(),
+          load: vi.fn(),
+          play: vi.fn(() => Promise.resolve()),
+          pause: vi.fn(),
+          destroy: vi.fn(),
+          on: vi.fn(),
+        };
+        instances.push(instance);
+        return instance;
+      });
+      return instances;
+    };
+
+    const getCallback = (instance, eventName) =>
+      instance.on.mock.calls.find((call) => call[0] === eventName)?.[1];
+
+    it('should ignore a late NetworkError from a player already replaced by a reconnect', async () => {
+      vi.useFakeTimers();
+      const instances = mockDistinctPlayerInstances();
+      render(<FloatingVideo />);
+      expect(instances).toHaveLength(1);
+
+      // Player #1 hits a NetworkError -> schedules a reconnect (1000ms).
+      act(() => {
+        getCallback(instances[0], mpegts.Events.ERROR)(
+          'NetworkError',
+          'connection lost'
+        );
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(instances).toHaveLength(2); // reconnect created player #2
+
+      // A second NetworkError arrives late from player #1 -- already
+      // replaced by player #2 by the time this fires (mirrors a real
+      // mpegts.js worker message that was already in flight when we tore
+      // player #1 down).
+      act(() => {
+        getCallback(instances[0], mpegts.Events.ERROR)(
+          'NetworkError',
+          'connection lost'
+        );
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10000);
+      });
+
+      // Must be a no-op: no third player created, and the current player
+      // #2 must not have been torn down.
+      expect(instances).toHaveLength(2);
+      expect(instances[1].destroy).not.toHaveBeenCalled();
+    });
+
+    it('should ignore a late autoplay-prevented rejection from a replaced player', async () => {
+      vi.useFakeTimers();
+      const instances = mockDistinctPlayerInstances();
+      // Player #1's play() call resolves only after we've moved on to
+      // player #2, simulating a slow/late-settling promise.
+      let rejectFirstPlay;
+      render(<FloatingVideo />);
+      instances[0].play.mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectFirstPlay = reject;
+        })
+      );
+
+      // Trigger player #1's MEDIA_INFO -> its play() call is now pending.
+      act(() => {
+        getCallback(instances[0], mpegts.Events.MEDIA_INFO)();
+      });
+
+      // A NetworkError replaces player #1 with player #2 (reconnect).
+      act(() => {
+        getCallback(instances[0], mpegts.Events.ERROR)(
+          'NetworkError',
+          'connection lost'
+        );
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(instances).toHaveLength(2);
+
+      // Player #1's play() promise finally rejects (autoplay-prevented),
+      // long after player #2 took over.
+      await act(async () => {
+        rejectFirstPlay(new DOMException('', 'NotAllowedError'));
+        await Promise.resolve().catch(() => {});
+      });
+
+      // Must not show the stale "Auto-play was prevented" message, since
+      // it refers to a player instance that is no longer active.
+      expect(
+        screen.queryByText(/Auto-play was prevented/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe('VOD Player', () => {
     beforeEach(() => {
       useVideoStore.mockImplementation((selector) => {

--- a/frontend/src/components/__tests__/FloatingVideo.test.jsx
+++ b/frontend/src/components/__tests__/FloatingVideo.test.jsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import FloatingVideo from '../FloatingVideo';
 import useVideoStore from '../../store/useVideoStore';
@@ -246,6 +252,170 @@ describe('FloatingVideo', () => {
       await mediaInfoCallback();
 
       expect(mockPlayer.play).toHaveBeenCalled();
+    });
+  });
+
+  describe('Live stream reconnect', () => {
+    beforeEach(() => {
+      useVideoStore.mockImplementation((selector) => {
+        const state = {
+          isVisible: true,
+          streamUrl: 'http://example.com/stream.ts',
+          contentType: 'live',
+          metadata: null,
+          hideVideo: mockHideVideo,
+        };
+        return selector ? selector(state) : state;
+      });
+    });
+
+    // The mock always returns the same mockPlayer instance across
+    // destroy+recreate cycles, so mockPlayer.on.mock.calls accumulates every
+    // registration made so far. Grab the most recently registered handler --
+    // the one bound to the currently "live" player -- not the first.
+    const getErrorCallback = () =>
+      mockPlayer.on.mock.calls
+        .filter((call) => call[0] === mpegts.Events.ERROR)
+        .at(-1)?.[1];
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should destroy and recreate the player after a NetworkError, with backoff', async () => {
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(1);
+
+      const errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('NetworkError', 'connection lost');
+      });
+
+      expect(
+        screen.getByText(/reconnecting\.\.\. \(attempt 1\/5\)/i)
+      ).toBeInTheDocument();
+      expect(mockPlayer.destroy).not.toHaveBeenCalled();
+
+      // First retry fires after the base delay (1000ms), not immediately.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(999);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mockPlayer.destroy).toHaveBeenCalledTimes(1);
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(2);
+    });
+
+    it('should give up after 5 NetworkError attempts and show a permanent error', async () => {
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      const delays = [1000, 2000, 4000, 8000, 10000];
+      for (let i = 0; i < delays.length; i++) {
+        const errorCallback = getErrorCallback();
+        act(() => {
+          errorCallback('NetworkError', 'connection lost');
+        });
+        expect(
+          screen.getByText(new RegExp(`attempt ${i + 1}/5`, 'i'))
+        ).toBeInTheDocument();
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(delays[i]);
+        });
+      }
+
+      // All 5 attempts used -- the 6th NetworkError should not schedule
+      // another retry and should surface the real error message instead.
+      const finalErrorCallback = getErrorCallback();
+      act(() => {
+        finalErrorCallback('NetworkError', 'connection lost');
+      });
+
+      expect(
+        screen.getByText(/NetworkError - connection lost/i)
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/reconnecting/i)).not.toBeInTheDocument();
+    });
+
+    it('should not retry a MediaError (non-transient, retrying would not help)', async () => {
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      const errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('MediaError', 'AC3 codec not supported');
+      });
+
+      expect(
+        screen.getByText(/Audio codec not supported/i)
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/reconnecting/i)).not.toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15000);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reset the retry budget after the stream recovers', async () => {
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      let errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('NetworkError', 'connection lost');
+      });
+      expect(screen.getByText(/attempt 1\/5/i)).toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(2);
+
+      // Stream recovers -- LOADING_COMPLETE resets the attempt counter.
+      const loadingCompleteCallback = mockPlayer.on.mock.calls
+        .filter((call) => call[0] === mpegts.Events.LOADING_COMPLETE)
+        .at(-1)?.[1];
+      act(() => {
+        loadingCompleteCallback();
+      });
+
+      // A subsequent error should again start at attempt 1, not 2.
+      errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('NetworkError', 'connection lost');
+      });
+      expect(screen.getByText(/attempt 1\/5/i)).toBeInTheDocument();
+    });
+
+    it('should not fire a queued reconnect after the player is closed', async () => {
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      const errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('NetworkError', 'connection lost');
+      });
+      expect(screen.getByText(/attempt 1\/5/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('close-button'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50); // handleClose's setTimeout(hideVideo, 50)
+      });
+
+      const createPlayerCallsAfterClose = mpegts.createPlayer.mock.calls.length;
+
+      // Advance well past the scheduled reconnect delay -- it must not fire.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10000);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(
+        createPlayerCallsAfterClose
+      );
     });
   });
 

--- a/frontend/src/components/__tests__/FloatingVideo.test.jsx
+++ b/frontend/src/components/__tests__/FloatingVideo.test.jsx
@@ -8,6 +8,7 @@ import {
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import FloatingVideo from '../FloatingVideo';
 import useVideoStore from '../../store/useVideoStore';
+import useOutputProfilesStore from '../../store/outputProfiles';
 
 // Mock the video store
 vi.mock('../../store/useVideoStore');
@@ -416,6 +417,139 @@ describe('FloatingVideo', () => {
       expect(mpegts.createPlayer).toHaveBeenCalledTimes(
         createPlayerCallsAfterClose
       );
+    });
+  });
+
+  describe('Live stream AAC-profile fallback', () => {
+    const AAC_PROFILE = { id: 42, name: 'Web Player (AAC Audio)' };
+
+    beforeEach(() => {
+      useVideoStore.mockImplementation((selector) => {
+        const state = {
+          isVisible: true,
+          streamUrl: 'http://example.com/stream.ts?output_format=mpegts',
+          contentType: 'live',
+          metadata: null,
+          hideVideo: mockHideVideo,
+        };
+        return selector ? selector(state) : state;
+      });
+      useOutputProfilesStore.setState({ profiles: [AAC_PROFILE] });
+    });
+
+    afterEach(() => {
+      useOutputProfilesStore.setState({ profiles: [] });
+      vi.useRealTimers();
+    });
+
+    const getErrorCallback = () =>
+      mockPlayer.on.mock.calls
+        .filter((call) => call[0] === mpegts.Events.ERROR)
+        .at(-1)?.[1];
+
+    it('should retry once with the AAC profile on a MediaError', async () => {
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      const errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('MediaError', 'AC3 codec not supported');
+      });
+
+      expect(
+        screen.getByText(/retrying with a compatible profile/i)
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(2);
+      const secondCallUrl = mpegts.createPlayer.mock.calls[1][0].url;
+      expect(secondCallUrl).toContain('output_profile=42');
+    });
+
+    it('should not retry a second time if the AAC-profile attempt also errors', async () => {
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      let errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('MediaError', 'AC3 codec not supported');
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(2);
+
+      // The AAC-profile player itself now fails too.
+      errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('MediaError', 'still broken');
+      });
+
+      expect(
+        screen.getByText(/codec not supported|Media codec/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/retrying with a compatible profile/i)
+      ).not.toBeInTheDocument();
+
+      // No further reconnect attempt should ever be scheduled.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15000);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not retry if already on the AAC profile', async () => {
+      useVideoStore.mockImplementation((selector) => {
+        const state = {
+          isVisible: true,
+          streamUrl:
+            'http://example.com/stream.ts?output_format=mpegts&output_profile=42',
+          contentType: 'live',
+          metadata: null,
+          hideVideo: mockHideVideo,
+        };
+        return selector ? selector(state) : state;
+      });
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      const errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('MediaError', 'still broken');
+      });
+
+      expect(
+        screen.getByText(/codec not supported|Media codec/i)
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15000);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not retry if the AAC profile is not available', async () => {
+      useOutputProfilesStore.setState({ profiles: [] });
+      vi.useFakeTimers();
+      render(<FloatingVideo />);
+
+      const errorCallback = getErrorCallback();
+      act(() => {
+        errorCallback('MediaError', 'AC3 codec not supported');
+      });
+
+      expect(
+        screen.getByText(/codec not supported|Media codec/i)
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15000);
+      });
+      expect(mpegts.createPlayer).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/utils/components/FloatingVideoUtils.js
+++ b/frontend/src/utils/components/FloatingVideoUtils.js
@@ -13,6 +13,27 @@ export const buildLiveStreamUrl = (path) => {
   return `${path}?${params.toString()}`;
 };
 
+/**
+ * Read the `output_profile` query param from a live-stream URL built by
+ * buildLiveStreamUrl(), or null if unset.
+ */
+export const getOutputProfileParam = (url) => {
+  if (!url || typeof url !== 'string') return null;
+  const [, query = ''] = url.split('?');
+  return new URLSearchParams(query).get('output_profile');
+};
+
+/**
+ * Return a copy of a live-stream URL with `output_profile` set/replaced.
+ */
+export const setOutputProfileParam = (url, profileId) => {
+  if (!url || typeof url !== 'string') return url;
+  const [base, query = ''] = url.split('?');
+  const params = new URLSearchParams(query);
+  params.set('output_profile', String(profileId));
+  return `${base}?${params.toString()}`;
+};
+
 export const getPlayerPrefs = () => {
   try {
     return JSON.parse(localStorage.getItem(PLAYER_PREFS_KEY) || '{}');


### PR DESCRIPTION
## Description

Browsers' MediaSource Extensions can't decode AC3 audio. A live channel whose source (or
whose currently-selected Output Profile) produces AC3 audio plays with no sound and shows
"Your browser doesn't support the codecs used in this stream." The app already has a fix
for exactly this — a locked, seeded-on-install `OutputProfile` named "Web Player (AAC
Audio)" (`core/migrations/0024_outputprofile.py`) that transcodes to AAC — but the web
player didn't use it automatically; the user had to know to go select it in Settings.

This PR: on a `MediaError`, if the player isn't already using that profile, makes one
automatic attempt — destroy the player, look up the AAC profile's id from the
already-app-wide-loaded `useOutputProfilesStore`, rebuild the stream URL with
`output_profile=<that id>`, and recreate the player. If it's already on that profile (or
the profile can't be found), falls straight through to the existing error message — no
infinite loop, no repeated attempts.

New helpers in `FloatingVideoUtils.js`: `getOutputProfileParam(url)` /
`setOutputProfileParam(url, id)`, since `FloatingVideo.jsx` receives an already-built
stream URL from its caller (channel tables etc.) rather than constructing it itself.

Builds on #1567 (the stale-player-instance guard from that PR is what makes this
fallback's destroy/recreate reliable — without it, a late event from the pre-fallback
player could revert a successful fallback back to the broken state, which is exactly how
that bug was originally found, live-testing an earlier version of this change).

## Related Issue

Closes #1566

## How was it tested?

**Automated**: 4 new Vitest tests covering the fallback decision logic: retries once with
the AAC profile on `MediaError`, does not retry a second time if the AAC-profile attempt
also errors (no infinite loop), does not retry if already on the AAC profile, and does
not retry if the AAC profile isn't available in the store. Full existing suite (6100+
tests, including the stale-guard tests from #1567) also passes, no regressions. ESLint
and Prettier clean on all changed files (pre-existing lint warnings elsewhere in the file
are untouched, per the "don't reformat outside scope" guidance).

**Live**: built this branch into a local `dispatch-test-aio` instance and tested against
real IPTV streams with AC3 audio. Confirmed via backend proxy logs (`Stream #0:1 -> #0:1
(ac3 (native) -> aac (native))`) and audibly on-screen that audio now works automatically
on channels that previously played silently — including one case where the source audio
was already AAC-native but the currently-selected Output Profile was itself transcoding
it *into* AC3 (same symptom, confirms the fallback isn't limited to raw AC3-passthrough
sources specifically). Repeated attempts on the same channels showed a clean single
profile-switch in the backend logs with no flapping back to the broken state.

## Checklist

- [x] I have read the CONTRIBUTING.md in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed (N/A — frontend-only change)
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema (N/A — no new endpoints)
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
