### PR TITLE
fix(dvr): series rule mode "new" honours previously-shown, not just new

### DIFF
--- a/apps/channels/api_views.py
+++ b/apps/channels/api_views.py
@@ -4278,7 +4278,15 @@ class SeriesRulePreviewAPIView(APIView):
         # over the bounded result set we already filtered down to.
         candidates = list(qs[:limit * 4])  # small overshoot to allow new-only filtering
         if mode == "new":
-            candidates = [p for p in candidates if (p.custom_properties or {}).get("new")]
+            # PATCH 13: preview previously_shown. Mirrors the scheduler filter
+            # in _evaluate_series_rules_locked: XMLTV feeds may mark first runs
+            # with <new/> OR mark repeats with <previously-shown/>, and testing
+            # only the former hides every programme on a feed using the latter.
+            candidates = [
+                p for p in candidates
+                if (p.custom_properties or {}).get("new")
+                or not (p.custom_properties or {}).get("previously_shown")
+            ]
 
         total = len(candidates)
         candidates = candidates[:limit]
@@ -4296,7 +4304,8 @@ class SeriesRulePreviewAPIView(APIView):
                 "end_time": p.end_time.isoformat(),
                 "season": cp.get("season"),
                 "episode": cp.get("episode"),
-                "is_new": bool(cp.get("new")),
+                "is_new": bool(cp.get("new"))
+                or not cp.get("previously_shown"),
             })
 
         return Response({

--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -751,10 +751,18 @@ def _evaluate_series_rules_locked(tvg_id, result):
 
         # Optionally filter to only brand-new episodes before grouping
         if mode == "new":
+            # PATCH 12: previously_shown. XMLTV allows a feed to mark first runs
+            # with <new/> OR to mark repeats with <previously-shown/>. Testing only
+            # the former makes this rule match NOTHING on a feed that uses the
+            # latter - which is every feed here (measured 2026-08-19: the "new" key
+            # is absent on all programmes across all four auepg feeds, while repeats
+            # carry "previously_shown"). Neither tag counts as new, erring toward
+            # recording: an extra capture costs disk, a missed one is unrecoverable.
             filtered = []
             for p in programs:
                 try:
-                    if (p.custom_properties or {}).get("new"):
+                    props = p.custom_properties or {}
+                    if props.get("new") or not props.get("previously_shown"):
                         filtered.append(p)
                 except Exception:
                     pass

--- a/apps/channels/tests/test_series_rule_new_mode.py
+++ b/apps/channels/tests/test_series_rule_new_mode.py
@@ -1,0 +1,102 @@
+"""Tests for series rule mode="new" against both XMLTV freshness conventions.
+
+XMLTV lets a feed mark first runs with <new/> or mark repeats with
+<previously-shown/>. Accepting only the first convention makes a mode="new" rule
+match nothing at all on a feed that uses the second, and the failure is silent:
+a rule that matches nothing looks exactly like a show that is not airing.
+"""
+from datetime import timedelta
+from unittest.mock import patch
+
+from apps.channels.models import Recording
+from apps.channels.tests.test_series_rule_dedup import (
+    SeriesRuleDedupBaseTestCase,
+    _set_series_rules,
+)
+
+
+@patch("apps.channels.tasks.prefetch_recording_artwork")
+@patch("apps.channels.signals.schedule_recording_task", return_value="mock-task-id")
+class SeriesRuleNewModeTests(SeriesRuleDedupBaseTestCase):
+    """mode="new" must recognise first runs under either convention."""
+
+    def setUp(self):
+        super().setUp()
+        _set_series_rules([{
+            "tvg_id": "test.channel.1",
+            "mode": "new",
+            "title": "Test Show",
+        }])
+
+    def _programme(self, hours, props, sub_title="Episode 1"):
+        from apps.epg.models import ProgramData
+        start = self.now + timedelta(hours=hours)
+        return ProgramData.objects.create(
+            epg=self.epg, tvg_id="test.channel.1",
+            start_time=start, end_time=start + timedelta(hours=1),
+            title="Test Show", sub_title=sub_title,
+            custom_properties=props,
+        )
+
+    @patch("apps.channels.tasks.acquire_task_lock", return_value=True)
+    @patch("apps.channels.tasks.release_task_lock")
+    def test_new_tag_still_recorded(self, mock_release, mock_lock,
+                                    mock_schedule, mock_artwork):
+        """The existing convention keeps working."""
+        from apps.channels.tasks import evaluate_series_rules_impl
+
+        self._programme(2, {"new": True})
+        self.assertEqual(evaluate_series_rules_impl()["scheduled"], 1)
+        self.assertEqual(Recording.objects.count(), 1)
+
+    @patch("apps.channels.tasks.acquire_task_lock", return_value=True)
+    @patch("apps.channels.tasks.release_task_lock")
+    def test_previously_shown_is_skipped(self, mock_release, mock_lock,
+                                         mock_schedule, mock_artwork):
+        """A repeat marked <previously-shown/> must not be recorded."""
+        from apps.channels.tasks import evaluate_series_rules_impl
+
+        self._programme(2, {"previously_shown": "2026-08-01"})
+        self.assertEqual(evaluate_series_rules_impl()["scheduled"], 0)
+        self.assertEqual(Recording.objects.count(), 0)
+
+    @patch("apps.channels.tasks.acquire_task_lock", return_value=True)
+    @patch("apps.channels.tasks.release_task_lock")
+    def test_untagged_first_run_is_recorded(self, mock_release, mock_lock,
+                                            mock_schedule, mock_artwork):
+        """A feed that marks only repeats: an untagged airing is a first run.
+
+        Before this change such a programme was skipped, so a mode="new" rule on
+        such a feed recorded nothing whatsoever.
+        """
+        from apps.channels.tasks import evaluate_series_rules_impl
+
+        self._programme(2, {"season": 22, "episode": 13})
+        self.assertEqual(evaluate_series_rules_impl()["scheduled"], 1)
+        self.assertEqual(Recording.objects.count(), 1)
+
+    @patch("apps.channels.tasks.acquire_task_lock", return_value=True)
+    @patch("apps.channels.tasks.release_task_lock")
+    def test_mixed_schedule_records_only_first_runs(self, mock_release, mock_lock,
+                                                    mock_schedule, mock_artwork):
+        """The real shape of an affected feed: evening first runs, daytime repeats."""
+        from apps.channels.tasks import evaluate_series_rules_impl
+
+        self._programme(2, {"season": 22, "episode": 13}, sub_title="Ep 13")
+        self._programme(4, {"season": 22, "episode": 12,
+                            "previously_shown": "2026-08-18"}, sub_title="Ep 12")
+        self._programme(6, {"season": 22, "episode": 14}, sub_title="Ep 14")
+
+        self.assertEqual(evaluate_series_rules_impl()["scheduled"], 2)
+        self.assertEqual(Recording.objects.count(), 2)
+
+    @patch("apps.channels.tasks.acquire_task_lock", return_value=True)
+    @patch("apps.channels.tasks.release_task_lock")
+    def test_new_tag_wins_over_previously_shown(self, mock_release, mock_lock,
+                                                mock_schedule, mock_artwork):
+        """An explicit <new/> is authoritative even alongside a previously-shown date."""
+        from apps.channels.tasks import evaluate_series_rules_impl
+
+        self._programme(2, {"new": True, "previously_shown": "2026-08-01"})
+        self.assertEqual(evaluate_series_rules_impl()["scheduled"], 1)
+        self.assertEqual(Recording.objects.count(), 1)


### PR DESCRIPTION
## Description

A `mode="new"` series rule accepts a programme only when the EPG explicitly tagged it `<new/>`:

```python
if (p.custom_properties or {}).get("new"):
```

XMLTV also lets a feed mark **repeats** with `<previously-shown/>` instead, and a feed using that convention exclusively never sets `<new/>` on anything. On such a feed a `mode="new"` rule matches **nothing at all**.

The failure mode is what makes this worth fixing rather than documenting: it is completely silent, and it is hard to attribute. A rule that matches nothing looks exactly like a series that is not currently airing — no error, no warning, just an empty schedule. On the instance where this was found, a rule had been sitting in `mode="new"` for **months** with **zero** recordings, and it only came to light while investigating something unrelated.

Measured across the four EPG feeds in use there, the `new` key is absent from **every** programme, while repeats consistently carry `previously_shown`. A representative day for one series, where the split is exact:

| airing | `previously_shown` | |
|---|---|---|
| 19:00–19:31 | absent | first run |
| 12:00 / 14:10 / 15:20 | present | repeat |

### The change

Treat a programme as new when it is tagged `<new/>`, **or** when it is not tagged `<previously-shown/>`:

```python
props = p.custom_properties or {}
if props.get("new") or not props.get("previously_shown"):
```

Feeds that do tag `<new/>` are unaffected for those programmes. A programme carrying neither tag now counts as new, which errs toward recording — the safe direction for a DVR, where an extra capture costs disk but a missed one is unrecoverable. That also matches how the two tags are defined: `<previously-shown/>` is the positive assertion that something is a repeat, so its absence is the better signal when `<new/>` is not in use.

## Related Issue

None open that I could find — I searched issues and PRs for both `previously_shown` and the `mode: new` behaviour before writing this. Closest existing items are #862 (EPG tag management) and #1518 (original air date placeholder), neither of which covers this.

## How was it tested?

Five tests in `apps/channels/tests/test_series_rule_new_mode.py`, reusing the existing `SeriesRuleDedupBaseTestCase` fixture:

- `test_new_tag_still_recorded` — the existing convention keeps working
- `test_previously_shown_is_skipped` — a marked repeat is still excluded
- `test_untagged_first_run_is_recorded` — the bug: previously skipped, so nothing recorded at all
- `test_mixed_schedule_records_only_first_runs` — the real shape of an affected feed: evening first runs plus a daytime repeat, expects exactly the first runs
- `test_new_tag_wins_over_previously_shown` — an explicit `<new/>` stays authoritative alongside a previously-shown date

**Against pristine `dev` the two untagged-first-run tests fail and the other three pass**, so they isolate this behaviour and nothing else:

```
FAIL: test_mixed_schedule_records_only_first_runs
FAIL: test_untagged_first_run_is_recorded
Ran 5 tests in 0.449s
FAILED (failures=2)
```

With the change, the new tests plus both existing series-rule suites pass:

```
Ran 47 tests in 4.818s
OK
```

(5 new + 29 `test_series_rule_dedup` + 13 `test_series_rule_dedup_time_drift`, zero regressions.)

Also verified against the live EPG on the affected instance: with the change, the rule selects the 5 first-run airings and skips the 7 repeats, matching the `previously_shown` split exactly.


### Addendum: the preview endpoint has its own copy of this filter

The Edit Series Rule dialog's preview (`api_views.py`) filters candidates independently of the scheduler:

```python
if mode == "new":
    candidates = [p for p in candidates if (p.custom_properties or {}).get("new")]
```

so fixing only `tasks.py` produced a UI that disagrees with reality — the dialog shows **"0 OF 0 — No matching upcoming programs in the next 7 days"** for a rule the scheduler would happily record. The second commit applies the same `new`-or-not-`previously_shown` logic there, and widens `is_new` in the response identically so the per-row flag agrees with the filter that selected it.

Verified against the same live feeds: a title with three untagged upcoming airings previewed as 0 matches before, 3 after — matching what the scheduler selects.
## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed (N/A — no model changes)
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema (N/A — no API changes)
- [x] Frontend: ESLint and Prettier pass cleanly (N/A — backend only)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

