### PR TITLE
fix(nginx): redirect slash-less artwork URLs to the canonical cached path

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -55,6 +55,17 @@ server {
         proxy_cache_use_stale error timeout updating;  # Serve stale if Django is slow
     }
 
+    # Clients that normalise URLs (e.g. ChannelsDVR) drop the trailing slash
+    # when they proxy artwork URLs. The slash-less form misses the cache
+    # location above, falls through to `location /`, and Django's SPA
+    # catch-all answers 200 text/html instead of the image -- a silent
+    # failure the client renders as nothing. Redirect to the canonical
+    # slashed form, preserving the query string.
+    location ~ ^/api/channels/logos/(?<logo_id_noslash>\d+)/cache$ {
+        absolute_redirect off;  # emit a relative Location: keeps the client's scheme/host/port
+        return 301 /api/channels/logos/$logo_id_noslash/cache/$is_args$args;
+    }
+
     location ~ ^/api/vod/vodlogos/(?<logo_id>\d+)/cache/ {
         proxy_pass http://127.0.0.1:5656;
         proxy_cache logo_cache;
@@ -62,6 +73,13 @@ server {
         proxy_cache_valid 200 24h;  # Cache successful logos for 24 hours
         proxy_cache_valid 404 1m;   # Short negative cache; avoids stampeding Django/upstream
         proxy_cache_use_stale error timeout updating;  # Serve stale if Django is slow
+    }
+
+    # Slash-less form of the cache location above; see the note on the
+    # channel logo redirect.
+    location ~ ^/api/vod/vodlogos/(?<vodlogo_id_noslash>\d+)/cache$ {
+        absolute_redirect off;  # emit a relative Location: keeps the client's scheme/host/port
+        return 301 /api/vod/vodlogos/$vodlogo_id_noslash/cache/$is_args$args;
     }
 
     # Parent-scoped VOD images (backdrops, episode stills, etc.)
@@ -74,6 +92,13 @@ server {
         proxy_cache_use_stale error timeout updating;
     }
 
+    # Slash-less form of the cache location above; see the note on the
+    # channel logo redirect.
+    location ~ ^/api/vod/(?<vod_kind_noslash>movies|series|episodes)/(?<vod_id_noslash>\d+)/image$ {
+        absolute_redirect off;  # emit a relative Location: keeps the client's scheme/host/port
+        return 301 /api/vod/$vod_kind_noslash/$vod_id_noslash/image/$is_args$args;
+    }
+
     # SD program posters: 14d nginx cache. Clients pass ?v=<hash of sd_icon>
     # Do not add proxy_cache_valid 404 here. Bare HTTP 404s from SD/CDN are treated
     # as transient in the poster proxy (only code 5000 blacklists); a negative cache
@@ -84,6 +109,13 @@ server {
         proxy_cache_key "$scheme$request_uri";
         proxy_cache_valid 200 14d;
         proxy_cache_use_stale error timeout updating;
+    }
+
+    # Slash-less form of the cache location above; see the note on the
+    # channel logo redirect.
+    location ~ ^/api/epg/programs/(?<prog_id_noslash>\d+)/poster$ {
+        absolute_redirect off;  # emit a relative Location: keeps the client's scheme/host/port
+        return 301 /api/epg/programs/$prog_id_noslash/poster/$is_args$args;
     }
 
     # Admin UI disabled outside dedicated admin access. Match /admin and all


### PR DESCRIPTION
## Description

The four image cache locations in `docker/nginx.conf` are regex-matched on a path ending in a slash. Clients that normalise artwork URLs and strip that slash (ChannelsDVR does this with XMLTV `<icon>` URLs) miss the location entirely, fall through to `location /` → uWSGI, and are answered by the SPA catch-all in `dispatcharr/urls.py`. The client gets **HTTP 200 `text/html`** — the React shell — instead of the image, so artwork renders blank with nothing logged as a failure on either side.

This adds a sibling `$`-anchored `location` for each of the four endpoints that 301s to the canonical slashed form, preserving the query string via `$is_args$args` (the poster and logo URLs carry a `?v=` cache-buster). Config change only, no code changes.

Each redirect sets `absolute_redirect off` so nginx emits a **relative** `Location` header. With nginx's default (`on`) the redirect is built into an absolute URL from `$scheme` and `$host`, which behind a TLS-terminating reverse proxy downgrades it to `http://` and appends the internal listen port — e.g. `Location: http://dispatcharr.example.com:9191/...` for a client that arrived over HTTPS on 443. A relative `Location` leaves the client's original scheme, host and port intact. The setting is scoped to the four new locations, so the existing `/admin` → `/login` redirect is unchanged.

The two regexes are mutually exclusive — the existing one requires the slash, the new one is anchored with `$` immediately after the slash-less path — so ordering between them does not matter, and the existing cache locations and their `proxy_cache` behaviour are untouched.

### Why a redirect, and not an optional slash

The smaller diff would be to make the slash optional in each regex (`.../poster/?`). I tested that and it does not work, so this PR does not use it.

With `.../poster/?`, nginx *does* match the block — but `proxy_pass` forwards the original slash-less URI to `127.0.0.1:5656`, and Django cannot route it:

- the viewsets are registered on `DefaultRouter()` with no `trailing_slash=False`, so the only route is the slashed one;
- `APPEND_SLASH = True` (`dispatcharr/settings.py:449`) does not save it, because `CommonMiddleware` only redirects when the response is a 404 — and the SPA catch-all returns 200.

So the request still lands on the catch-all and still returns the HTML shell. The optional-slash change moves the failure from nginx to Django without fixing it.

| config | slash-less request | result |
|---|---|---|
| current `dev` | falls through to `location /` | `200 text/html` |
| optional slash `.../poster/?` | matches the poster block (confirmed via a marker header) | `200 text/html` — still broken |
| this PR (301) | matches the `$`-anchored redirect | `301` → `200 image/jpeg` |

## Related Issue

Closes #1590

## How was it tested?

**Against a live 0.29.0 instance**, all four endpoint families reproduce the bug on stock config — the slash-less form returns `200 text/html` (858 b, the SPA shell) while the canonical form returns the image:

| endpoint | slash-less | with slash |
|---|---|---|
| `/api/channels/logos/3992/cache` | `200 text/html` 858 b | `200 image/png` 64291 b |
| `/api/vod/vodlogos/1/cache` | `200 text/html` 858 b | `200 image/jpeg` 67577 b |
| `/api/vod/movies/500/image` | `200 text/html` 858 b | `404 application/json` (reaches DRF) |
| `/api/epg/programs/<id>/poster` | `200 text/html` 858 b | `200 image/jpeg` 131188 b |

**Against real nginx with the patched blocks from this diff**, taken verbatim and proxied to a Django/DRF app reproducing the upstream routing (`DefaultRouter` trailing-slash routes, `APPEND_SLASH=True`, `CommonMiddleware`, and the `<path:unused_path>` SPA catch-all):

- all six slash-less route shapes (`channels/logos/<id>/cache`, `vod/vodlogos/<id>/cache`, `vod/{movies,series,episodes}/<id>/image`, `epg/programs/<id>/poster`) return `301` → `200 image/jpeg` in one hop;
- the query string survives the redirect, and no bare `?` is appended when there is no query string;
- behind a simulated TLS-terminating reverse proxy (`Host: dispatcharr.example.com`, `X-Forwarded-Proto: https`), all four redirects emit a relative `Location` with no scheme downgrade and no leaked port;
- the canonical slashed URLs are unchanged (`200 image/jpeg`);
- non-target paths are unaffected — `/api/epg/programs/<id>/`, `/api/channels/logos/<id>/`, `/api/epg/programs/abc/poster`, `/api/channels/logos/<id>/cache/extra` and ordinary SPA routes are not redirected;
- `nginx -t` passes.

The redirect approach has also been running in production against a real ChannelsDVR client (bind-mounted over the container's config) for the poster endpoint, where it restored programme posters that had been blank.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed — n/a, no models changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema — n/a, no new endpoints
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`) — n/a, no frontend changes
- [ ] Tests are included for new functionality — the repo has no harness for exercising `docker/nginx.conf`; verification is the manual matrix above
- [ ] Existing tests still pass — not run locally; this change touches no Python or JS, only `docker/nginx.conf`
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
