### PR TITLE
fix(stats): load connection logos on direct visits

### DIFF
--- a/frontend/src/components/LazyLogo.jsx
+++ b/frontend/src/components/LazyLogo.jsx
@@ -29,6 +29,7 @@ const LazyLogo = ({
 
   // Cleanup on unmount
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
     };

--- a/frontend/src/components/__tests__/LazyLogo.test.jsx
+++ b/frontend/src/components/__tests__/LazyLogo.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
 import '@testing-library/jest-dom';
 import LazyLogo from '../LazyLogo';
 import useLogosStore from '../../store/logos';
@@ -181,6 +182,18 @@ describe('LazyLogo', () => {
       mockStore.logos = {};
 
       render(<LazyLogo logoId="logo-1" />);
+
+      vi.advanceTimersByTime(100);
+
+      expect(mockFetchLogosByIds).toHaveBeenCalledWith(['logo-1']);
+    });
+
+    it('should fetch logos when mounted in Strict Mode', () => {
+      render(
+        <StrictMode>
+          <LazyLogo logoId="logo-1" />
+        </StrictMode>
+      );
 
       vi.advanceTimersByTime(100);
 

--- a/frontend/src/components/cards/StreamConnectionCard.jsx
+++ b/frontend/src/components/cards/StreamConnectionCard.jsx
@@ -36,6 +36,7 @@ import {
 import { CustomTable, useTable } from '../tables/CustomTable/index.jsx';
 import { TableHelper } from '../../helpers/index.jsx';
 import logo from '../../images/logo.png';
+import LazyLogo from '../LazyLogo.jsx';
 import { formatBytes, formatSpeed } from '../../utils/networkUtils.js';
 import { showNotification } from '../../utils/notificationUtils.js';
 import {
@@ -43,7 +44,6 @@ import {
   durationAccessor,
   getBufferingSpeedThreshold,
   getChannelStreams,
-  getLogoUrl,
   getM3uAccountsMap,
   getSelectedStream,
   getStartDate,
@@ -60,7 +60,6 @@ const StreamConnectionCard = ({
   clients,
   stopClient,
   stopChannel,
-  logos,
   channelsByUUID,
   channels,
   currentProgram,
@@ -465,9 +464,6 @@ const StreamConnectionCard = ({
     },
   });
 
-  // Get logo URL from the logos object if available
-  const logoUrl = getLogoUrl(channel.logo_id, logos, previewedStream);
-
   useEffect(() => {
     let isMounted = true;
     // Only fetch if we have a stream_id and NO channel.name
@@ -556,8 +552,9 @@ const StreamConnectionCard = ({
             h={70}
             display="flex"
           >
-            <img
-              src={logoUrl || logo}
+            <LazyLogo
+              logoId={channel.logo_id}
+              fallbackSrc={previewedStream?.logo_url || logo}
               style={{
                 maxWidth: '100%',
                 maxHeight: '100%',

--- a/frontend/src/components/cards/TimeshiftConnectionCard.jsx
+++ b/frontend/src/components/cards/TimeshiftConnectionCard.jsx
@@ -19,6 +19,7 @@ import {
   Timer,
 } from 'lucide-react';
 import ProgramPreview from '../ProgramPreview.jsx';
+import LazyLogo from '../LazyLogo.jsx';
 import {
   calculateConnectionDuration,
   calculateConnectionStartTime,
@@ -26,7 +27,6 @@ import {
   getConnectionDurationSeconds,
 } from '../../utils/cards/TimeshiftConnectionCardUtils.js';
 import { useDateTimeFormat } from '../../utils/dateTimeUtils.js';
-import { getLogoUrl } from '../../utils/cards/StreamConnectionCardUtils.js';
 import useUsersStore from '../../store/users.jsx';
 
 const ClientDetails = ({ connection, connectionStartTime }) => (
@@ -109,7 +109,6 @@ const TimeshiftConnectionCard = ({
   timeshiftSession,
   currentProgram,
   stopTimeshiftSession,
-  logos,
 }) => {
   const { fullDateTimeFormat } = useDateTimeFormat();
   const [isClientExpanded, setIsClientExpanded] = useState(false);
@@ -134,8 +133,6 @@ const TimeshiftConnectionCard = ({
   const connection =
     timeshiftSession.individual_connection ||
     (timeshiftSession.connections && timeshiftSession.connections[0]);
-
-  const logoUrl = getLogoUrl(timeshiftSession.logo_id, logos) || logo;
 
   const programmePreview = useMemo(() => {
     if (currentProgram?.title) {
@@ -224,8 +221,9 @@ const TimeshiftConnectionCard = ({
             h={70}
             display="flex"
           >
-            <img
-              src={logoUrl}
+            <LazyLogo
+              logoId={timeshiftSession.logo_id}
+              fallbackSrc={logo}
               style={{
                 maxWidth: '100%',
                 maxHeight: '100%',

--- a/frontend/src/components/cards/__tests__/StreamConnectionCard.test.jsx
+++ b/frontend/src/components/cards/__tests__/StreamConnectionCard.test.jsx
@@ -72,6 +72,16 @@ vi.mock('../../../helpers/index.jsx', () => ({
 // ── logo image ────────────────────────────────────────────────────────────────
 vi.mock('../../../images/logo.png', () => ({ default: 'logo.png' }));
 
+vi.mock('../../LazyLogo.jsx', () => ({
+  default: ({ logoId, fallbackSrc, ...props }) => (
+    <img
+      src={logoId ? `logo-${logoId}.png` : fallbackSrc}
+      alt="channel logo"
+      {...props}
+    />
+  ),
+}));
+
 // ── Mantine core ──────────────────────────────────────────────────────────────
 vi.mock('@mantine/core', () => ({
   ActionIcon: ({ children, onClick, color, disabled }) => (

--- a/frontend/src/components/cards/__tests__/TimeshiftConnectionCard.test.jsx
+++ b/frontend/src/components/cards/__tests__/TimeshiftConnectionCard.test.jsx
@@ -11,10 +11,6 @@ vi.mock('../../../store/users.jsx', () => ({
 
 vi.mock('../../../images/logo.png', () => ({ default: 'default-logo.png' }));
 
-vi.mock('../../../utils/cards/StreamConnectionCardUtils.js', () => ({
-  getLogoUrl: vi.fn(),
-}));
-
 vi.mock('../../../utils/cards/TimeshiftConnectionCardUtils.js', () => ({
   calculateConnectionDuration: vi.fn(() => '5m'),
   calculateConnectionStartTime: vi.fn(() => 'Jan 1 2024 10:00 AM'),
@@ -46,16 +42,24 @@ vi.mock('../../ProgramPreview.jsx', () => ({
   default: () => <div data-testid="program-preview" />,
 }));
 
+vi.mock('../../LazyLogo.jsx', () => ({
+  default: ({ logoId, fallbackSrc, ...props }) => (
+    <img
+      src={logoId ? `logo-${logoId}.png` : fallbackSrc}
+      alt="channel logo"
+      {...props}
+    />
+  ),
+}));
+
 import TimeshiftConnectionCard from '../TimeshiftConnectionCard.jsx';
-import { getLogoUrl } from '../../../utils/cards/StreamConnectionCardUtils.js';
 
 describe('TimeshiftConnectionCard logos', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getLogoUrl.mockReturnValue('/api/channels/logos/77/cache/');
   });
 
-  it('resolves the channel logo via logo_id and the logos store', () => {
+  it('passes the channel logo ID to LazyLogo', () => {
     render(
       <TimeshiftConnectionCard
         timeshiftSession={{
@@ -72,14 +76,10 @@ describe('TimeshiftConnectionCard logos', () => {
             },
           ],
         }}
-        logos={{ 77: { cache_url: '/api/channels/logos/77/cache/' } }}
       />
     );
 
-    expect(getLogoUrl).toHaveBeenCalledWith(77, {
-      77: { cache_url: '/api/channels/logos/77/cache/' },
-    });
     const img = screen.getByAltText('channel logo');
-    expect(img.getAttribute('src')).toBe('/api/channels/logos/77/cache/');
+    expect(img.getAttribute('src')).toBe('logo-77.png');
   });
 });

--- a/frontend/src/pages/Stats.jsx
+++ b/frontend/src/pages/Stats.jsx
@@ -59,8 +59,6 @@ const Connections = ({
   currentPrograms,
   catchupPrograms,
 }) => {
-  const logos = useLogosStore((s) => s.logos);
-
   return combinedConnections.length === 0 ? (
     <Box
       ta="center"
@@ -85,7 +83,6 @@ const Connections = ({
                 clients={clients}
                 stopClient={stopClient}
                 stopChannel={stopChannel}
-                logos={logos}
                 channelsByUUID={channelsByUUID}
                 channels={channels}
                 currentProgram={currentPrograms[connection.data.channel_id]}
@@ -106,7 +103,6 @@ const Connections = ({
                 timeshiftSession={connection.data}
                 currentProgram={catchupPrograms[connection.data.session_id]}
                 stopTimeshiftSession={handleStopTimeshiftSession}
-                logos={logos}
               />
             );
           }
@@ -124,6 +120,7 @@ const StatsPage = () => {
   const setVodStats = useChannelsStore((s) => s.setVodStats);
   const timeshiftSessions = useChannelsStore((s) => s.activeTimeshiftSessions);
   const setTimeshiftStats = useChannelsStore((s) => s.setTimeshiftStats);
+  const enableLogoRendering = useLogosStore((s) => s.enableLogoRendering);
   const streamProfiles = useStreamProfilesStore((s) => s.profiles);
 
   const [clients, setClients] = useState([]);
@@ -133,6 +130,10 @@ const StatsPage = () => {
   const [catchupPrograms, setCatchupPrograms] = useState({});
   const [channels, setChannels] = useState({}); // id -> channel
   const [channelsByUUID, setChannelsByUUID] = useState({}); // uuid -> id
+
+  useEffect(() => {
+    enableLogoRendering();
+  }, [enableLogoRendering]);
 
   // Compute needed channel UUIDs from the current active channels.
   // Stream previews use a non-UUID hash as channel_id; filter those out.

--- a/frontend/src/pages/__tests__/Stats.test.jsx
+++ b/frontend/src/pages/__tests__/Stats.test.jsx
@@ -165,6 +165,7 @@ describe('StatsPage', () => {
   let mockSetRefreshInterval;
   let mockSetVodStats;
   let mockSetTimeshiftStats;
+  let mockEnableLogoRendering;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -173,6 +174,7 @@ describe('StatsPage', () => {
     mockSetRefreshInterval = vi.fn();
     mockSetVodStats = vi.fn();
     mockSetTimeshiftStats = vi.fn();
+    mockEnableLogoRendering = vi.fn();
 
     // Setup store mocks
     useChannelsStore.mockImplementation((selector) => {
@@ -199,6 +201,7 @@ describe('StatsPage', () => {
     useLogosStore.mockImplementation((selector) => {
       const state = {
         logos: mockLogos,
+        enableLogoRendering: mockEnableLogoRendering,
       };
       return selector ? selector(state) : state;
     });
@@ -231,6 +234,12 @@ describe('StatsPage', () => {
         expect(mockSetChannelStats).toHaveBeenCalledWith(mockChannelStats);
         expect(mockSetVodStats).toHaveBeenCalledWith(mockVODStats);
       });
+    });
+
+    it('enables lazy logo rendering on mount', () => {
+      render(<StatsPage />);
+
+      expect(mockEnableLogoRendering).toHaveBeenCalledOnce();
     });
 
     it('displays connection counts', async () => {


### PR DESCRIPTION
Reuse LazyLogo for Stats cards and restore its mount state after React Strict Mode effect cleanup so direct Stats visits fetch missing logos