### PR TITLE
feat(logs): in-app log file browser [logging 2]

### DIFF
--- a/core/api_urls.py
+++ b/core/api_urls.py
@@ -14,6 +14,12 @@ from .api_views import (
     TimezoneListView,
     get_system_events
 )
+from .log_files import (
+    get_log_file,
+    list_log_files,
+    get_log_download_token,
+    download_log_file,
+)
 
 router = DefaultRouter()
 router.register(r'useragents', UserAgentViewSet, basename='useragent')
@@ -27,5 +33,9 @@ urlpatterns = [
     path('rehash-streams/', rehash_streams_endpoint, name='rehash_streams'),
     path('timezones/', TimezoneListView.as_view(), name='timezones'),
     path('system-events/', get_system_events, name='system_events'),
+    path('logs/', list_log_files, name='log_files'),
+    path('logs/<str:name>/download-token/', get_log_download_token, name='log_file_download_token'),
+    path('logs/<str:name>/download/', download_log_file, name='log_file_download'),
+    path('logs/<str:name>/', get_log_file, name='log_file'),
     path('', include(router.urls)),
 ]

--- a/core/api_urls.py
+++ b/core/api_urls.py
@@ -17,7 +17,6 @@ from .api_views import (
 from .log_files import (
     get_log_file,
     list_log_files,
-    get_log_download_token,
     download_log_file,
 )
 
@@ -34,7 +33,6 @@ urlpatterns = [
     path('timezones/', TimezoneListView.as_view(), name='timezones'),
     path('system-events/', get_system_events, name='system_events'),
     path('logs/', list_log_files, name='log_files'),
-    path('logs/<str:name>/download-token/', get_log_download_token, name='log_file_download_token'),
     path('logs/<str:name>/download/', download_log_file, name='log_file_download'),
     path('logs/<str:name>/', get_log_file, name='log_file'),
     path('', include(router.urls)),

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -43,7 +43,7 @@ def _resolve(name):
     """Resolve *name* to a real log file inside the log directory, else None."""
     # DISPATCHARR_LOG_DIR may hold more than logs.
     log_dir = settings.LOG_FILE_DIR
-    if not log_dir or not _NAME_RE.match(name) or not name.startswith(BASE_NAME):
+    if not log_dir or not _NAME_RE.fullmatch(name) or not name.startswith(BASE_NAME):
         return None
     base = os.path.realpath(log_dir)
     path = os.path.realpath(os.path.join(base, name))

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -32,6 +32,14 @@ def _log_dir():
     return getattr(settings, "LOG_FILE_DIR", None) or "/data/logs"
 
 
+def _open_log(path):
+    """Open *path*, mapping a file pruned since resolution to a 404."""
+    try:
+        return open(path, "rb")
+    except FileNotFoundError:
+        raise NotFound("Log file not found")
+
+
 def _at_line_start(f, offset):
     """Whether *offset* sits just past a newline, i.e. begins a record."""
     if offset == 0:
@@ -124,7 +132,7 @@ def get_log_file(request, name):
         raise NotFound("Log file not found")
 
     cursor = request.GET.get("cursor", "")
-    with open(path, "rb") as f:
+    with _open_log(path) as f:
         # Identity and size come from the open handle, so a rotation cannot land
         # between them and leave us seeking past the end of a fresh, empty file.
         stat = os.fstat(f.fileno())
@@ -177,7 +185,7 @@ def download_log_file(request, name):
         raise NotFound("Log file not found")
 
     response = FileResponse(
-        open(path, "rb"), content_type="text/plain; charset=utf-8"
+        _open_log(path), content_type="text/plain; charset=utf-8"
     )
     response["Content-Disposition"] = f'attachment; filename="{name}"'
     return response

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -36,7 +36,7 @@ def _log_dir():
 
 def _resolve(name):
     """Resolve *name* to a real log file inside the log directory, else None."""
-    # The family check lives here, not only in the listing: DISPATCHARR_LOG_DIR may point at a directory holding more than logs.
+    # Checked here, not only in the listing: DISPATCHARR_LOG_DIR may hold more than logs.
     if not _NAME_RE.match(name) or not name.startswith(LOG_NAME_PREFIX):
         return None
     base = os.path.realpath(_log_dir())

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -154,10 +154,9 @@ def get_log_file(request, name):
         if newline >= 0:
             start += newline + 1
             data = data[newline + 1 :]
-    elif not reset:
-        # Mid-write, the tail is a fragment; it arrives whole on the next poll.
-        end = data.rfind(b"\n")
-        data = data[: end + 1] if end >= 0 else b""
+    # Mid-write, the tail is a fragment; it arrives whole on the next poll.
+    end = data.rfind(b"\n")
+    data = data[: end + 1] if end >= 0 else b""
 
     return Response(
         {

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -2,22 +2,17 @@
 Admin-only: log lines can reference provider URLs and account names.
 """
 
-import hashlib
-import hmac
 import os
 import re
-import time
 from datetime import datetime, timezone
 
 from django.conf import settings
 from django.http import FileResponse, HttpResponse
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import NotFound
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 from apps.accounts.permissions import IsAdmin
-from dispatcharr.utils import network_access_allowed
 from dispatcharr.log_collector import collector_running
 
 # Plain filenames only: no separators, no dotfiles.
@@ -44,39 +39,6 @@ def _resolve(name):
     if os.path.dirname(path) != base or not os.path.isfile(path):
         return None
     return path
-
-
-# uWSGI logs request URIs into this very log, so a download token must expire fast.
-DOWNLOAD_TOKEN_TTL = 60
-
-
-def _sign_download(name, user_id, expires):
-    payload = f"{name}|{user_id}|{expires}"
-    return hmac.new(
-        settings.SECRET_KEY.encode(), payload.encode(), hashlib.sha256
-    ).hexdigest()[:32]
-
-
-def _download_token(name, user_id, expires=None):
-    """Short-lived token letting a plain link download *name* without the JWT.
-
-    Bound to the requesting user and to a deadline, so a token that leaks -
-    into this log, a proxy log, a browser history - is a minute of exposure
-    rather than a permanent key to the file.
-    """
-    expires = int(expires if expires is not None else time.time() + DOWNLOAD_TOKEN_TTL)
-    return f"{user_id}.{expires}.{_sign_download(name, user_id, expires)}"
-
-
-def _verify_download_token(name, token):
-    try:
-        user_id, expires, signature = str(token).split(".")
-        expires = int(expires)
-    except (AttributeError, ValueError):
-        return False
-    if expires < time.time():
-        return False
-    return hmac.compare_digest(_sign_download(name, user_id, expires), signature)
 
 
 @api_view(["GET"])
@@ -142,33 +104,8 @@ def get_log_file(request, name):
 
 @api_view(["GET"])
 @permission_classes([IsAdmin])
-def get_log_download_token(request, name):
-    """Mint a signed token for downloading *name* over a plain link."""
-    path = _resolve(name)
-    if path is None:
-        raise NotFound("Log file not found")
-    return Response({"token": _download_token(name, request.user.pk)})
-
-
-@api_view(["GET"])
-@permission_classes([AllowAny])
 def download_log_file(request, name):
-    """Stream a log file as an attachment; requires a signed ``token`` param or admin auth."""
-    # AllowAny so a plain link can carry the token, so the network gate IsAdmin would have applied is applied by hand.
-    user = request.user if request.user.is_authenticated else None
-    if not network_access_allowed(request, "UI", user):
-        return Response({"detail": "Forbidden"}, status=403)
-    token = request.query_params.get("token")
-    if token:
-        if not _verify_download_token(name, token):
-            return Response({"detail": "Invalid download token"}, status=403)
-    else:
-        if not (
-            request.user.is_authenticated
-            and getattr(request.user, "user_level", 0) >= 10
-        ):
-            return Response({"detail": "Authentication required"}, status=401)
-
+    """Stream a log file as an attachment over the authenticated session."""
     path = _resolve(name)
     if path is None:
         raise NotFound("Log file not found")

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -25,10 +25,6 @@ _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 MAX_VIEW_BYTES = 5 * 1024 * 1024
 
 
-def _log_dir():
-    return getattr(settings, "LOG_FILE_DIR", None) or "/data/logs"
-
-
 def _open_log(path):
     """Open *path*, mapping a file pruned since resolution to a 404."""
     try:
@@ -48,9 +44,10 @@ def _at_line_start(f, offset):
 def _resolve(name):
     """Resolve *name* to a real log file inside the log directory, else None."""
     # Checked here, not only in the listing: DISPATCHARR_LOG_DIR may hold more than logs.
-    if not _NAME_RE.match(name) or not name.startswith(BASE_NAME):
+    log_dir = settings.LOG_FILE_DIR
+    if not log_dir or not _NAME_RE.match(name) or not name.startswith(BASE_NAME):
         return None
-    base = os.path.realpath(_log_dir())
+    base = os.path.realpath(log_dir)
     path = os.path.realpath(os.path.join(base, name))
     if os.path.dirname(path) != base or not os.path.isfile(path):
         return None
@@ -60,10 +57,10 @@ def _resolve(name):
 @api_view(["GET"])
 @permission_classes([IsAdmin])
 def list_log_files(request):
-    base = _log_dir()
+    base = settings.LOG_FILE_DIR
     files = []
     try:
-        names = os.listdir(base)
+        names = os.listdir(base) if base else []
     except OSError:
         names = []
     for name in names:

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -16,13 +16,10 @@ from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 
 from apps.accounts.permissions import IsAdmin
-from dispatcharr.log_collector import collector_running
+from dispatcharr.log_collector import BASE_NAME, collector_running
 
 # Plain filenames only: no separators, no dotfiles.
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
-
-# The only family these endpoints serve: the live log and its rotations.
-LOG_NAME_PREFIX = "dispatcharr.log"
 
 # Inline viewing serves this many trailing bytes; download streams the whole file.
 MAX_VIEW_BYTES = 5 * 1024 * 1024
@@ -51,7 +48,7 @@ def _at_line_start(f, offset):
 def _resolve(name):
     """Resolve *name* to a real log file inside the log directory, else None."""
     # Checked here, not only in the listing: DISPATCHARR_LOG_DIR may hold more than logs.
-    if not _NAME_RE.match(name) or not name.startswith(LOG_NAME_PREFIX):
+    if not _NAME_RE.match(name) or not name.startswith(BASE_NAME):
         return None
     base = os.path.realpath(_log_dir())
     path = os.path.realpath(os.path.join(base, name))

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -1,0 +1,180 @@
+"""Browse/view/download the persisted log files in LOG_FILE_DIR (System > Logs).
+Admin-only: log lines can reference provider URLs and account names.
+"""
+
+import hashlib
+import hmac
+import os
+import re
+import time
+from datetime import datetime, timezone
+
+from django.conf import settings
+from django.http import FileResponse, HttpResponse
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from apps.accounts.permissions import IsAdmin
+from dispatcharr.utils import network_access_allowed
+from dispatcharr.log_collector import collector_running
+
+# Plain filenames only: no separators, no dotfiles.
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# The only family these endpoints serve: the live log and its rotations.
+LOG_NAME_PREFIX = "dispatcharr.log"
+
+# Inline viewing serves this many trailing bytes; download streams the whole file.
+MAX_VIEW_BYTES = 5 * 1024 * 1024
+
+
+def _log_dir():
+    return getattr(settings, "LOG_FILE_DIR", None) or "/data/logs"
+
+
+def _resolve(name):
+    """Resolve *name* to a real log file inside the log directory, else None."""
+    # The family check lives here, not only in the listing: DISPATCHARR_LOG_DIR may point at a directory holding more than logs.
+    if not _NAME_RE.match(name) or not name.startswith(LOG_NAME_PREFIX):
+        return None
+    base = os.path.realpath(_log_dir())
+    path = os.path.realpath(os.path.join(base, name))
+    if os.path.dirname(path) != base or not os.path.isfile(path):
+        return None
+    return path
+
+
+# uWSGI logs request URIs into this very log, so a download token must expire fast.
+DOWNLOAD_TOKEN_TTL = 60
+
+
+def _sign_download(name, user_id, expires):
+    payload = f"{name}|{user_id}|{expires}"
+    return hmac.new(
+        settings.SECRET_KEY.encode(), payload.encode(), hashlib.sha256
+    ).hexdigest()[:32]
+
+
+def _download_token(name, user_id, expires=None):
+    """Short-lived token letting a plain link download *name* without the JWT.
+
+    Bound to the requesting user and to a deadline, so a token that leaks -
+    into this log, a proxy log, a browser history - is a minute of exposure
+    rather than a permanent key to the file.
+    """
+    expires = int(expires if expires is not None else time.time() + DOWNLOAD_TOKEN_TTL)
+    return f"{user_id}.{expires}.{_sign_download(name, user_id, expires)}"
+
+
+def _verify_download_token(name, token):
+    try:
+        user_id, expires, signature = str(token).split(".")
+        expires = int(expires)
+    except (AttributeError, ValueError):
+        return False
+    if expires < time.time():
+        return False
+    return hmac.compare_digest(_sign_download(name, user_id, expires), signature)
+
+
+@api_view(["GET"])
+@permission_classes([IsAdmin])
+def list_log_files(request):
+    base = _log_dir()
+    files = []
+    try:
+        names = os.listdir(base)
+    except OSError:
+        names = []
+    for name in names:
+        # Same containment gate as view/download: a symlink escaping the dir is never listed.
+        path = _resolve(name)
+        if path is None:
+            continue
+        try:
+            stat = os.stat(path)
+        except OSError:
+            continue
+        files.append(
+            {
+                "name": name,
+                "size": stat.st_size,
+                "modified": datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc
+                ).isoformat(),
+            }
+        )
+    files.sort(key=lambda f: f["modified"], reverse=True)
+    return Response(
+        {
+            "path": base,
+            "files": files,
+            "collector_running": collector_running(base),
+        }
+    )
+
+
+@api_view(["GET"])
+@permission_classes([IsAdmin])
+def get_log_file(request, name):
+    path = _resolve(name)
+    if path is None:
+        raise NotFound("Log file not found")
+
+    size = os.path.getsize(path)
+    truncated = size > MAX_VIEW_BYTES
+    with open(path, "rb") as f:
+        if truncated:
+            f.seek(size - MAX_VIEW_BYTES)
+            data = f.read(MAX_VIEW_BYTES)
+            # Start at a line boundary so the client never sees a torn line.
+            newline = data.find(b"\n")
+            if newline >= 0:
+                data = data[newline + 1 :]
+        else:
+            data = f.read()
+    response = HttpResponse(data, content_type="text/plain; charset=utf-8")
+    response["X-Log-Truncated"] = "1" if truncated else "0"
+    return response
+
+
+@api_view(["GET"])
+@permission_classes([IsAdmin])
+def get_log_download_token(request, name):
+    """Mint a signed token for downloading *name* over a plain link."""
+    path = _resolve(name)
+    if path is None:
+        raise NotFound("Log file not found")
+    return Response({"token": _download_token(name, request.user.pk)})
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def download_log_file(request, name):
+    """Stream a log file as an attachment; requires a signed ``token`` param or admin auth."""
+    # AllowAny so a plain link can carry the token, so the network gate IsAdmin would have applied is applied by hand.
+    user = request.user if request.user.is_authenticated else None
+    if not network_access_allowed(request, "UI", user):
+        return Response({"detail": "Forbidden"}, status=403)
+    token = request.query_params.get("token")
+    if token:
+        if not _verify_download_token(name, token):
+            return Response({"detail": "Invalid download token"}, status=403)
+    else:
+        if not (
+            request.user.is_authenticated
+            and getattr(request.user, "user_level", 0) >= 10
+        ):
+            return Response({"detail": "Authentication required"}, status=401)
+
+    path = _resolve(name)
+    if path is None:
+        raise NotFound("Log file not found")
+
+    response = FileResponse(
+        open(path, "rb"), content_type="text/plain; charset=utf-8"
+    )
+    response["Content-Disposition"] = f'attachment; filename="{name}"'
+    return response

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -29,6 +29,14 @@ def _log_dir():
     return getattr(settings, "LOG_FILE_DIR", None) or "/data/logs"
 
 
+def _at_line_start(f, offset):
+    """Whether *offset* sits just past a newline, i.e. begins a record."""
+    if offset == 0:
+        return True
+    f.seek(offset - 1)
+    return f.read(1) == b"\n"
+
+
 def _resolve(name):
     """Resolve *name* to a real log file inside the log directory, else None."""
     # Checked here, not only in the listing: DISPATCHARR_LOG_DIR may hold more than logs.
@@ -85,21 +93,45 @@ def get_log_file(request, name):
     if path is None:
         raise NotFound("Log file not found")
 
+    cursor = request.GET.get("cursor", "")
     with open(path, "rb") as f:
-        # Size comes from the open handle, so a rotation cannot land between
-        # the two and leave us seeking past the end of a fresh, empty file.
-        size = os.fstat(f.fileno()).st_size
-        truncated = size > MAX_VIEW_BYTES
+        # Identity and size come from the open handle, so a rotation cannot land
+        # between them and leave us seeking past the end of a fresh, empty file.
+        stat = os.fstat(f.fileno())
+        start, reset = 0, True
+        if cursor:
+            prev_inode, _, prev_end = cursor.partition("-")
+            # A new inode is a rotation: the old offset means nothing in the new
+            # file, and resuming at it would skip content or freeze the view.
+            if prev_inode == str(stat.st_ino) and prev_end.isdigit():
+                offset = min(int(prev_end), stat.st_size)
+                # Rotation frees inodes for reuse, so identity alone can be
+                # fooled; an offset mid-line did not come from this file.
+                if _at_line_start(f, offset):
+                    start, reset = offset, False
+        # A tab that slept asks for more than we serve; fall back to the tail.
+        truncated = stat.st_size - start > MAX_VIEW_BYTES
         if truncated:
-            f.seek(size - MAX_VIEW_BYTES)
-            data = f.read(MAX_VIEW_BYTES)
-            # Start at a line boundary so the client never sees a torn line.
-            newline = data.find(b"\n")
-            if newline >= 0:
-                data = data[newline + 1 :]
-        else:
-            data = f.read()
+            start, reset = stat.st_size - MAX_VIEW_BYTES, True
+        f.seek(start)
+        # Bounded by the size this handle reported, so concurrent appends
+        # cannot push the body past the cap the response advertises.
+        data = f.read(stat.st_size - start)
+
+    if reset and start:
+        # Start at a line boundary so the client never sees a torn line.
+        newline = data.find(b"\n")
+        if newline >= 0:
+            start += newline + 1
+            data = data[newline + 1 :]
+    elif not reset:
+        # Mid-write, the tail is a fragment; it arrives whole on the next poll.
+        end = data.rfind(b"\n")
+        data = data[: end + 1] if end >= 0 else b""
+
     response = HttpResponse(data, content_type="text/plain; charset=utf-8")
+    response["X-Log-Cursor"] = f"{stat.st_ino}-{start + len(data)}"
+    response["X-Log-Reset"] = "1" if reset else "0"
     response["X-Log-Truncated"] = "1" if truncated else "0"
     return response
 

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -1,6 +1,4 @@
-"""Browse/view/download the persisted log files in LOG_FILE_DIR (System > Logs).
-Admin-only: log lines can reference provider URLs and account names.
-"""
+"""Browse, view and download the persisted log files (System > Logs)."""
 
 import os
 import re
@@ -43,7 +41,7 @@ def _at_line_start(f, offset):
 
 def _resolve(name):
     """Resolve *name* to a real log file inside the log directory, else None."""
-    # Checked here, not only in the listing: DISPATCHARR_LOG_DIR may hold more than logs.
+    # DISPATCHARR_LOG_DIR may hold more than logs.
     log_dir = settings.LOG_FILE_DIR
     if not log_dir or not _NAME_RE.match(name) or not name.startswith(BASE_NAME):
         return None
@@ -126,19 +124,16 @@ def get_log_file(request, name):
 
     cursor = request.GET.get("cursor", "")
     with _open_log(path) as f:
-        # Identity and size come from the open handle, so a rotation cannot land
-        # between them and leave us seeking past the end of a fresh, empty file.
+        # Size and identity from one handle, so a rotation cannot land between them.
         stat = os.fstat(f.fileno())
         start, reset = 0, True
         if cursor:
             prev_inode, _, prev_end = cursor.partition("-")
-            # A new inode is a rotation: the old offset means nothing in the new
-            # file, and resuming at it would skip content or freeze the view.
+            # A new inode is a rotation; the old offset means nothing there.
             valid = len(prev_end) < 20 and prev_end.isdecimal()
             if prev_inode == str(stat.st_ino) and valid:
                 offset = int(prev_end)
-                # Rotation frees inodes for reuse, so identity alone can be
-                # fooled; an offset mid-line did not come from this file.
+                # Inodes are reused; an offset mid-line did not come from this file.
                 if _at_line_start(f, offset):
                     start, reset = offset, False
         # A tab that slept asks for more than we serve; fall back to the tail.
@@ -146,8 +141,7 @@ def get_log_file(request, name):
         if truncated:
             start, reset = stat.st_size - MAX_VIEW_BYTES, True
         f.seek(start)
-        # Bounded by the size this handle reported, so concurrent appends
-        # cannot push the body past the cap the response advertises.
+        # Bounded by the size this handle reported, not by concurrent appends.
         data = f.read(stat.st_size - start)
 
     if reset and start:
@@ -173,7 +167,7 @@ def get_log_file(request, name):
 @api_view(["GET"])
 @permission_classes([IsAdmin])
 def download_log_file(request, name):
-    """Stream a log file as an attachment over the authenticated session."""
+    """Stream a log file as an attachment."""
     path = _resolve(name)
     if path is None:
         raise NotFound("Log file not found")

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 
 from django.conf import settings
 from django.http import FileResponse, HttpResponse
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
@@ -86,6 +88,22 @@ def list_log_files(request):
     )
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter(
+            name="cursor",
+            type=OpenApiTypes.STR,
+            location=OpenApiParameter.QUERY,
+            required=False,
+            description=(
+                "Opaque position from a previous response's X-Log-Cursor. "
+                "Serves only the bytes written past it, unless the file "
+                "rotated or the gap exceeds the view cap, in which case the "
+                "response resets to a fresh tail and X-Log-Reset is 1."
+            ),
+        ),
+    ],
+)
 @api_view(["GET"])
 @permission_classes([IsAdmin])
 def get_log_file(request, name):

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -84,7 +84,6 @@ def list_log_files(request):
     files.sort(key=lambda f: (f["modified"], f["name"]), reverse=True)
     return Response(
         {
-            "path": base,
             "files": files,
             "collector_running": collector_running(base),
         }

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -138,8 +138,9 @@ def get_log_file(request, name):
             prev_inode, _, prev_end = cursor.partition("-")
             # A new inode is a rotation: the old offset means nothing in the new
             # file, and resuming at it would skip content or freeze the view.
-            if prev_inode == str(stat.st_ino) and prev_end.isdigit():
-                offset = min(int(prev_end), stat.st_size)
+            valid = len(prev_end) < 20 and prev_end.isdecimal()
+            if prev_inode == str(stat.st_ino) and valid:
+                offset = int(prev_end)
                 # Rotation frees inodes for reuse, so identity alone can be
                 # fooled; an offset mid-line did not come from this file.
                 if _at_line_start(f, offset):

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -7,9 +7,10 @@ import re
 from datetime import datetime, timezone
 
 from django.conf import settings
-from django.http import FileResponse, HttpResponse
+from django.http import FileResponse
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import extend_schema, inline_serializer, OpenApiParameter
+from rest_framework import serializers
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
@@ -96,13 +97,24 @@ def list_log_files(request):
             location=OpenApiParameter.QUERY,
             required=False,
             description=(
-                "Opaque position from a previous response's X-Log-Cursor. "
-                "Serves only the bytes written past it, unless the file "
-                "rotated or the gap exceeds the view cap, in which case the "
-                "response resets to a fresh tail and X-Log-Reset is 1."
+                "Opaque position from a previous response's cursor. Serves "
+                "only the bytes written past it, unless the file rotated or "
+                "the gap exceeds the view cap, in which case the response "
+                "resets to a fresh tail."
             ),
         ),
     ],
+    responses={
+        200: inline_serializer(
+            name="LogTail",
+            fields={
+                "content": serializers.CharField(),
+                "cursor": serializers.CharField(),
+                "reset": serializers.BooleanField(),
+                "truncated": serializers.BooleanField(),
+            },
+        )
+    },
 )
 @api_view(["GET"])
 @permission_classes([IsAdmin])
@@ -147,11 +159,14 @@ def get_log_file(request, name):
         end = data.rfind(b"\n")
         data = data[: end + 1] if end >= 0 else b""
 
-    response = HttpResponse(data, content_type="text/plain; charset=utf-8")
-    response["X-Log-Cursor"] = f"{stat.st_ino}-{start + len(data)}"
-    response["X-Log-Reset"] = "1" if reset else "0"
-    response["X-Log-Truncated"] = "1" if truncated else "0"
-    return response
+    return Response(
+        {
+            "content": data.decode("utf-8", "replace"),
+            "cursor": f"{stat.st_ino}-{start + len(data)}",
+            "reset": reset,
+            "truncated": truncated,
+        }
+    )
 
 
 @api_view(["GET"])

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -85,9 +85,11 @@ def get_log_file(request, name):
     if path is None:
         raise NotFound("Log file not found")
 
-    size = os.path.getsize(path)
-    truncated = size > MAX_VIEW_BYTES
     with open(path, "rb") as f:
+        # Size comes from the open handle, so a rotation cannot land between
+        # the two and leave us seeking past the end of a fresh, empty file.
+        size = os.fstat(f.fileno()).st_size
+        truncated = size > MAX_VIEW_BYTES
         if truncated:
             f.seek(size - MAX_VIEW_BYTES)
             data = f.read(MAX_VIEW_BYTES)

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -87,7 +87,7 @@ def list_log_files(request):
                 ).isoformat(),
             }
         )
-    files.sort(key=lambda f: f["modified"], reverse=True)
+    files.sort(key=lambda f: (f["modified"], f["name"]), reverse=True)
     return Response(
         {
             "path": base,

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -19,8 +19,8 @@ from dispatcharr.log_collector import BASE_NAME, collector_running
 # Plain filenames only: no separators, no dotfiles.
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
-# Inline viewing serves this many trailing bytes; download streams the whole file.
-MAX_VIEW_BYTES = 10 * 1024 * 1024
+# Above any log the collector can write: only a file it did not write is cut.
+MAX_VIEW_BYTES = 24 * 1024 * 1024
 
 
 def _open_log(path):

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -143,13 +143,12 @@ def get_log_file(request, name):
         f.seek(start)
         # Bounded by the size this handle reported, not by concurrent appends.
         data = f.read(stat.st_size - start)
-
-    if reset and start:
-        # Start at a line boundary so the client never sees a torn line.
-        newline = data.find(b"\n")
-        if newline >= 0:
-            start += newline + 1
-            data = data[newline + 1 :]
+        # The cap lands mid-record unless it happens to fall on a boundary.
+        if truncated and not _at_line_start(f, start):
+            newline = data.find(b"\n")
+            if newline >= 0:
+                start += newline + 1
+                data = data[newline + 1 :]
     # Mid-write, the tail is a fragment; it arrives whole on the next poll.
     end = data.rfind(b"\n")
     data = data[: end + 1] if end >= 0 else b""

--- a/core/log_files.py
+++ b/core/log_files.py
@@ -20,7 +20,7 @@ from dispatcharr.log_collector import BASE_NAME, collector_running
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 # Inline viewing serves this many trailing bytes; download streams the whole file.
-MAX_VIEW_BYTES = 5 * 1024 * 1024
+MAX_VIEW_BYTES = 10 * 1024 * 1024
 
 
 def _open_log(path):

--- a/core/models.py
+++ b/core/models.py
@@ -15,6 +15,8 @@ from redis.exceptions import AuthorizationError as RedisAuthorizationError
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
+from dispatcharr.log_collector import DEFAULT_LOG_KEEP, DEFAULT_LOG_MB
+
 logger = logging.getLogger(__name__)
 
 
@@ -783,8 +785,8 @@ class CoreSettings(models.Model):
             "auto_import_mapped_files": True,
             "enable_ip_lookup": True,
             "catchup_enabled": True,
-            "log_max_mb": 10,
-            "log_keep": 5,
+            "log_max_mb": DEFAULT_LOG_MB,
+            "log_keep": DEFAULT_LOG_KEEP,
             "log_persist": True,
         })
 

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -95,7 +95,7 @@ class CoreSettingsSerializer(serializers.ModelSerializer):
                     )
                 if "log_keep" in value:
                     value["log_keep"] = _clamp_int(
-                        value["log_keep"], DEFAULT_LOG_KEEP, 1, MAX_LOG_KEEP
+                        value["log_keep"], DEFAULT_LOG_KEEP, 2, MAX_LOG_KEEP
                     )
                 if "log_persist" in value:
                     value["log_persist"] = value["log_persist"] is not False

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -3,6 +3,13 @@ import json
 import ipaddress
 
 from rest_framework import serializers
+
+from dispatcharr.log_collector import (
+    DEFAULT_LOG_KEEP,
+    DEFAULT_LOG_MB,
+    MAX_LOG_KEEP,
+    MAX_LOG_MB,
+)
 from .models import CoreSettings, UserAgent, StreamProfile, OutputProfile, DVR_SETTINGS_KEY, NETWORK_ACCESS_KEY, SYSTEM_SETTINGS_KEY
 
 
@@ -83,9 +90,13 @@ class CoreSettingsSerializer(serializers.ModelSerializer):
             value = validated_data.get("value")
             if isinstance(value, dict):
                 if "log_max_mb" in value:
-                    value["log_max_mb"] = _clamp_int(value["log_max_mb"], 10, 1, 1000)
+                    value["log_max_mb"] = _clamp_int(
+                        value["log_max_mb"], DEFAULT_LOG_MB, 1, MAX_LOG_MB
+                    )
                 if "log_keep" in value:
-                    value["log_keep"] = _clamp_int(value["log_keep"], 5, 1, 50)
+                    value["log_keep"] = _clamp_int(
+                        value["log_keep"], DEFAULT_LOG_KEEP, 1, MAX_LOG_KEEP
+                    )
                 if "log_persist" in value:
                     value["log_persist"] = value["log_persist"] is not False
 

--- a/core/tests/test_log_collector.py
+++ b/core/tests/test_log_collector.py
@@ -164,7 +164,7 @@ class ConfTests(SimpleTestCase):
         self.assertEqual(self.collector._buf_bytes, 0)
 
     def test_rotation_at_cap_shifts_and_prunes(self):
-        self.collector.conf.update({"max_mb": 1, "keep": 2})
+        self.collector.conf.update({"max_mb": 1, "keep": 3})
         with open(self.collector.live_path, "w") as f:
             f.write("x" * (1024 * 1024 + 1))
         for n in (1, 2):
@@ -290,7 +290,7 @@ class ConfTests(SimpleTestCase):
         for n in (1, 2, 9):
             with open(f"{self.collector.live_path}.{n}", "w") as f:
                 f.write("old")
-        log_collector.write_conf(self.log_dir, True, 10, 2)
+        log_collector.write_conf(self.log_dir, True, 10, 3)
         self.collector._apply_conf()
         names = sorted(self.collector._archive_indices())
         self.assertEqual(names, [1, 2])

--- a/core/tests/test_log_collector.py
+++ b/core/tests/test_log_collector.py
@@ -24,13 +24,13 @@ class ConfTests(SimpleTestCase):
         self.addCleanup(shutil.rmtree, self.log_dir, ignore_errors=True)
 
     def test_conf_round_trip(self):
-        log_collector.write_conf(self.log_dir, False, 42, 7, "Pacific/Auckland")
+        log_collector.write_conf(self.log_dir, False, 17, 7, "Pacific/Auckland")
         conf = log_collector.read_conf(self.log_dir)
         self.assertEqual(
             conf,
             {
                 "persist": False,
-                "max_mb": 42,
+                "max_mb": 17,
                 "keep": 7,
                 "time_zone": "Pacific/Auckland",
             },
@@ -48,7 +48,7 @@ class ConfTests(SimpleTestCase):
         with open(path, "w") as f:
             f.write("persist=1\nmax_mb=99999\nkeep=abc\n")
         conf = log_collector.read_conf(self.log_dir)
-        self.assertEqual(conf["max_mb"], 1000)
+        self.assertEqual(conf["max_mb"], log_collector.MAX_LOG_MB)
         self.assertEqual(conf["keep"], 5)
         self.assertTrue(conf["persist"])
 
@@ -532,14 +532,14 @@ class ApplySettingsTests(SimpleTestCase):
     def test_settings_round_trip_to_conf(self):
         log_collector.apply_settings(
             self.log_dir,
-            {"log_persist": False, "log_max_mb": 25, "log_keep": 3},
+            {"log_persist": False, "log_max_mb": 15, "log_keep": 3},
         )
         conf = log_collector.read_conf(self.log_dir)
         self.assertEqual(
             conf,
             {
                 "persist": False,
-                "max_mb": 25,
+                "max_mb": 15,
                 "keep": 3,
                 "time_zone": "UTC",
             },

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -243,6 +243,14 @@ class LogFilesEndpointTests(TestCase):
         response = self.client.get("/api/core/logs/nope.log/")
         self.assertEqual(response.status_code, 404)
 
+    def test_file_pruned_after_resolution_is_404(self):
+        with mock.patch(
+            "core.log_files.open", side_effect=FileNotFoundError, create=True
+        ):
+            for name in ("dispatcharr.log/", "dispatcharr.log/download/"):
+                url = "/api/core/logs/" + name
+                self.assertEqual(self.client.get(url).status_code, 404, url)
+
     def test_non_admin_is_forbidden(self):
         self.client.force_authenticate(self.viewer)
         self.assertEqual(self.client.get("/api/core/logs/").status_code, 403)

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -239,6 +239,7 @@ class LogFilesEndpointTests(TestCase):
         self.assertIsNone(log_files._resolve("/etc/passwd"))
         self.assertIsNone(log_files._resolve(".hidden"))
         self.assertIsNone(log_files._resolve("sub/dir.log"))
+        self.assertIsNone(log_files._resolve("dispatcharr.log\n"))
         self.assertEqual(
             log_files._resolve("dispatcharr.log"),
             os.path.realpath(os.path.join(self.log_dir, "dispatcharr.log")),

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -1,0 +1,208 @@
+"""Tests for the log file browsing endpoints (System > Logs)."""
+
+import os
+import time
+import shutil
+import tempfile
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from core import log_files
+
+
+class LogFilesEndpointTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.admin = User.objects.create_user(
+            username="log-admin", password="x", user_level=10
+        )
+        cls.viewer = User.objects.create_user(
+            username="log-viewer", password="x", user_level=0
+        )
+
+    def setUp(self):
+        self.log_dir = tempfile.mkdtemp(prefix="dispatcharr-logs-")
+        self.addCleanup(shutil.rmtree, self.log_dir, ignore_errors=True)
+        with open(os.path.join(self.log_dir, "dispatcharr.log"), "w") as f:
+            f.write("line one\nline two\n")
+        with open(os.path.join(self.log_dir, "dispatcharr.log.1"), "w") as f:
+            f.write("old run\n")
+        self.settings_override = override_settings(LOG_FILE_DIR=self.log_dir)
+        self.settings_override.enable()
+        self.addCleanup(self.settings_override.disable)
+
+        self.client = APIClient()
+        self.client.force_authenticate(self.admin)
+
+    def test_lists_log_files_with_metadata(self):
+        for extra in ("collector.conf", "collector.pid"):
+            with open(os.path.join(self.log_dir, extra), "w") as f:
+                f.write("x")
+        response = self.client.get("/api/core/logs/")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["path"], self.log_dir)
+        names = {f["name"] for f in payload["files"]}
+        self.assertEqual(names, {"dispatcharr.log", "dispatcharr.log.1"})
+        for entry in payload["files"]:
+            self.assertGreater(entry["size"], 0)
+            self.assertIn("T", entry["modified"])  # ISO timestamp
+
+    def test_list_reports_whether_anything_is_writing_these_files(self):
+        response = self.client.get("/api/core/logs/")
+        self.assertFalse(response.json()["collector_running"])
+
+    def test_view_returns_plain_text(self):
+        response = self.client.get("/api/core/logs/dispatcharr.log/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/plain", response["Content-Type"])
+        self.assertEqual(response.content, b"line one\nline two\n")
+        self.assertEqual(response["X-Log-Truncated"], "0")
+
+    def test_view_truncates_large_files_at_line_boundary(self):
+        big = os.path.join(self.log_dir, "dispatcharr.log.big")
+        line = b"x" * 99 + b"\n"
+        with open(big, "wb") as f:
+            for _ in range((log_files.MAX_VIEW_BYTES // 100) + 100):
+                f.write(line)
+        response = self.client.get("/api/core/logs/dispatcharr.log.big/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["X-Log-Truncated"], "1")
+        self.assertLessEqual(len(response.content), log_files.MAX_VIEW_BYTES)
+        # Line-boundary start: content begins with a full line
+        self.assertTrue(response.content.startswith(b"x"))
+        self.assertEqual(len(response.content) % 100, 0)
+
+    def test_download_sets_attachment_disposition(self):
+        response = self.client.get("/api/core/logs/dispatcharr.log/download/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertEqual(
+            b"".join(response.streaming_content), b"line one\nline two\n"
+        )
+
+    def test_admin_gets_token_then_downloads_with_it(self):
+        token_response = self.client.get(
+            "/api/core/logs/dispatcharr.log/download-token/"
+        )
+        self.assertEqual(token_response.status_code, 200)
+        token = token_response.json()["token"]
+        self.assertTrue(token)
+
+        # A plain link carries the token but no JWT (anonymous client).
+        self.client.force_authenticate(None)
+        response = self.client.get(
+            f"/api/core/logs/dispatcharr.log/download/?token={token}"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertEqual(
+            b"".join(response.streaming_content), b"line one\nline two\n"
+        )
+
+    def test_download_token_expires(self):
+        # uWSGI logs request URIs into this log, so a lasting token is a key inside the file.
+        stale = log_files._download_token(
+            "dispatcharr.log", self.admin.pk, expires=time.time() - 1
+        )
+        self.client.logout()
+        response = self.client.get(
+            f"/api/core/logs/dispatcharr.log/download/?token={stale}"
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_download_token_is_bound_to_one_file(self):
+        token = log_files._download_token("dispatcharr.log", self.admin.pk)
+        self.client.logout()
+        response = self.client.get(
+            f"/api/core/logs/dispatcharr.log.1/download/?token={token}"
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_endpoints_serve_only_the_log_family(self):
+        # DISPATCHARR_LOG_DIR may point at a data root; view and download are not a file server.
+        with open(os.path.join(self.log_dir, "secrets.env"), "w") as f:
+            f.write("nothing to see")
+        self.assertEqual(
+            self.client.get("/api/core/logs/secrets.env/").status_code, 404
+        )
+        self.assertEqual(
+            self.client.get("/api/core/logs/secrets.env/download/").status_code, 404
+        )
+
+    def test_download_with_bad_token_is_forbidden(self):
+        self.client.force_authenticate(None)
+        response = self.client.get(
+            "/api/core/logs/dispatcharr.log/download/?token=deadbeef"
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_download_without_token_or_auth_is_unauthorized(self):
+        self.client.force_authenticate(None)
+        response = self.client.get("/api/core/logs/dispatcharr.log/download/")
+        self.assertEqual(response.status_code, 401)
+
+    def test_resolver_rejects_traversal_and_dotfiles(self):
+        # A traversal URL never reaches this view; it decodes to a slashed path the SPA serves.
+        self.assertIsNone(log_files._resolve("../secret.txt"))
+        self.assertIsNone(log_files._resolve("..%2f..%2fetc%2fpasswd"))
+        self.assertIsNone(log_files._resolve("/etc/passwd"))
+        self.assertIsNone(log_files._resolve(".hidden"))
+        self.assertIsNone(log_files._resolve("sub/dir.log"))
+        self.assertEqual(
+            log_files._resolve("dispatcharr.log"),
+            os.path.realpath(os.path.join(self.log_dir, "dispatcharr.log")),
+        )
+
+    def test_resolver_rejects_symlink_escape(self):
+        fd, outside = tempfile.mkstemp(prefix="dispatcharr-escape-")
+        os.close(fd)
+        self.addCleanup(os.remove, outside)
+        os.symlink(outside, os.path.join(self.log_dir, "escape.log"))
+        self.assertIsNone(log_files._resolve("escape.log"))
+
+    def test_list_excludes_symlink_escape(self):
+        fd, outside = tempfile.mkstemp(prefix="dispatcharr-escape-")
+        os.close(fd)
+        self.addCleanup(os.remove, outside)
+        os.symlink(outside, os.path.join(self.log_dir, "escape.log"))
+        response = self.client.get("/api/core/logs/")
+        self.assertEqual(response.status_code, 200)
+        names = {f["name"] for f in response.json()["files"]}
+        self.assertNotIn("escape.log", names)
+        self.assertEqual(names, {"dispatcharr.log", "dispatcharr.log.1"})
+
+    def test_traversal_name_that_reaches_the_view_is_404(self):
+        # Only slash-free names route here, so this is the closest a URL gets.
+        secret = os.path.join(self.log_dir, os.pardir, "secret.txt")
+        with open(secret, "w") as f:
+            f.write("TOP SECRET")
+        self.addCleanup(os.remove, secret)
+        response = self.client.get("/api/core/logs/.hidden/")
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn(b"TOP SECRET", response.content)
+
+    def test_missing_file_is_404(self):
+        response = self.client.get("/api/core/logs/nope.log/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_non_admin_is_forbidden(self):
+        self.client.force_authenticate(self.viewer)
+        self.assertEqual(self.client.get("/api/core/logs/").status_code, 403)
+        self.assertEqual(
+            self.client.get("/api/core/logs/dispatcharr.log/").status_code, 403
+        )
+
+    def test_non_admin_download_token_is_forbidden(self):
+        self.client.force_authenticate(self.viewer)
+        response = self.client.get(
+            "/api/core/logs/dispatcharr.log/download-token/"
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_anonymous_is_unauthorized(self):
+        self.client.force_authenticate(None)
+        self.assertIn(self.client.get("/api/core/logs/").status_code, (401, 403))

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -56,12 +56,12 @@ class LogFilesEndpointTests(TestCase):
         response = self.client.get("/api/core/logs/")
         self.assertFalse(response.json()["collector_running"])
 
-    def test_view_returns_plain_text(self):
+    def test_view_returns_the_tail(self):
         response = self.client.get("/api/core/logs/dispatcharr.log/")
         self.assertEqual(response.status_code, 200)
-        self.assertIn("text/plain", response["Content-Type"])
-        self.assertEqual(response.content, b"line one\nline two\n")
-        self.assertEqual(response["X-Log-Truncated"], "0")
+        payload = response.json()
+        self.assertEqual(payload["content"], "line one\nline two\n")
+        self.assertFalse(payload["truncated"])
 
     def test_view_truncates_large_files_at_line_boundary(self):
         big = os.path.join(self.log_dir, "dispatcharr.log.big")
@@ -71,11 +71,12 @@ class LogFilesEndpointTests(TestCase):
                 f.write(line)
         response = self.client.get("/api/core/logs/dispatcharr.log.big/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["X-Log-Truncated"], "1")
-        self.assertLessEqual(len(response.content), log_files.MAX_VIEW_BYTES)
+        payload = response.json()
+        self.assertTrue(payload["truncated"])
+        self.assertLessEqual(len(payload["content"]), log_files.MAX_VIEW_BYTES)
         # Line-boundary start: content begins with a full line
-        self.assertTrue(response.content.startswith(b"x"))
-        self.assertEqual(len(response.content) % 100, 0)
+        self.assertTrue(payload["content"].startswith("x"))
+        self.assertEqual(len(payload["content"]) % 100, 0)
 
     def test_view_sizes_the_open_handle_not_the_path(self):
         """A rotation between sizing and reading must not empty the view."""
@@ -101,45 +102,45 @@ class LogFilesEndpointTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         # Sized from the handle: the fresh file is served whole, not seeked past.
-        self.assertEqual(response.content, b"new\n")
-        self.assertEqual(response["X-Log-Truncated"], "0")
+        self.assertEqual(response.json()["content"], "new\n")
+        self.assertFalse(response.json()["truncated"])
 
     def test_cursor_returns_only_bytes_written_since(self):
         live = os.path.join(self.log_dir, "dispatcharr.log")
-        first = self.client.get("/api/core/logs/dispatcharr.log/")
-        self.assertEqual(first["X-Log-Reset"], "1")
+        first = self.client.get("/api/core/logs/dispatcharr.log/").json()
+        self.assertTrue(first["reset"])
         with open(live, "a") as f:
             f.write("line three\n")
 
         second = self.client.get(
-            "/api/core/logs/dispatcharr.log/", {"cursor": first["X-Log-Cursor"]}
-        )
-        self.assertEqual(second["X-Log-Reset"], "0")
-        self.assertEqual(second.content, b"line three\n")
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["cursor"]}
+        ).json()
+        self.assertFalse(second["reset"])
+        self.assertEqual(second["content"], "line three\n")
 
     def test_cursor_withholds_a_line_still_being_written(self):
         live = os.path.join(self.log_dir, "dispatcharr.log")
-        first = self.client.get("/api/core/logs/dispatcharr.log/")
+        first = self.client.get("/api/core/logs/dispatcharr.log/").json()
         with open(live, "a") as f:
             f.write("complete\npartial-so-far")
 
         second = self.client.get(
-            "/api/core/logs/dispatcharr.log/", {"cursor": first["X-Log-Cursor"]}
-        )
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["cursor"]}
+        ).json()
         # The fragment is held back; the cursor stays in front of it.
-        self.assertEqual(second.content, b"complete\n")
+        self.assertEqual(second["content"], "complete\n")
 
         with open(live, "a") as f:
             f.write("-and-the-rest\n")
         third = self.client.get(
-            "/api/core/logs/dispatcharr.log/", {"cursor": second["X-Log-Cursor"]}
-        )
-        self.assertEqual(third.content, b"partial-so-far-and-the-rest\n")
+            "/api/core/logs/dispatcharr.log/", {"cursor": second["cursor"]}
+        ).json()
+        self.assertEqual(third["content"], "partial-so-far-and-the-rest\n")
 
     def test_cursor_from_a_rotated_file_resets_instead_of_skipping(self):
         """A stale offset must not be resumed against a different inode."""
         live = os.path.join(self.log_dir, "dispatcharr.log")
-        first = self.client.get("/api/core/logs/dispatcharr.log/")
+        first = self.client.get("/api/core/logs/dispatcharr.log/").json()
 
         # The collector's rotation, then a new file grown past the old offset.
         os.replace(live, live + ".9")
@@ -147,29 +148,26 @@ class LogFilesEndpointTests(TestCase):
             f.write("fresh one\nfresh two\nfresh three\n")
 
         second = self.client.get(
-            "/api/core/logs/dispatcharr.log/", {"cursor": first["X-Log-Cursor"]}
-        )
-        self.assertEqual(second["X-Log-Reset"], "1")
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["cursor"]}
+        ).json()
+        self.assertTrue(second["reset"])
         # Every line of the new file, not the slice past a meaningless offset.
-        self.assertEqual(
-            second.content, b"fresh one\nfresh two\nfresh three\n"
-        )
+        self.assertEqual(second["content"], "fresh one\nfresh two\nfresh three\n")
 
     def test_cursor_beyond_a_gap_falls_back_to_the_tail(self):
         """A tab that slept must not be handed more than the view cap."""
         live = os.path.join(self.log_dir, "dispatcharr.log")
-        first = self.client.get("/api/core/logs/dispatcharr.log/")
+        first = self.client.get("/api/core/logs/dispatcharr.log/").json()
         with open(live, "ab") as f:
             f.write((b"x" * 99 + b"\n") * 40)
 
         with mock.patch.object(log_files, "MAX_VIEW_BYTES", 1000):
-            response = self.client.get(
-                "/api/core/logs/dispatcharr.log/",
-                {"cursor": first["X-Log-Cursor"]},
-            )
-        self.assertEqual(response["X-Log-Truncated"], "1")
-        self.assertEqual(response["X-Log-Reset"], "1")
-        self.assertLessEqual(len(response.content), 1000)
+            payload = self.client.get(
+                "/api/core/logs/dispatcharr.log/", {"cursor": first["cursor"]}
+            ).json()
+        self.assertTrue(payload["truncated"])
+        self.assertTrue(payload["reset"])
+        self.assertLessEqual(len(payload["content"]), 1000)
 
     def test_cursor_is_ignored_when_malformed(self):
         for bad in ("", "garbage", "12-", "-5", "abc-def"):
@@ -177,8 +175,8 @@ class LogFilesEndpointTests(TestCase):
                 "/api/core/logs/dispatcharr.log/", {"cursor": bad}
             )
             self.assertEqual(response.status_code, 200, bad)
-            self.assertEqual(response["X-Log-Reset"], "1", bad)
-            self.assertEqual(response.content, b"line one\nline two\n", bad)
+            self.assertTrue(response.json()["reset"], bad)
+            self.assertEqual(response.json()["content"], "line one\nline two\n", bad)
 
     def test_download_sets_attachment_disposition(self):
         response = self.client.get("/api/core/logs/dispatcharr.log/download/")

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -56,6 +56,15 @@ class LogFilesEndpointTests(TestCase):
         response = self.client.get("/api/core/logs/")
         self.assertFalse(response.json()["collector_running"])
 
+    def test_console_only_install_has_no_files(self):
+        with override_settings(LOG_FILE_DIR=None):
+            listing = self.client.get("/api/core/logs/").json()
+            self.assertEqual(listing["files"], [])
+            self.assertFalse(listing["collector_running"])
+            self.assertEqual(
+                self.client.get("/api/core/logs/dispatcharr.log/").status_code, 404
+            )
+
     def test_view_returns_the_tail(self):
         response = self.client.get("/api/core/logs/dispatcharr.log/")
         self.assertEqual(response.status_code, 200)

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -45,7 +45,6 @@ class LogFilesEndpointTests(TestCase):
         response = self.client.get("/api/core/logs/")
         self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertEqual(payload["path"], self.log_dir)
         names = {f["name"] for f in payload["files"]}
         self.assertEqual(names, {"dispatcharr.log", "dispatcharr.log.1"})
         for entry in payload["files"]:

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -4,6 +4,7 @@ import os
 import time
 import shutil
 import tempfile
+from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
@@ -75,6 +76,33 @@ class LogFilesEndpointTests(TestCase):
         # Line-boundary start: content begins with a full line
         self.assertTrue(response.content.startswith(b"x"))
         self.assertEqual(len(response.content) % 100, 0)
+
+    def test_view_sizes_the_open_handle_not_the_path(self):
+        """A rotation between sizing and reading must not empty the view."""
+        live = os.path.join(self.log_dir, "dispatcharr.log")
+        with open(live, "wb") as f:
+            f.write(b"old\n" * 500)
+
+        real_open = open
+
+        def rotating_open(path, *args, **kwargs):
+            # Rotate exactly once, the way the collector does, as the view opens.
+            if path == live and not getattr(rotating_open, "fired", False):
+                rotating_open.fired = True
+                os.replace(live, live + ".9")
+                with real_open(live, "wb") as fresh:
+                    fresh.write(b"new\n")
+            return real_open(path, *args, **kwargs)
+
+        with mock.patch.object(log_files, "MAX_VIEW_BYTES", 100), mock.patch(
+            "core.log_files.open", rotating_open, create=True
+        ):
+            response = self.client.get("/api/core/logs/dispatcharr.log/")
+
+        self.assertEqual(response.status_code, 200)
+        # Sized from the handle: the fresh file is served whole, not seeked past.
+        self.assertEqual(response.content, b"new\n")
+        self.assertEqual(response["X-Log-Truncated"], "0")
 
     def test_download_sets_attachment_disposition(self):
         response = self.client.get("/api/core/logs/dispatcharr.log/download/")

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -1,7 +1,6 @@
 """Tests for the log file browsing endpoints (System > Logs)."""
 
 import os
-import time
 import shutil
 import tempfile
 from unittest import mock
@@ -14,6 +13,12 @@ from core import log_files
 
 
 class LogFilesEndpointTests(TestCase):
+    URLS = (
+        "/api/core/logs/",
+        "/api/core/logs/dispatcharr.log/",
+        "/api/core/logs/dispatcharr.log/download/",
+    )
+
     @classmethod
     def setUpTestData(cls):
         User = get_user_model()
@@ -227,11 +232,6 @@ class LogFilesEndpointTests(TestCase):
             self.client.get("/api/core/logs/secrets.env/download/").status_code, 404
         )
 
-    def test_download_requires_authentication(self):
-        self.client.force_authenticate(None)
-        response = self.client.get("/api/core/logs/dispatcharr.log/download/")
-        self.assertEqual(response.status_code, 401)
-
     def test_resolver_rejects_traversal_and_dotfiles(self):
         # A traversal URL never reaches this view; it decodes to a slashed path the SPA serves.
         self.assertIsNone(log_files._resolve("../secret.txt"))
@@ -262,16 +262,6 @@ class LogFilesEndpointTests(TestCase):
         self.assertNotIn("escape.log", names)
         self.assertEqual(names, {"dispatcharr.log", "dispatcharr.log.1"})
 
-    def test_traversal_name_that_reaches_the_view_is_404(self):
-        # Only slash-free names route here, so this is the closest a URL gets.
-        secret = os.path.join(self.log_dir, os.pardir, "secret.txt")
-        with open(secret, "w") as f:
-            f.write("TOP SECRET")
-        self.addCleanup(os.remove, secret)
-        response = self.client.get("/api/core/logs/.hidden/")
-        self.assertEqual(response.status_code, 404)
-        self.assertNotIn(b"TOP SECRET", response.content)
-
     def test_missing_file_is_404(self):
         response = self.client.get("/api/core/logs/nope.log/")
         self.assertEqual(response.status_code, 404)
@@ -286,11 +276,10 @@ class LogFilesEndpointTests(TestCase):
 
     def test_non_admin_is_forbidden(self):
         self.client.force_authenticate(self.viewer)
-        self.assertEqual(self.client.get("/api/core/logs/").status_code, 403)
-        self.assertEqual(
-            self.client.get("/api/core/logs/dispatcharr.log/").status_code, 403
-        )
+        for url in self.URLS:
+            self.assertEqual(self.client.get(url).status_code, 403, url)
 
     def test_anonymous_is_unauthorized(self):
         self.client.force_authenticate(None)
-        self.assertIn(self.client.get("/api/core/logs/").status_code, (401, 403))
+        for url in self.URLS:
+            self.assertEqual(self.client.get(url).status_code, 401, url)

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -104,6 +104,82 @@ class LogFilesEndpointTests(TestCase):
         self.assertEqual(response.content, b"new\n")
         self.assertEqual(response["X-Log-Truncated"], "0")
 
+    def test_cursor_returns_only_bytes_written_since(self):
+        live = os.path.join(self.log_dir, "dispatcharr.log")
+        first = self.client.get("/api/core/logs/dispatcharr.log/")
+        self.assertEqual(first["X-Log-Reset"], "1")
+        with open(live, "a") as f:
+            f.write("line three\n")
+
+        second = self.client.get(
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["X-Log-Cursor"]}
+        )
+        self.assertEqual(second["X-Log-Reset"], "0")
+        self.assertEqual(second.content, b"line three\n")
+
+    def test_cursor_withholds_a_line_still_being_written(self):
+        live = os.path.join(self.log_dir, "dispatcharr.log")
+        first = self.client.get("/api/core/logs/dispatcharr.log/")
+        with open(live, "a") as f:
+            f.write("complete\npartial-so-far")
+
+        second = self.client.get(
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["X-Log-Cursor"]}
+        )
+        # The fragment is held back; the cursor stays in front of it.
+        self.assertEqual(second.content, b"complete\n")
+
+        with open(live, "a") as f:
+            f.write("-and-the-rest\n")
+        third = self.client.get(
+            "/api/core/logs/dispatcharr.log/", {"cursor": second["X-Log-Cursor"]}
+        )
+        self.assertEqual(third.content, b"partial-so-far-and-the-rest\n")
+
+    def test_cursor_from_a_rotated_file_resets_instead_of_skipping(self):
+        """A stale offset must not be resumed against a different inode."""
+        live = os.path.join(self.log_dir, "dispatcharr.log")
+        first = self.client.get("/api/core/logs/dispatcharr.log/")
+
+        # The collector's rotation, then a new file grown past the old offset.
+        os.replace(live, live + ".9")
+        with open(live, "w") as f:
+            f.write("fresh one\nfresh two\nfresh three\n")
+
+        second = self.client.get(
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["X-Log-Cursor"]}
+        )
+        self.assertEqual(second["X-Log-Reset"], "1")
+        # Every line of the new file, not the slice past a meaningless offset.
+        self.assertEqual(
+            second.content, b"fresh one\nfresh two\nfresh three\n"
+        )
+
+    def test_cursor_beyond_a_gap_falls_back_to_the_tail(self):
+        """A tab that slept must not be handed more than the view cap."""
+        live = os.path.join(self.log_dir, "dispatcharr.log")
+        first = self.client.get("/api/core/logs/dispatcharr.log/")
+        with open(live, "ab") as f:
+            f.write((b"x" * 99 + b"\n") * 40)
+
+        with mock.patch.object(log_files, "MAX_VIEW_BYTES", 1000):
+            response = self.client.get(
+                "/api/core/logs/dispatcharr.log/",
+                {"cursor": first["X-Log-Cursor"]},
+            )
+        self.assertEqual(response["X-Log-Truncated"], "1")
+        self.assertEqual(response["X-Log-Reset"], "1")
+        self.assertLessEqual(len(response.content), 1000)
+
+    def test_cursor_is_ignored_when_malformed(self):
+        for bad in ("", "garbage", "12-", "-5", "abc-def"):
+            response = self.client.get(
+                "/api/core/logs/dispatcharr.log/", {"cursor": bad}
+            )
+            self.assertEqual(response.status_code, 200, bad)
+            self.assertEqual(response["X-Log-Reset"], "1", bad)
+            self.assertEqual(response.content, b"line one\nline two\n", bad)
+
     def test_download_sets_attachment_disposition(self):
         response = self.client.get("/api/core/logs/dispatcharr.log/download/")
         self.assertEqual(response.status_code, 200)

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -93,7 +93,7 @@ class LogFilesEndpointTests(TestCase):
 
     def test_view_sizes_the_open_handle_not_the_path(self):
         """A rotation between sizing and reading must not empty the view."""
-        live = os.path.join(self.log_dir, "dispatcharr.log")
+        live = os.path.realpath(os.path.join(self.log_dir, "dispatcharr.log"))
         with open(live, "wb") as f:
             f.write(b"old\n" * 500)
 

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -166,8 +166,33 @@ class LogFilesEndpointTests(TestCase):
         self.assertTrue(payload["reset"])
         self.assertLessEqual(len(payload["content"]), 1000)
 
+    def test_cursor_past_the_end_of_the_same_inode_resets(self):
+        """In-place truncation or inode reuse leaves the offset beyond EOF."""
+        live = os.path.join(self.log_dir, "dispatcharr.log")
+        first = self.client.get("/api/core/logs/dispatcharr.log/").json()
+        with open(live, "w") as f:
+            f.write("fresh\n")
+
+        second = self.client.get(
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["cursor"]}
+        ).json()
+        self.assertTrue(second["reset"])
+        self.assertEqual(second["content"], "fresh\n")
+
+    def test_cursor_mid_line_on_the_same_inode_resets(self):
+        inode = os.stat(os.path.join(self.log_dir, "dispatcharr.log")).st_ino
+        payload = self.client.get(
+            "/api/core/logs/dispatcharr.log/", {"cursor": f"{inode}-5"}
+        ).json()
+        self.assertTrue(payload["reset"])
+        self.assertEqual(payload["content"], "line one\nline two\n")
+
     def test_cursor_is_ignored_when_malformed(self):
-        for bad in ("", "garbage", "12-", "-5", "abc-def"):
+        inode = os.stat(os.path.join(self.log_dir, "dispatcharr.log")).st_ino
+        bad_cursors = ("", "garbage", "12-", "-5", "abc-def")
+        # Characters isdigit() accepts but int() rejects, and int()'s digit limit.
+        bad_cursors += (f"{inode}-\u00b2", f"{inode}-" + "9" * 5000)
+        for bad in bad_cursors:
             response = self.client.get(
                 "/api/core/logs/dispatcharr.log/", {"cursor": bad}
             )

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -120,22 +120,19 @@ class LogFilesEndpointTests(TestCase):
 
     def test_cursor_withholds_a_line_still_being_written(self):
         live = os.path.join(self.log_dir, "dispatcharr.log")
-        first = self.client.get("/api/core/logs/dispatcharr.log/").json()
         with open(live, "a") as f:
             f.write("complete\npartial-so-far")
-
-        second = self.client.get(
-            "/api/core/logs/dispatcharr.log/", {"cursor": first["cursor"]}
-        ).json()
+        first = self.client.get("/api/core/logs/dispatcharr.log/").json()
         # The fragment is held back; the cursor stays in front of it.
-        self.assertEqual(second["content"], "complete\n")
+        self.assertEqual(first["content"], "line one\nline two\ncomplete\n")
 
         with open(live, "a") as f:
             f.write("-and-the-rest\n")
-        third = self.client.get(
-            "/api/core/logs/dispatcharr.log/", {"cursor": second["cursor"]}
+        second = self.client.get(
+            "/api/core/logs/dispatcharr.log/", {"cursor": first["cursor"]}
         ).json()
-        self.assertEqual(third["content"], "partial-so-far-and-the-rest\n")
+        self.assertFalse(second["reset"])
+        self.assertEqual(second["content"], "partial-so-far-and-the-rest\n")
 
     def test_cursor_from_a_rotated_file_resets_instead_of_skipping(self):
         """A stale offset must not be resumed against a different inode."""

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -84,44 +84,6 @@ class LogFilesEndpointTests(TestCase):
             b"".join(response.streaming_content), b"line one\nline two\n"
         )
 
-    def test_admin_gets_token_then_downloads_with_it(self):
-        token_response = self.client.get(
-            "/api/core/logs/dispatcharr.log/download-token/"
-        )
-        self.assertEqual(token_response.status_code, 200)
-        token = token_response.json()["token"]
-        self.assertTrue(token)
-
-        # A plain link carries the token but no JWT (anonymous client).
-        self.client.force_authenticate(None)
-        response = self.client.get(
-            f"/api/core/logs/dispatcharr.log/download/?token={token}"
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("attachment", response["Content-Disposition"])
-        self.assertEqual(
-            b"".join(response.streaming_content), b"line one\nline two\n"
-        )
-
-    def test_download_token_expires(self):
-        # uWSGI logs request URIs into this log, so a lasting token is a key inside the file.
-        stale = log_files._download_token(
-            "dispatcharr.log", self.admin.pk, expires=time.time() - 1
-        )
-        self.client.logout()
-        response = self.client.get(
-            f"/api/core/logs/dispatcharr.log/download/?token={stale}"
-        )
-        self.assertEqual(response.status_code, 403)
-
-    def test_download_token_is_bound_to_one_file(self):
-        token = log_files._download_token("dispatcharr.log", self.admin.pk)
-        self.client.logout()
-        response = self.client.get(
-            f"/api/core/logs/dispatcharr.log.1/download/?token={token}"
-        )
-        self.assertEqual(response.status_code, 403)
-
     def test_endpoints_serve_only_the_log_family(self):
         # DISPATCHARR_LOG_DIR may point at a data root; view and download are not a file server.
         with open(os.path.join(self.log_dir, "secrets.env"), "w") as f:
@@ -133,14 +95,7 @@ class LogFilesEndpointTests(TestCase):
             self.client.get("/api/core/logs/secrets.env/download/").status_code, 404
         )
 
-    def test_download_with_bad_token_is_forbidden(self):
-        self.client.force_authenticate(None)
-        response = self.client.get(
-            "/api/core/logs/dispatcharr.log/download/?token=deadbeef"
-        )
-        self.assertEqual(response.status_code, 403)
-
-    def test_download_without_token_or_auth_is_unauthorized(self):
+    def test_download_requires_authentication(self):
         self.client.force_authenticate(None)
         response = self.client.get("/api/core/logs/dispatcharr.log/download/")
         self.assertEqual(response.status_code, 401)
@@ -195,13 +150,6 @@ class LogFilesEndpointTests(TestCase):
         self.assertEqual(
             self.client.get("/api/core/logs/dispatcharr.log/").status_code, 403
         )
-
-    def test_non_admin_download_token_is_forbidden(self):
-        self.client.force_authenticate(self.viewer)
-        response = self.client.get(
-            "/api/core/logs/dispatcharr.log/download-token/"
-        )
-        self.assertEqual(response.status_code, 403)
 
     def test_anonymous_is_unauthorized(self):
         self.client.force_authenticate(None)

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -91,6 +91,26 @@ class LogFilesEndpointTests(TestCase):
         self.assertTrue(payload["content"].startswith("x"))
         self.assertEqual(len(payload["content"]) % 100, 0)
 
+    def test_truncation_on_a_record_boundary_keeps_that_record(self):
+        """The cap can land on a boundary; skipping anyway drops a whole line."""
+        big = os.path.join(self.log_dir, "dispatcharr.log.big")
+        with open(big, "wb") as f:
+            for i in range(10):
+                f.write(b"%d" % i + b"x" * 8 + b"\n")
+
+        # 50 is exactly where line 5 begins.
+        with mock.patch.object(log_files, "MAX_VIEW_BYTES", 50):
+            payload = self.client.get("/api/core/logs/dispatcharr.log.big/").json()
+        self.assertTrue(payload["truncated"])
+        self.assertEqual(len(payload["content"]), 50)
+        self.assertTrue(payload["content"].startswith("5xxxxxxxx\n"))
+
+        # 45 lands mid-line, and there the partial record has to go.
+        with mock.patch.object(log_files, "MAX_VIEW_BYTES", 45):
+            payload = self.client.get("/api/core/logs/dispatcharr.log.big/").json()
+        self.assertTrue(payload["content"].startswith("6xxxxxxxx\n"))
+        self.assertEqual(len(payload["content"]), 40)
+
     def test_view_sizes_the_open_handle_not_the_path(self):
         """A rotation between sizing and reading must not empty the view."""
         live = os.path.realpath(os.path.join(self.log_dir, "dispatcharr.log"))

--- a/core/tests/test_log_files.py
+++ b/core/tests/test_log_files.py
@@ -10,6 +10,7 @@ from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 
 from core import log_files
+from dispatcharr import log_collector
 
 
 class LogFilesEndpointTests(TestCase):
@@ -110,6 +111,11 @@ class LogFilesEndpointTests(TestCase):
             payload = self.client.get("/api/core/logs/dispatcharr.log.big/").json()
         self.assertTrue(payload["content"].startswith("6xxxxxxxx\n"))
         self.assertEqual(len(payload["content"]), 40)
+
+    def test_ceiling_covers_the_largest_permitted_log(self):
+        """A rotation fires after the batch that crossed the cap, so files run over."""
+        largest = log_collector.MAX_LOG_MB * 1024 * 1024 + 2 * log_collector._BATCH_BYTES
+        self.assertGreaterEqual(log_files.MAX_VIEW_BYTES, largest)
 
     def test_view_sizes_the_open_handle_not_the_path(self):
         """A rotation between sizing and reading must not empty the view."""

--- a/core/tests/test_log_rotation.py
+++ b/core/tests/test_log_rotation.py
@@ -34,5 +34,5 @@ class SystemSettingsCoercionTests(TestCase):
             inst, {"value": {"log_max_mb": "abc", "log_keep": 999}}
         )
         inst.refresh_from_db()
-        self.assertEqual(inst.value["log_max_mb"], 10)  # garbage -> default
+        self.assertEqual(inst.value["log_max_mb"], 5)  # garbage -> default
         self.assertEqual(inst.value["log_keep"], 50)  # above max -> clamped

--- a/dispatcharr/log_collector.py
+++ b/dispatcharr/log_collector.py
@@ -31,7 +31,8 @@ def _role_suffix():
 
 
 _SUFFIX = _role_suffix()
-LIVE_NAME = f"dispatcharr.log{_SUFFIX}"
+BASE_NAME = "dispatcharr.log"
+LIVE_NAME = f"{BASE_NAME}{_SUFFIX}"
 # Shared: one settings save configures every collector on this log directory.
 CONF_NAME = "collector.conf"
 PID_NAME = f"collector{_SUFFIX}.pid"

--- a/dispatcharr/log_collector.py
+++ b/dispatcharr/log_collector.py
@@ -258,9 +258,9 @@ def read_conf(log_dir):
     except OSError:
         return conf
     conf["persist"] = str(conf["persist"]).strip() not in ("0", "false", "")
-    for key, cap in (("max_mb", MAX_LOG_MB), ("keep", MAX_LOG_KEEP)):
+    for key, lo, cap in (("max_mb", 1, MAX_LOG_MB), ("keep", 2, MAX_LOG_KEEP)):
         try:
-            conf[key] = min(max(int(conf[key]), 1), cap)
+            conf[key] = min(max(int(conf[key]), lo), cap)
         except (TypeError, ValueError):
             conf[key] = _DEFAULT_CONF[key]
     return conf
@@ -677,7 +677,7 @@ class Collector:
         self._close_fd()
         try:
             for n in sorted(self._archive_indices(), reverse=True):
-                if n >= self.conf["keep"]:
+                if n + 1 >= self.conf["keep"]:
                     os.remove(f"{self.live_path}.{n}")
                 else:
                     os.replace(f"{self.live_path}.{n}", f"{self.live_path}.{n + 1}")
@@ -692,7 +692,7 @@ class Collector:
         # must converge without waiting for a size-cap rotation.
         try:
             for n in self._archive_indices():
-                if n > self.conf["keep"]:
+                if n >= self.conf["keep"]:
                     os.remove(f"{self.live_path}.{n}")
         except OSError:
             pass

--- a/dispatcharr/log_collector.py
+++ b/dispatcharr/log_collector.py
@@ -45,10 +45,15 @@ _MAX_RECORD_BYTES = 16 * 1024
 
 _TRUNCATED = b" ... [log_collector truncated this record at %d bytes]\n" % _MAX_RECORD_BYTES
 
+DEFAULT_LOG_MB = 5
+MAX_LOG_MB = 20
+DEFAULT_LOG_KEEP = 5
+MAX_LOG_KEEP = 50
+
 _DEFAULT_CONF = {
     "persist": True,
-    "max_mb": 10,
-    "keep": 5,
+    "max_mb": DEFAULT_LOG_MB,
+    "keep": DEFAULT_LOG_KEEP,
     "time_zone": "",
 }
 
@@ -202,8 +207,8 @@ def apply_settings(log_dir, values, warn_if_absent=False):
     write_conf(
         log_dir,
         values.get("log_persist", True) is not False,
-        values.get("log_max_mb", 10) or 10,
-        values.get("log_keep", 5) or 5,
+        values.get("log_max_mb", DEFAULT_LOG_MB) or DEFAULT_LOG_MB,
+        values.get("log_keep", DEFAULT_LOG_KEEP) or DEFAULT_LOG_KEEP,
         values.get("time_zone") or "UTC",
     )
     if warn_if_absent and not collector_running(log_dir):
@@ -253,7 +258,7 @@ def read_conf(log_dir):
     except OSError:
         return conf
     conf["persist"] = str(conf["persist"]).strip() not in ("0", "false", "")
-    for key, cap in (("max_mb", 1000), ("keep", 50)):
+    for key, cap in (("max_mb", MAX_LOG_MB), ("keep", MAX_LOG_KEEP)):
         try:
             conf[key] = min(max(int(conf[key]), 1), cap)
         except (TypeError, ValueError):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,8 @@ import Channels from './pages/Channels';
 import ContentSources from './pages/ContentSources';
 import Guide from './pages/Guide';
 import Stats from './pages/Stats';
+import LogFilesPage from './pages/LogFiles';
+import LogFileViewPage from './pages/LogFileView';
 import DVR from './pages/DVR';
 import Settings from './pages/Settings';
 import PluginsPage from './pages/Plugins';
@@ -167,6 +169,11 @@ const App = () => {
                             <Route path="/guide" element={<Guide />} />
                             <Route path="/dvr" element={<DVR />} />
                             <Route path="/stats" element={<Stats />} />
+                            <Route path="/logs" element={<LogFilesPage />} />
+                            <Route
+                              path="/logs/:name"
+                              element={<LogFileViewPage />}
+                            />
                             <Route
                               path="/plugins/browse"
                               element={<PluginBrowsePage />}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3809,7 +3809,6 @@ export default class API {
     }
   }
 
-  // Fetched over the authenticated session, so no secret ever rides in a URL.
   static async downloadLogFile(name) {
     try {
       const response = await fetch(

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3799,32 +3799,9 @@ export default class API {
   static async getLogFile(name, { silent = false, cursor = null } = {}) {
     try {
       const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
-      const response = await fetch(
-        `${host}/api/core/logs/${encodeURIComponent(name)}/${query}`,
-        {
-          headers: { Authorization: `Bearer ${await API.getAuthToken()}` },
-        }
+      return await request(
+        `${host}/api/core/logs/${encodeURIComponent(name)}/${query}`
       );
-      if (!response.ok) {
-        const error = new Error(`HTTP error! Status: ${response.status}`);
-        let errorBody = await response.text();
-        try {
-          errorBody = JSON.parse(errorBody);
-        } catch {
-          // If parsing fails, leave errorBody as the raw text
-        }
-        error.status = response.status;
-        error.response = response;
-        error.body = errorBody;
-        throw error;
-      }
-      return {
-        content: await response.text(),
-        truncated: response.headers.get('X-Log-Truncated') === '1',
-        cursor: response.headers.get('X-Log-Cursor'),
-        // A backend without the cursor headers replaces the buffer every poll.
-        reset: response.headers.get('X-Log-Reset') !== '0',
-      };
     } catch (e) {
       if (!silent) {
         errorNotification('Failed to retrieve log file', e);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3795,11 +3795,12 @@ export default class API {
     }
   }
 
-  // { silent: true } drops the toast for background auto-refresh polls.
-  static async getLogFile(name, { silent = false } = {}) {
+  // silent drops the toast for background polls; a cursor asks only for new bytes.
+  static async getLogFile(name, { silent = false, cursor = null } = {}) {
     try {
+      const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
       const response = await fetch(
-        `${host}/api/core/logs/${encodeURIComponent(name)}/`,
+        `${host}/api/core/logs/${encodeURIComponent(name)}/${query}`,
         {
           headers: { Authorization: `Bearer ${await API.getAuthToken()}` },
         }
@@ -3820,6 +3821,9 @@ export default class API {
       return {
         content: await response.text(),
         truncated: response.headers.get('X-Log-Truncated') === '1',
+        cursor: response.headers.get('X-Log-Cursor'),
+        // A backend without the cursor headers replaces the buffer every poll.
+        reset: response.headers.get('X-Log-Reset') !== '0',
       };
     } catch (e) {
       if (!silent) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3835,7 +3835,7 @@ export default class API {
     return response.token;
   }
 
-  // A signed token lets a plain <a download> link stream the file instead of buffering it in tab memory.
+  // A signed token lets a plain <a download> link stream the file, not buffer it.
   static async downloadLogFile(name) {
     try {
       const token = await API.getLogDownloadToken(name);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3787,6 +3787,73 @@ export default class API {
     }
   }
 
+  static async getLogFiles() {
+    try {
+      return await request(`${host}/api/core/logs/`);
+    } catch (e) {
+      errorNotification('Failed to retrieve log files', e);
+    }
+  }
+
+  // { silent: true } drops the toast for background auto-refresh polls.
+  static async getLogFile(name, { silent = false } = {}) {
+    try {
+      const response = await fetch(
+        `${host}/api/core/logs/${encodeURIComponent(name)}/`,
+        {
+          headers: { Authorization: `Bearer ${await API.getAuthToken()}` },
+        }
+      );
+      if (!response.ok) {
+        const error = new Error(`HTTP error! Status: ${response.status}`);
+        let errorBody = await response.text();
+        try {
+          errorBody = JSON.parse(errorBody);
+        } catch {
+          // If parsing fails, leave errorBody as the raw text
+        }
+        error.status = response.status;
+        error.response = response;
+        error.body = errorBody;
+        throw error;
+      }
+      return {
+        content: await response.text(),
+        truncated: response.headers.get('X-Log-Truncated') === '1',
+      };
+    } catch (e) {
+      if (!silent) {
+        errorNotification('Failed to retrieve log file', e);
+      }
+    }
+  }
+
+  static async getLogDownloadToken(name) {
+    const response = await request(
+      `${host}/api/core/logs/${encodeURIComponent(name)}/download-token/`
+    );
+    return response.token;
+  }
+
+  // A signed token lets a plain <a download> link stream the file instead of buffering it in tab memory.
+  static async downloadLogFile(name) {
+    try {
+      const token = await API.getLogDownloadToken(name);
+      const downloadUrl = `${host}/api/core/logs/${encodeURIComponent(name)}/download/?token=${encodeURIComponent(token)}`;
+
+      const link = document.createElement('a');
+      link.href = downloadUrl;
+      link.download = name;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      return { name };
+    } catch (e) {
+      errorNotification('Failed to download log file', e);
+    }
+  }
+
   static async getSystemEvents(limit = 100, offset = 0, eventType = null) {
     try {
       const params = new URLSearchParams();

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3828,25 +3828,26 @@ export default class API {
     }
   }
 
-  static async getLogDownloadToken(name) {
-    const response = await request(
-      `${host}/api/core/logs/${encodeURIComponent(name)}/download-token/`
-    );
-    return response.token;
-  }
-
-  // A signed token lets a plain <a download> link stream the file, not buffer it.
+  // Fetched over the authenticated session, so no secret ever rides in a URL.
   static async downloadLogFile(name) {
     try {
-      const token = await API.getLogDownloadToken(name);
-      const downloadUrl = `${host}/api/core/logs/${encodeURIComponent(name)}/download/?token=${encodeURIComponent(token)}`;
-
+      const response = await fetch(
+        `${host}/api/core/logs/${encodeURIComponent(name)}/download/`,
+        {
+          headers: { Authorization: `Bearer ${await API.getAuthToken()}` },
+        }
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      const url = URL.createObjectURL(await response.blob());
       const link = document.createElement('a');
-      link.href = downloadUrl;
+      link.href = url;
       link.download = name;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      URL.revokeObjectURL(url);
 
       return { name };
     } catch (e) {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -75,6 +75,11 @@ const request = async (url, options = {}) => {
     throw error;
   }
 
+  // { raw: true } hands back the Response for a caller that wants a blob.
+  if (options.raw) {
+    return response;
+  }
+
   // 204 / empty bodies are success with no payload. Return null, not '',
   // so callers that destructure the result don't silently get undefined fields.
   const text = await response.text();
@@ -3811,15 +3816,10 @@ export default class API {
 
   static async downloadLogFile(name) {
     try {
-      const response = await fetch(
+      const response = await request(
         `${host}/api/core/logs/${encodeURIComponent(name)}/download/`,
-        {
-          headers: { Authorization: `Bearer ${await API.getAuthToken()}` },
-        }
+        { raw: true }
       );
-      if (!response.ok) {
-        throw new Error(`HTTP error! Status: ${response.status}`);
-      }
       const url = URL.createObjectURL(await response.blob());
       const link = document.createElement('a');
       link.href = url;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -3829,8 +3829,6 @@ export default class API {
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
-
-      return { name };
     } catch (e) {
       errorNotification('Failed to download log file', e);
     }

--- a/frontend/src/components/DownloadLogButton.jsx
+++ b/frontend/src/components/DownloadLogButton.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Button } from '@mantine/core';
+import API from '../api';
+
+// The whole body arrives before the browser saves anything; say so.
+const DownloadLogButton = ({ name, ...props }) => {
+  const [busy, setBusy] = useState(false);
+  return (
+    <Button
+      size="xs"
+      variant="subtle"
+      loading={busy}
+      onClick={async () => {
+        setBusy(true);
+        try {
+          await API.downloadLogFile(name);
+        } catch {
+          // errorNotification already surfaced the failure
+        } finally {
+          setBusy(false);
+        }
+      }}
+      {...props}
+    >
+      Download
+    </Button>
+  );
+};
+
+export default DownloadLogButton;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -209,20 +209,14 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
 
   const navOrder = getNavOrder();
   const hiddenNav = getHiddenNav();
-  // A missing flag counts as running.
-  const logCollectorRunning = environment.log_collector_running !== false;
+  const logCollectorRunning = environment.log_collector_running;
   const navItems = useMemo(() => {
     const ordered = getOrderedNavItems(navOrder, isAdmin, channelIds, {
       canViewDvr: userCanViewDvr,
       canViewVod: userCanViewVod,
+      logCollectorRunning,
     });
-    // A deployment with no collector has no log files to browse.
-    const visible = (entry) => entry.path !== '/logs' || logCollectorRunning;
-    return ordered
-      .filter((item) => !hiddenNav.includes(item.id) && visible(item))
-      .map((item) =>
-        item.paths ? { ...item, paths: item.paths.filter(visible) } : item
-      );
+    return ordered.filter((item) => !hiddenNav.includes(item.id));
   }, [
     navOrder,
     hiddenNav,

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -209,7 +209,7 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
 
   const navOrder = getNavOrder();
   const hiddenNav = getHiddenNav();
-  // Absent on an older backend: assume running rather than hide a working page.
+  // A missing flag counts as running.
   const logCollectorRunning = environment.log_collector_running !== false;
   const navItems = useMemo(() => {
     const ordered = getOrderedNavItems(navOrder, isAdmin, channelIds, {

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -214,8 +214,21 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
       canViewDvr: userCanViewDvr,
       canViewVod: userCanViewVod,
     });
-    return ordered.filter((item) => !hiddenNav.includes(item.id));
-  }, [navOrder, hiddenNav, isAdmin, userCanViewDvr, userCanViewVod, channelIds]);
+    return ordered.filter(
+      (item) =>
+        !hiddenNav.includes(item.id) &&
+        // Modular mode is stdout-only: no collector, no log file to browse.
+        !(item.path === '/logs' && environment.env_mode === 'modular')
+    );
+  }, [
+    navOrder,
+    hiddenNav,
+    isAdmin,
+    userCanViewDvr,
+    userCanViewVod,
+    channelIds,
+    environment.env_mode,
+  ]);
 
   const isSettingsPage = location.pathname.startsWith('/settings');
   const activeSettingsId = location.hash.replace('#', '');

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -214,21 +214,8 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
       canViewDvr: userCanViewDvr,
       canViewVod: userCanViewVod,
     });
-    return ordered.filter(
-      (item) =>
-        !hiddenNav.includes(item.id) &&
-        // Modular mode is stdout-only: no collector, no log file to browse.
-        !(item.path === '/logs' && environment.env_mode === 'modular')
-    );
-  }, [
-    navOrder,
-    hiddenNav,
-    isAdmin,
-    userCanViewDvr,
-    userCanViewVod,
-    channelIds,
-    environment.env_mode,
-  ]);
+    return ordered.filter((item) => !hiddenNav.includes(item.id));
+  }, [navOrder, hiddenNav, isAdmin, userCanViewDvr, userCanViewVod, channelIds]);
 
   const isSettingsPage = location.pathname.startsWith('/settings');
   const activeSettingsId = location.hash.replace('#', '');

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -209,13 +209,29 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
 
   const navOrder = getNavOrder();
   const hiddenNav = getHiddenNav();
+  // Absent on an older backend: assume running rather than hide a working page.
+  const logCollectorRunning = environment.log_collector_running !== false;
   const navItems = useMemo(() => {
     const ordered = getOrderedNavItems(navOrder, isAdmin, channelIds, {
       canViewDvr: userCanViewDvr,
       canViewVod: userCanViewVod,
     });
-    return ordered.filter((item) => !hiddenNav.includes(item.id));
-  }, [navOrder, hiddenNav, isAdmin, userCanViewDvr, userCanViewVod, channelIds]);
+    // A deployment with no collector has no log files to browse.
+    const visible = (entry) => entry.path !== '/logs' || logCollectorRunning;
+    return ordered
+      .filter((item) => !hiddenNav.includes(item.id) && visible(item))
+      .map((item) =>
+        item.paths ? { ...item, paths: item.paths.filter(visible) } : item
+      );
+  }, [
+    navOrder,
+    hiddenNav,
+    isAdmin,
+    userCanViewDvr,
+    userCanViewVod,
+    channelIds,
+    logCollectorRunning,
+  ]);
 
   const isSettingsPage = location.pathname.startsWith('/settings');
   const activeSettingsId = location.hash.replace('#', '');

--- a/frontend/src/components/SystemEvents.jsx
+++ b/frontend/src/components/SystemEvents.jsx
@@ -30,6 +30,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import API from '../api';
+import { REFRESH_INTERVAL_OPTIONS } from '../constants';
 import useBrowserStorage from '../hooks/useBrowserStorage';
 import { format } from '../utils/dateTimeUtils.js';
 
@@ -261,13 +262,7 @@ const SystemEvents = () => {
                 label="Auto Refresh"
                 value={eventsRefreshInterval.toString()}
                 onChange={(value) => setEventsRefreshInterval(parseInt(value))}
-                data={[
-                  { value: '0', label: 'Manual' },
-                  { value: '5', label: '5s' },
-                  { value: '10', label: '10s' },
-                  { value: '30', label: '30s' },
-                  { value: '60', label: '1m' },
-                ]}
+                data={REFRESH_INTERVAL_OPTIONS}
                 style={{ width: 120 }}
               />
               <Button

--- a/frontend/src/components/__tests__/ConnectLogsSection.test.jsx
+++ b/frontend/src/components/__tests__/ConnectLogsSection.test.jsx
@@ -39,6 +39,7 @@ vi.mock('lucide-react', () => ({
   Webhook: () => <svg data-testid="icon-webhook" />,
   FileCode: () => <svg data-testid="icon-file-code" />,
   Logs: () => <svg data-testid="icon-logs" />,
+  ScrollText: () => <svg />,
   ChevronDown: () => <svg data-testid="icon-chevron-down" />,
 }));
 

--- a/frontend/src/components/__tests__/ConnectLogsSection.test.jsx
+++ b/frontend/src/components/__tests__/ConnectLogsSection.test.jsx
@@ -39,7 +39,6 @@ vi.mock('lucide-react', () => ({
   Webhook: () => <svg data-testid="icon-webhook" />,
   FileCode: () => <svg data-testid="icon-file-code" />,
   Logs: () => <svg data-testid="icon-logs" />,
-  ScrollText: () => <svg />,
   ChevronDown: () => <svg data-testid="icon-chevron-down" />,
 }));
 

--- a/frontend/src/components/__tests__/Sidebar.test.jsx
+++ b/frontend/src/components/__tests__/Sidebar.test.jsx
@@ -303,6 +303,31 @@ describe('Sidebar', () => {
     });
   });
 
+  describe('Navigation Links - No log collector', () => {
+    it('shows Logs while the collector flag is true or absent', async () => {
+      renderSidebar();
+      fireEvent.click(screen.getByText('System'));
+      await waitFor(() => {
+        expect(screen.getByText('Logs')).toBeInTheDocument();
+      });
+    });
+
+    it('hides Logs when no collector runs in this deployment', async () => {
+      useSettingsStore.mockImplementation((selector) =>
+        selector({
+          environment: { ...mockEnvironment, log_collector_running: false },
+          version: mockVersion,
+        })
+      );
+      renderSidebar();
+      fireEvent.click(screen.getByText('System'));
+      await waitFor(() => {
+        expect(screen.getByText('Logo Manager')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Logs')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Navigation Links - Regular User without DVR view', () => {
     beforeEach(() => {
       useAuthStore.mockImplementation((selector) => {

--- a/frontend/src/components/cards/__tests__/StreamConnectionCard.test.jsx
+++ b/frontend/src/components/cards/__tests__/StreamConnectionCard.test.jsx
@@ -172,6 +172,7 @@ vi.mock('lucide-react', () => ({
   FileImage: () => <svg data-testid="icon-file-image" />,
   Webhook: () => <svg data-testid="icon-webhook" />,
   Logs: () => <svg data-testid="icon-logs" />,
+  ScrollText: () => <svg />,
   Blocks: () => <svg data-testid="icon-blocks" />,
   MonitorCog: () => <svg data-testid="icon-monitor-cog" />,
   // StreamConnectionCard-specific icons

--- a/frontend/src/components/cards/__tests__/StreamConnectionCard.test.jsx
+++ b/frontend/src/components/cards/__tests__/StreamConnectionCard.test.jsx
@@ -172,7 +172,7 @@ vi.mock('lucide-react', () => ({
   FileImage: () => <svg data-testid="icon-file-image" />,
   Webhook: () => <svg data-testid="icon-webhook" />,
   Logs: () => <svg data-testid="icon-logs" />,
-  ScrollText: () => <svg />,
+  ScrollText: () => <svg data-testid="icon-scroll-text" />,
   Blocks: () => <svg data-testid="icon-blocks" />,
   MonitorCog: () => <svg data-testid="icon-monitor-cog" />,
   // StreamConnectionCard-specific icons

--- a/frontend/src/components/cards/__tests__/VodConnectionCard.test.jsx
+++ b/frontend/src/components/cards/__tests__/VodConnectionCard.test.jsx
@@ -135,6 +135,7 @@ vi.mock('lucide-react', () => ({
   FileImage: () => <svg data-testid="icon-file-image" />,
   Webhook: () => <svg data-testid="icon-webhook" />,
   Logs: () => <svg data-testid="icon-logs" />,
+  ScrollText: () => <svg />,
   Blocks: () => <svg data-testid="icon-blocks" />,
   MonitorCog: () => <svg data-testid="icon-monitor-cog" />,
   // VodConnectionCard-specific icons

--- a/frontend/src/components/cards/__tests__/VodConnectionCard.test.jsx
+++ b/frontend/src/components/cards/__tests__/VodConnectionCard.test.jsx
@@ -135,7 +135,7 @@ vi.mock('lucide-react', () => ({
   FileImage: () => <svg data-testid="icon-file-image" />,
   Webhook: () => <svg data-testid="icon-webhook" />,
   Logs: () => <svg data-testid="icon-logs" />,
-  ScrollText: () => <svg />,
+  ScrollText: () => <svg data-testid="icon-scroll-text" />,
   Blocks: () => <svg data-testid="icon-blocks" />,
   MonitorCog: () => <svg data-testid="icon-monitor-cog" />,
   // VodConnectionCard-specific icons

--- a/frontend/src/components/forms/__tests__/Channel.test.jsx
+++ b/frontend/src/components/forms/__tests__/Channel.test.jsx
@@ -131,6 +131,7 @@ vi.mock('lucide-react', () => ({
   LayoutGrid: () => <svg data-testid="icon-layout-grid" />,
   ListOrdered: () => <svg data-testid="icon-list-ordered" />,
   Logs: () => <svg data-testid="icon-logs" />,
+  ScrollText: () => <svg />,
   MonitorCog: () => <svg data-testid="icon-monitor-cog" />,
   Package: () => <svg data-testid="icon-package" />,
   Play: () => <svg data-testid="icon-play" />,

--- a/frontend/src/components/forms/__tests__/Channel.test.jsx
+++ b/frontend/src/components/forms/__tests__/Channel.test.jsx
@@ -131,7 +131,7 @@ vi.mock('lucide-react', () => ({
   LayoutGrid: () => <svg data-testid="icon-layout-grid" />,
   ListOrdered: () => <svg data-testid="icon-list-ordered" />,
   Logs: () => <svg data-testid="icon-logs" />,
-  ScrollText: () => <svg />,
+  ScrollText: () => <svg data-testid="icon-scroll-text" />,
   MonitorCog: () => <svg data-testid="icon-monitor-cog" />,
   Package: () => <svg data-testid="icon-package" />,
   Play: () => <svg data-testid="icon-play" />,

--- a/frontend/src/components/forms/settings/SystemSettingsForm.jsx
+++ b/frontend/src/components/forms/settings/SystemSettingsForm.jsx
@@ -105,13 +105,13 @@ const SystemSettingsForm = React.memo(({ active }) => {
             label="Maximum Log File Size (MB)"
             description="Rotate the application log once it grows past this size. Older logs are kept up to the retention limit below."
             id="log_max_mb"
-            value={form.values['log_max_mb'] || 10}
+            value={form.values['log_max_mb'] || 5}
             onChange={(value) => {
               form.setFieldValue('log_max_mb', value);
             }}
             min={1}
-            max={1000}
-            step={5}
+            max={20}
+            step={1}
           />
           <NumberInput
             label="Log Files Retained"

--- a/frontend/src/components/forms/settings/SystemSettingsForm.jsx
+++ b/frontend/src/components/forms/settings/SystemSettingsForm.jsx
@@ -97,13 +97,13 @@ const SystemSettingsForm = React.memo(({ active }) => {
         <>
           <Switch
             label="Persist Logs to File"
-            description="Write application logs to disk for the Logs page. Console logging is unaffected."
+            description="Write logs to disk for the Logs page. Console output is unaffected."
             {...form.getInputProps('log_persist', { type: 'checkbox' })}
             id="log_persist"
           />
           <NumberInput
             label="Maximum Log File Size (MB)"
-            description="Rotate the application log once it grows past this size. Older logs are kept up to the retention limit below."
+            description="Rotate the log once it grows past this size."
             id="log_max_mb"
             value={form.values['log_max_mb'] || 5}
             onChange={(value) => {
@@ -114,14 +114,14 @@ const SystemSettingsForm = React.memo(({ active }) => {
             step={1}
           />
           <NumberInput
-            label="Log Files Retained"
-            description="How many rotated log files to keep before the oldest is deleted."
+            label="Log Files Kept"
+            description="How many log files to keep before the oldest is deleted."
             id="log_keep"
             value={form.values['log_keep'] || 5}
             onChange={(value) => {
               form.setFieldValue('log_keep', value);
             }}
-            min={1}
+            min={2}
             max={50}
             step={1}
           />

--- a/frontend/src/components/forms/settings/SystemSettingsForm.jsx
+++ b/frontend/src/components/forms/settings/SystemSettingsForm.jsx
@@ -97,7 +97,7 @@ const SystemSettingsForm = React.memo(({ active }) => {
         <>
           <Switch
             label="Persist Logs to File"
-            description="Write application logs to disk. Console logging is unaffected."
+            description="Write application logs to disk for the Logs page. Console logging is unaffected."
             {...form.getInputProps('log_persist', { type: 'checkbox' })}
             id="log_persist"
           />

--- a/frontend/src/components/forms/settings/__tests__/SystemSettingsForm.test.jsx
+++ b/frontend/src/components/forms/settings/__tests__/SystemSettingsForm.test.jsx
@@ -121,7 +121,7 @@ const setupMocks = ({
 } = {}) => {
   const formValues = {
     max_system_events: settings?.max_system_events ?? 100,
-    log_max_mb: 10,
+    log_max_mb: 5,
     log_keep: 5,
     log_persist: true,
     preferred_region: '',
@@ -207,7 +207,7 @@ describe('SystemSettingsForm', () => {
       expect(
         screen.getByText('Maximum Log File Size (MB)')
       ).toBeInTheDocument();
-      expect(screen.getByTestId('log_max_mb')).toHaveValue(10);
+      expect(screen.getByTestId('log_max_mb')).toHaveValue(5);
     });
 
     it('renders the Log Files Retained input', () => {
@@ -341,7 +341,7 @@ describe('SystemSettingsForm', () => {
       render(<SystemSettingsForm active={true} />);
       expect(formMock.setValues).toHaveBeenCalledWith({
         max_system_events: 100,
-        log_max_mb: 10,
+        log_max_mb: 5,
         log_keep: 5,
         log_persist: true,
         preferred_region: '',
@@ -429,7 +429,7 @@ describe('SystemSettingsForm', () => {
 
       await waitFor(() => {
         expect(getChangedGroupSettings).toHaveBeenCalledWith(
-          expect.objectContaining({ log_max_mb: 10, log_keep: 5 }),
+          expect.objectContaining({ log_max_mb: 5, log_keep: 5 }),
           expect.anything(),
           'system_settings'
         );

--- a/frontend/src/components/forms/settings/__tests__/SystemSettingsForm.test.jsx
+++ b/frontend/src/components/forms/settings/__tests__/SystemSettingsForm.test.jsx
@@ -210,10 +210,10 @@ describe('SystemSettingsForm', () => {
       expect(screen.getByTestId('log_max_mb')).toHaveValue(5);
     });
 
-    it('renders the Log Files Retained input', () => {
+    it('renders the Log Files Kept input', () => {
       setupMocks();
       render(<SystemSettingsForm active={true} />);
-      expect(screen.getByText('Log Files Retained')).toBeInTheDocument();
+      expect(screen.getByText('Log Files Kept')).toBeInTheDocument();
       expect(screen.getByTestId('log_keep')).toHaveValue(5);
     });
 

--- a/frontend/src/components/tables/__tests__/M3UsTable.test.jsx
+++ b/frontend/src/components/tables/__tests__/M3UsTable.test.jsx
@@ -200,6 +200,7 @@ vi.mock('lucide-react', () => ({
   LayoutGrid: () => <svg />,
   ListOrdered: () => <svg />,
   Logs: () => <svg />,
+  ScrollText: () => <svg />,
   MonitorCog: () => <svg />,
   Package: () => <svg />,
   Play: () => <svg />,

--- a/frontend/src/config/__tests__/navigation.test.js
+++ b/frontend/src/config/__tests__/navigation.test.js
@@ -162,6 +162,15 @@ describe('navigation config', () => {
       expect(resultIds).not.toContain('dvr');
     });
 
+    it('drops the Logs entry when no log collector is running', () => {
+      const paths = (access) =>
+        getOrderedNavItems(null, true, [], access)
+          .find((item) => item.id === 'system')
+          .paths.map((entry) => entry.path);
+      expect(paths({ logCollectorRunning: false })).not.toContain('/logs');
+      expect(paths({})).toContain('/logs');
+    });
+
     it('includes dvr for non-admin users when canViewDvr is true', () => {
       const result = getOrderedNavItems(null, false, [], { canViewDvr: true });
       const resultIds = result.map((item) => item.id);

--- a/frontend/src/config/navigation.js
+++ b/frontend/src/config/navigation.js
@@ -87,7 +87,7 @@ export const NAV_ITEMS = {
       { label: 'Users', icon: User, path: '/users' },
       { label: 'Logo Manager', icon: FileImage, path: '/logos' },
       { label: 'Connect', icon: Webhook, path: '/connect' },
-      { label: 'Logs', icon: ScrollText, path: '/logs' },
+      { label: 'Logs', icon: ScrollText, path: '/logs', requires: 'logCollectorRunning' },
       { ...SETTINGS_NAV_BASE },
     ],
   },
@@ -152,9 +152,9 @@ export const getOrderedNavItems = (
   userOrder,
   isAdmin,
   channelIds = [],
-  { canViewDvr = false, canViewVod = false } = {}
+  access = {}
 ) => {
-  const defaultOrder = getDefaultOrder(isAdmin, { canViewDvr, canViewVod });
+  const defaultOrder = getDefaultOrder(isAdmin, access);
 
   let order;
   if (userOrder && Array.isArray(userOrder) && userOrder.length > 0) {
@@ -181,7 +181,10 @@ export const getOrderedNavItems = (
         id: item.id,
         label: item.label,
         icon: item.icon,
-        paths: item.paths,
+        // A missing flag keeps the entry.
+        paths: item.paths.filter(
+          (entry) => !entry.requires || access[entry.requires] !== false
+        ),
         canHide: item.canHide,
       };
     }

--- a/frontend/src/config/navigation.js
+++ b/frontend/src/config/navigation.js
@@ -13,6 +13,7 @@ import {
   FileImage,
   Webhook,
   MonitorCog,
+  ScrollText,
 } from 'lucide-react';
 
 // Shared by the top-level `settings` entry and the nested entry under
@@ -86,6 +87,7 @@ export const NAV_ITEMS = {
       { label: 'Users', icon: User, path: '/users' },
       { label: 'Logo Manager', icon: FileImage, path: '/logos' },
       { label: 'Connect', icon: Webhook, path: '/connect' },
+      { label: 'Logs', icon: ScrollText, path: '/logs' },
       { ...SETTINGS_NAV_BASE },
     ],
   },

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -372,6 +372,14 @@ export const REGION_CHOICES = [
   { value: 'zw', label: 'ZW' },
 ];
 
+export const REFRESH_INTERVAL_OPTIONS = [
+  { value: '0', label: 'Manual' },
+  { value: '5', label: '5s' },
+  { value: '10', label: '10s' },
+  { value: '30', label: '30s' },
+  { value: '60', label: '1m' },
+];
+
 export const VOD_TYPES = {
   MOVIE: 'movie',
   EPISODE: 'episode',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,10 @@ code {
   background: #777;
 }
 
+.log-body::-webkit-scrollbar-thumb {
+  min-height: 32px;
+}
+
 @supports (-moz-appearance: none) {
   input[readonly][aria-haspopup] {
     pointer-events: auto !important;

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -475,11 +475,9 @@ const LogFileViewPage = () => {
         : null;
 
   // Only new bytes arrive once a cursor is held, so classify only those and
-  // append. A reset (rotation, first load, or a backend without the headers)
-  // replaces the buffer instead.
+  // append. A reset (rotation or first load) replaces the buffer instead.
   const applyResponse = useCallback((response) => {
     cursorRef.current = response.cursor || null;
-    // Absent on an older backend: replace rather than append to a stale buffer.
     if (response.reset !== false) {
       const lines = response.content ? response.content.split('\n') : [];
       const { entries: next, inTraceback } = classifyLines(lines);

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -21,6 +21,7 @@ import {
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import API from '../api';
+import DownloadLogButton from '../components/DownloadLogButton';
 import useBrowserStorage from '../hooks/useBrowserStorage';
 
 const COLORS = {
@@ -421,8 +422,6 @@ const LogFileViewPage = () => {
     [query]
   );
   const [loadError, setLoadError] = useState(false);
-  // The whole body arrives before the browser saves anything; say so.
-  const [downloading, setDownloading] = useState(false);
 
   const loadingRef = useRef(false);
   const failuresRef = useRef(0);
@@ -725,22 +724,7 @@ const LogFileViewPage = () => {
               >
                 Refresh
               </Button>
-              <Button
-                size="xs"
-                variant="subtle"
-                loading={downloading}
-                onClick={async () => {
-                  setDownloading(true);
-                  try {
-                    await API.downloadLogFile(name);
-                  } finally {
-                    setDownloading(false);
-                  }
-                }}
-                style={{ marginTop: 'auto' }}
-              >
-                Download
-              </Button>
+              <DownloadLogButton name={name} style={{ marginTop: 'auto' }} />
             </Group>
           </Group>
         </Box>

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -195,30 +195,35 @@ const classifyLines = (lines, inTraceback = false) => {
   return { entries, inTraceback };
 };
 
-const groupEntries = (entries) => {
-  const groups = [];
-  for (const entry of entries) {
-    if (entry.kind !== 'continuation' || !groups.length) {
-      groups.push([entry]);
-    } else {
-      groups[groups.length - 1].push(entry);
-    }
-  }
-  return groups;
-};
+// Matching on a case-insensitive regex, not a lowercased copy per line: the
+// copies would double the retained text in memory for no extra speed.
+const escapeRegExp = (text) => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-const filterEntries = (entries, minRank, category, query) => {
+// A record and the continuations trailing it are kept or dropped together.
+// Walked in place rather than grouped into arrays first: the groups were one
+// short-lived array per record, which is the bulk of a filter pass's garbage.
+const filterEntries = (entries, minRank, category, matcher) => {
   const out = [];
-  for (const group of groupEntries(entries)) {
-    const record = group[0].record;
+  let start = 0;
+  while (start < entries.length) {
+    let end = start + 1;
+    while (end < entries.length && entries[end].kind === 'continuation')
+      end += 1;
+    const record = entries[start].record;
+    let keep = true;
     if (record) {
       const rank = LEVEL_RANK[record.level];
-      if (rank !== undefined && rank < minRank) continue;
-      if (category !== null && record.tier !== category) continue;
+      if (rank !== undefined && rank < minRank) keep = false;
+      else if (category !== null && record.tier !== category) keep = false;
     }
-    if (query && !group.some((e) => e.line.toLowerCase().includes(query)))
-      continue;
-    out.push(...group);
+    if (keep && matcher) {
+      keep = false;
+      for (let i = start; i < end && !keep; i += 1) {
+        keep = matcher.test(entries[i].line);
+      }
+    }
+    if (keep) for (let i = start; i < end; i += 1) out.push(entries[i]);
+    start = end;
   }
   return out;
 };
@@ -342,12 +347,13 @@ const LogFileViewPage = () => {
   // The box keeps up with typing; the filter waits for a pause.
   const [query, setQuery] = useState('');
   useEffect(() => {
-    const id = setTimeout(
-      () => setQuery(search.trim().toLowerCase()),
-      SEARCH_DEBOUNCE_MS
-    );
+    const id = setTimeout(() => setQuery(search.trim()), SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(id);
   }, [search]);
+  const matcher = useMemo(
+    () => (query ? new RegExp(escapeRegExp(query), 'i') : null),
+    [query]
+  );
   const [loadError, setLoadError] = useState(false);
   // The whole body arrives before the browser saves anything; say so.
   const [downloading, setDownloading] = useState(false);
@@ -385,15 +391,15 @@ const LogFileViewPage = () => {
 
   const { blocks, hiddenLines } = useMemo(() => {
     let kept = entries;
-    if (minLevel || category !== null || query)
-      kept = filterEntries(entries, minLevel, category, query);
+    if (minLevel || category !== null || matcher)
+      kept = filterEntries(entries, minLevel, category, matcher);
     const hidden = Math.max(0, kept.length - MAX_RENDER_LINES);
     if (hidden) kept = kept.slice(hidden);
     // Reversed as blocks, not entries, so continuations stay with their record.
     const built = buildBlocks(kept);
     if (newestFirst) built.reverse();
     return { blocks: built, hiddenLines: hidden };
-  }, [entries, newestFirst, minLevel, category, query]);
+  }, [entries, newestFirst, minLevel, category, matcher]);
 
   // Newest sits at whichever end the order puts it.
   const onViewportScroll = useCallback(() => {
@@ -414,6 +420,52 @@ const LogFileViewPage = () => {
 
   // Wrapped lines and continuations hang under the message column.
   const messageIndent = cols.stamp + cols.level + cols.module + 3;
+
+  // Every row style derives from the columns, the indent and the floor, so a
+  // handful of objects covers thousands of rows instead of six per row. Keyed
+  // off the primitives, not the cols object, so the identities survive a poll.
+  const styles = useMemo(() => {
+    const cache = new Map();
+    return {
+      stamp: { ...columnStyle(cols.stamp), color: COLORS.stamp },
+      module: {
+        ...columnStyle(cols.module),
+        color: COLORS.module,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      },
+      plain: {
+        borderLeft: '2px solid transparent',
+        paddingLeft: 8,
+        color: COLORS.stamp,
+      },
+      // Built on first sight of a level, so an unexpected one still renders.
+      forLevel: (level) => {
+        let style = cache.get(level);
+        if (!style) {
+          const severity = severityColor(level);
+          style = {
+            row: {
+              borderLeft: `2px solid ${barColor(level, minLevel)}`,
+              paddingLeft: `calc(8px + ${messageIndent}ch)`,
+              textIndent: `-${messageIndent}ch`,
+            },
+            level: {
+              ...columnStyle(cols.level),
+              color: levelColor(level),
+              fontWeight: 500,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            },
+            message: severity ? { color: severity } : undefined,
+            continuations: { textIndent: '0px', color: severity || undefined },
+          };
+          cache.set(level, style);
+        }
+        return style;
+      },
+    };
+  }, [cols.stamp, cols.level, cols.module, messageIndent, minLevel]);
 
   const notice =
     hiddenLines > 0
@@ -662,72 +714,34 @@ const LogFileViewPage = () => {
                   ? blocks.map((block, i) => {
                       if (!block.record) {
                         return (
-                          <div
-                            key={i}
-                            // Dimming marks these lines as unowned.
-                            style={{
-                              borderLeft: '2px solid transparent',
-                              paddingLeft: 8,
-                              color: COLORS.stamp,
-                            }}
-                          >
+                          // Dimming marks these lines as unowned.
+                          <div key={i} style={styles.plain}>
                             {block.lines.join('\n')}
                           </div>
                         );
                       }
-                      const mc = severityColor(block.record.level);
-                      const bc = barColor(block.record.level, minLevel);
+                      const rowStyle = styles.forLevel(block.record.level);
                       return (
-                        <div
-                          key={i}
-                          style={{
-                            borderLeft: `2px solid ${bc}`,
-                            paddingLeft: `calc(8px + ${messageIndent}ch)`,
-                            textIndent: `-${messageIndent}ch`,
-                          }}
-                        >
+                        <div key={i} style={rowStyle.row}>
+                          <span style={styles.stamp}>{block.record.stamp}</span>{' '}
                           <span
-                            style={{
-                              ...columnStyle(cols.stamp),
-                              color: COLORS.stamp,
-                            }}
-                          >
-                            {block.record.stamp}
-                          </span>{' '}
-                          <span
-                            style={{
-                              ...columnStyle(cols.level),
-                              color: levelColor(block.record.level),
-                              fontWeight: 500,
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                            }}
+                            style={rowStyle.level}
                             title={block.record.level}
                           >
                             {levelLabel(block.record.level)}
                           </span>{' '}
                           <span
-                            style={{
-                              ...columnStyle(cols.module),
-                              color: COLORS.module,
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                            }}
+                            style={styles.module}
                             title={block.record.source}
                           >
                             {block.record.module}
                           </span>
                           {block.record.sep}
-                          <span style={mc ? { color: mc } : undefined}>
+                          <span style={rowStyle.message}>
                             {block.record.message}
                           </span>
                           {block.continuations.length > 0 && (
-                            <div
-                              style={{
-                                textIndent: '0px',
-                                color: mc || undefined,
-                              }}
-                            >
+                            <div style={rowStyle.continuations}>
                               {renderContinuations(block.continuations)}
                             </div>
                           )}

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -544,17 +544,16 @@ const LogFileViewPage = () => {
   // append. A reset (rotation or first load) replaces the buffer instead.
   const applyResponse = useCallback((response) => {
     cursorRef.current = response.cursor || null;
+    const lines = response.content ? response.content.split('\n') : [];
+    // The body ends on a newline, so the split leaves a trailing empty line.
+    if (lines[lines.length - 1] === '') lines.pop();
     if (response.reset !== false) {
-      const lines = response.content ? response.content.split('\n') : [];
       const { entries: next, inTraceback } = classifyLines(lines);
       tracebackRef.current = inTraceback;
       setBuffer(trimBuffer(next, byteLength(next), response.truncated));
       return;
     }
-    if (!response.content) return;
-    // The delta ends on a newline, so the split leaves a trailing empty line.
-    const lines = response.content.split('\n');
-    if (lines[lines.length - 1] === '') lines.pop();
+    if (!lines.length) return;
     const { entries: added, inTraceback } = classifyLines(
       lines,
       tracebackRef.current

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -1,0 +1,653 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  Anchor,
+  Box,
+  Button,
+  Group,
+  Loader,
+  Paper,
+  Select,
+  Text,
+  TextInput,
+  Title,
+} from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import API from '../api';
+import useBrowserStorage from '../hooks/useBrowserStorage';
+
+const COLORS = {
+  error: '#ff6b6b',
+  warn: '#ffd43b',
+  stamp: '#a1a1aa',
+  module: '#8bc4eb',
+  level: '#e4e4e7',
+};
+
+// Captures the separator so an absent one is not re-invented; [\s\S] because JS '.' excludes the \r real messages carry.
+const RECORD_TOKENS =
+  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?: [+-]\d{4})?) (\S+) (\S+)( ?)([\s\S]*)$/;
+
+const LEVEL_RANK = {
+  TRACE: 10,
+  DEBUG: 10,
+  INFO: 20,
+  WARNING: 30,
+  ERROR: 40,
+  CRITICAL: 50,
+};
+
+const FIRST_PARTY = new Set([
+  'core',
+  'dispatcharr',
+  'live_proxy',
+  'vod_proxy',
+  'proxy',
+]);
+
+// Anything that is neither Dispatcharr's own code nor a plugin is Services, which keeps the category vocabulary closed.
+const parseSource = (source) => {
+  if (source.startsWith('apps.')) {
+    const module = source.split('.')[1] || source;
+    // apps.plugins is the plugin system itself, renamed so a plugins token always means third-party code.
+    if (module === 'plugins') return { module: 'plugin_sys', tier: 'plugins' };
+    return { module, tier: 'app' };
+  }
+  if (source.startsWith('plugins.'))
+    return { module: source.split('.')[1] || source, tier: 'plugins' };
+  // Disk-loaded plugins import as _dispatcharr_plugin_<key>.
+  if (source.startsWith('_dispatcharr_plugin_')) {
+    const head = source.split('.')[0];
+    return { module: head.slice(20) || head, tier: 'plugins' };
+  }
+  // First-party DB pool code logs under a django namespace.
+  if (source.startsWith('django.geventpool'))
+    return { module: 'geventpool', tier: 'app' };
+  const head = source.split('.')[0] || source;
+  return { module: head, tier: FIRST_PARTY.has(head) ? 'app' : 'services' };
+};
+
+const STAMP_OFFSET = /^(.*) ([+-])(\d{2})(\d{2})$/;
+
+const displayStamp = (stamp) => {
+  const m = STAMP_OFFSET.exec(stamp);
+  if (!m) return stamp;
+  const minutes = m[4] === '00' ? '' : `:${m[4]}`;
+  return `${m[1]} [UTC${m[2]}${Number(m[3])}${minutes}]`;
+};
+
+const parseRecord = (line) => {
+  const m = RECORD_TOKENS.exec(line);
+  if (!m) return null;
+  const { module, tier } = parseSource(m[3]);
+  return {
+    stamp: displayStamp(m[1]),
+    level: m[2],
+    source: m[3],
+    module,
+    tier,
+    sep: m[4],
+    message: m[5],
+  };
+};
+
+const levelLabel = (level) => {
+  if (level === 'CRITICAL') return 'ERROR';
+  if (level === 'WARNING') return 'WARN';
+  if (level === 'TRACE') return 'DEBUG';
+  return level;
+};
+
+const severityColor = (level) => {
+  if (level === 'ERROR' || level === 'CRITICAL') return COLORS.error;
+  if (level === 'WARNING') return COLORS.warn;
+  return null;
+};
+
+const levelColor = (level) => {
+  if (level === 'DEBUG' || level === 'TRACE') return COLORS.stamp;
+  return severityColor(level) || COLORS.level;
+};
+
+// The bar marks what rises above the floor: at a Warning floor every row would wear one and stop meaning anything.
+const barColor = (level, minRank) => {
+  const color = severityColor(level);
+  if (!color) return 'transparent';
+  // CRITICAL displays as ERROR, so it answers to ERROR's floor.
+  const rank = level === 'CRITICAL' ? LEVEL_RANK.ERROR : LEVEL_RANK[level];
+  return rank > minRank ? color : 'transparent';
+};
+
+// Sources the collector assigns when a line carries no level of its own.
+const INVENTED_LEVEL = new Set([
+  'stdout',
+  'entrypoint',
+  'uwsgi',
+  'nginx.access',
+]);
+
+const RECORD_START =
+  /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?: [+-]\d{4})? /;
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+// Bounds the DOM for low-end TV browsers.
+const MAX_RENDER_LINES = 5000;
+
+const LEVEL_COL_MAX = 12;
+const MODULE_COL_MAX = 12;
+
+const REFRESH_OPTIONS = [
+  { value: '0', label: 'Manual' },
+  { value: '5', label: '5s' },
+  { value: '10', label: '10s' },
+  { value: '30', label: '30s' },
+  { value: '60', label: '1m' },
+];
+
+const CATEGORY_OPTIONS = [
+  { value: 'all', label: 'All categories' },
+  { value: 'app', label: 'App' },
+  { value: 'plugins', label: 'Plugins' },
+  { value: 'services', label: 'Services' },
+];
+
+const LEVEL_OPTIONS = [
+  { value: '10', label: 'Debug' },
+  { value: '20', label: 'Info' },
+  { value: '30', label: 'Warning' },
+  { value: '40', label: 'Error' },
+];
+
+// Mirrors the collector's continuation rules: an open traceback claims its tail, indented and blank lines join the record above, and any other column-0 line stands alone.
+const TRACEBACK_HEAD = 'Traceback';
+
+const classifyLines = (lines) => {
+  const entries = [];
+  let inTraceback = false;
+  for (const line of lines) {
+    const record = parseRecord(line);
+    if (record) {
+      // The collector stamps an unstamped traceback header but leaves its tail at column 0.
+      inTraceback = record.message.startsWith(TRACEBACK_HEAD);
+      entries.push({ line, record, kind: 'record' });
+    } else if (RECORD_START.test(line)) {
+      inTraceback = false;
+      entries.push({ line, record: null, kind: 'standalone' });
+    } else if (line.startsWith(TRACEBACK_HEAD)) {
+      inTraceback = true;
+      entries.push({ line, record: null, kind: 'continuation' });
+    } else if (inTraceback || /^[ \t]/.test(line) || line === '') {
+      entries.push({ line, record: null, kind: 'continuation' });
+    } else {
+      entries.push({ line, record: null, kind: 'standalone' });
+    }
+  }
+  return entries;
+};
+
+const groupEntries = (entries) => {
+  const groups = [];
+  for (const entry of entries) {
+    if (entry.kind !== 'continuation' || !groups.length) {
+      groups.push([entry]);
+    } else {
+      groups[groups.length - 1].push(entry);
+    }
+  }
+  return groups;
+};
+
+const filterEntries = (entries, minRank, category, query) => {
+  const out = [];
+  for (const group of groupEntries(entries)) {
+    const record = group[0].record;
+    if (record) {
+      // An invented level is the collector's, not the producer's: gating on it would hide the tail of a traceback the floor kept.
+      const rank = INVENTED_LEVEL.has(record.source)
+        ? undefined
+        : LEVEL_RANK[record.level];
+      if (rank !== undefined && rank < minRank) continue;
+      if (category !== null && record.tier !== category) continue;
+    }
+    if (query && !group.some((e) => e.line.toLowerCase().includes(query)))
+      continue;
+    out.push(...group);
+  }
+  return out;
+};
+
+const renderContinuations = (lines) => {
+  const out = [];
+  let run = [];
+  let blank = null;
+  const flush = () => {
+    if (!run.length) return;
+    // join() alone loses a lone blank line: React renders no text node for '', and the byte leaves the DOM and the copy buffer with it.
+    const text = run.join('\n') + (blank ? '\n' : '');
+    out.push(
+      <div key={out.length} style={blank ? { lineHeight: 0.35 } : undefined}>
+        {text}
+      </div>
+    );
+    run = [];
+  };
+  for (const line of lines) {
+    const isBlank = line.trim() === '';
+    if (blank !== null && isBlank !== blank) flush();
+    blank = isBlank;
+    run.push(line);
+  }
+  flush();
+  return out;
+};
+
+// whiteSpace and textIndent inherit from the hanging block, so every column cell has to reset them.
+const columnStyle = (width) => ({
+  display: 'inline-block',
+  width: `${width}ch`,
+  whiteSpace: 'nowrap',
+  textIndent: '0px',
+  verticalAlign: 'bottom',
+});
+
+const emptyState = (message) => (
+  <Text size="sm" c="dimmed" ta="center" py="md">
+    {message}
+  </Text>
+);
+
+const buildBlocks = (entries) => {
+  const blocks = [];
+  for (const entry of entries) {
+    const last = blocks[blocks.length - 1];
+    if (entry.record) {
+      blocks.push({ record: entry.record, continuations: [] });
+    } else if (entry.kind === 'continuation' && last) {
+      if (last.record) last.continuations.push(entry.line);
+      else last.lines.push(entry.line);
+    } else {
+      blocks.push({ lines: [entry.line] });
+    }
+  }
+  return blocks;
+};
+
+const LogFileViewPage = () => {
+  const { name } = useParams();
+  const [content, setContent] = useState('');
+  const [truncated, setTruncated] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [refreshSetting, setRefreshSetting] = useBrowserStorage(
+    'log-viewer-refresh-interval',
+    0
+  );
+  // A stored value outside the options would render an empty select.
+  const refreshSeconds = REFRESH_OPTIONS.some(
+    (option) => option.value === String(refreshSetting)
+  )
+    ? refreshSetting
+    : 0;
+  const [newestFirst, setNewestFirst] = useBrowserStorage(
+    'log-viewer-newest-first',
+    false
+  );
+  const [minLevelSetting, setMinLevelSetting] = useBrowserStorage(
+    'log-viewer-min-level',
+    20
+  );
+  const minLevel = LEVEL_OPTIONS.some(
+    (option) => option.value === String(minLevelSetting)
+  )
+    ? Number(minLevelSetting)
+    : 20;
+  const [categorySetting, setCategorySetting] = useBrowserStorage(
+    'log-viewer-category',
+    'all'
+  );
+  const category =
+    categorySetting !== 'all' &&
+    CATEGORY_OPTIONS.some((option) => option.value === categorySetting)
+      ? categorySetting
+      : null;
+  // Ephemeral by design: searches are moments, not settings.
+  const [search, setSearch] = useState('');
+  // The box keeps up with typing; the filter waits for a pause, or every keystroke re-filters the whole file.
+  const [query, setQuery] = useState('');
+  useEffect(() => {
+    const id = setTimeout(
+      () => setQuery(search.trim().toLowerCase()),
+      SEARCH_DEBOUNCE_MS
+    );
+    return () => clearTimeout(id);
+  }, [search]);
+  const [loadError, setLoadError] = useState(false);
+
+  const loadingRef = useRef(false);
+  const failuresRef = useRef(0);
+
+  const entries = useMemo(
+    () => classifyLines(content ? content.split('\n') : []),
+    [content]
+  );
+
+  // Widths come from every record, not the visible ones: tracking the filtered set would slide the message column on each keystroke.
+  const cols = useMemo(() => {
+    let stamp = 0;
+    let level = 0;
+    let module = 0;
+    for (const entry of entries) {
+      if (!entry.record) continue;
+      stamp = Math.max(stamp, entry.record.stamp.length);
+      level = Math.max(level, levelLabel(entry.record.level).length);
+      module = Math.max(module, entry.record.module.length);
+    }
+    return {
+      stamp,
+      // Floored at ERROR's display width so the column stays put while tailing.
+      level: Math.min(Math.max(level, 5), LEVEL_COL_MAX),
+      module: Math.min(module, MODULE_COL_MAX),
+    };
+  }, [entries]);
+
+  const { blocks, hiddenLines } = useMemo(() => {
+    let kept = entries;
+    if (minLevel || category !== null || query)
+      kept = filterEntries(entries, minLevel, category, query);
+    const hidden = Math.max(0, kept.length - MAX_RENDER_LINES);
+    if (hidden) kept = kept.slice(hidden);
+    // Reversed as blocks, not entries: reversing entries first would strand an ownerless continuation run against an unrelated record.
+    const built = buildBlocks(kept);
+    if (newestFirst) built.reverse();
+    return { blocks: built, hiddenLines: hidden };
+  }, [entries, newestFirst, minLevel, category, query]);
+
+  // Wrapped lines and continuations both hang under the message column.
+  const messageIndent = cols.stamp + cols.level + cols.module + 3;
+
+  const notice =
+    hiddenLines > 0
+      ? `Showing the last ${MAX_RENDER_LINES.toLocaleString()} lines`
+      : truncated
+        ? 'Large file — showing the last 5 MB'
+        : null;
+
+  const load = useCallback(
+    async (showLoading = true, { silent = false } = {}) => {
+      loadingRef.current = true;
+      if (showLoading) setLoading(true);
+      try {
+        const response = await API.getLogFile(name, { silent });
+        if (response) {
+          setContent(response.content);
+          setTruncated(response.truncated);
+          if (!silent) setLoadError(false);
+          return true;
+        }
+        // Silent polls resolve to undefined on failure (no toast, no throw).
+        if (!silent) setLoadError(true);
+        return false;
+      } catch {
+        // getLogFile has already toasted.
+        if (!silent) setLoadError(true);
+        return false;
+      } finally {
+        loadingRef.current = false;
+        if (showLoading) setLoading(false);
+      }
+    },
+    [name]
+  );
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!refreshSeconds) return undefined;
+    failuresRef.current = 0;
+    const id = setInterval(async () => {
+      if (document.hidden || loadingRef.current) return;
+      const ok = await load(false, { silent: true });
+      if (ok) {
+        failuresRef.current = 0;
+      } else {
+        failuresRef.current += 1;
+        if (failuresRef.current >= 3) {
+          setRefreshSetting(0);
+          notifications.show({
+            title: 'Auto-refresh paused',
+            message:
+              'Stopped auto-refresh after repeated errors loading the log.',
+            color: 'yellow',
+            autoClose: 6000,
+          });
+        }
+      }
+    }, refreshSeconds * 1000);
+    return () => clearInterval(id);
+  }, [refreshSeconds, setRefreshSetting, load]);
+
+  return (
+    <Box p="md">
+      <Paper
+        withBorder
+        radius="md"
+        p={0}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: 'calc(100vh - var(--mantine-spacing-md) * 2)',
+        }}
+      >
+        <Box
+          style={{
+            flex: '0 0 auto',
+            borderBottom: '1px solid var(--mantine-color-default-border)',
+            padding: 'var(--mantine-spacing-sm)',
+          }}
+        >
+          <Group justify="space-between">
+            <Group gap="sm">
+              <Anchor component={Link} to="/logs" size="sm">
+                ← Logs
+              </Anchor>
+              <Title order={4}>{name}</Title>
+            </Group>
+            <Group gap="sm">
+              {notice && (
+                <Text size="sm" c="yellow">
+                  {notice}
+                </Text>
+              )}
+              <TextInput
+                size="xs"
+                label="Search"
+                placeholder="Filter text"
+                value={search}
+                onChange={(event) => setSearch(event.currentTarget.value)}
+                style={{ width: 240 }}
+              />
+              <Select
+                size="xs"
+                label="Level"
+                value={String(minLevel)}
+                onChange={(value) => setMinLevelSetting(parseInt(value))}
+                allowDeselect={false}
+                data={LEVEL_OPTIONS}
+                style={{ width: 110 }}
+              />
+              <Select
+                size="xs"
+                label="Category"
+                value={category === null ? 'all' : category}
+                onChange={(value) => setCategorySetting(value)}
+                allowDeselect={false}
+                data={CATEGORY_OPTIONS}
+                style={{ width: 130 }}
+              />
+              <Select
+                size="xs"
+                label="Order"
+                value={newestFirst ? 'newest' : 'oldest'}
+                onChange={(value) => setNewestFirst(value === 'newest')}
+                allowDeselect={false}
+                data={[
+                  { value: 'newest', label: 'Newest first' },
+                  { value: 'oldest', label: 'Newest last' },
+                ]}
+                style={{ width: 130 }}
+              />
+              <Select
+                size="xs"
+                label="Auto Refresh"
+                value={refreshSeconds.toString()}
+                onChange={(value) => setRefreshSetting(parseInt(value))}
+                allowDeselect={false}
+                data={REFRESH_OPTIONS}
+                style={{ width: 120 }}
+              />
+              <Button
+                size="xs"
+                variant="subtle"
+                onClick={() => load()}
+                loading={loading}
+                style={{ marginTop: 'auto' }}
+              >
+                Refresh
+              </Button>
+              <Button
+                size="xs"
+                variant="subtle"
+                onClick={() => API.downloadLogFile(name)}
+                style={{ marginTop: 'auto' }}
+              >
+                Download
+              </Button>
+            </Group>
+          </Group>
+        </Box>
+
+        <Box
+          p="sm"
+          // Without minHeight:0 a flex item refuses to shrink below its content and the panel grows instead of scrolling.
+          style={{ flex: '1 1 auto', overflow: 'auto', minHeight: '0px' }}
+        >
+          {loading && !content ? (
+            <Loader />
+          ) : !content && loadError ? (
+            <Group gap="sm">
+              <Text size="sm" c="red">
+                Failed to load {name}
+              </Text>
+              <Button size="xs" variant="subtle" onClick={() => load()}>
+                Retry
+              </Button>
+            </Group>
+          ) : (
+            <div
+              style={{
+                margin: 0,
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                fontSize: 12,
+                lineHeight: 1.45,
+                // anywhere breaks the unbroken tokens (URLs, SQL dumps) that no space would ever break.
+                whiteSpace: 'pre-wrap',
+                overflowWrap: 'anywhere',
+              }}
+            >
+              {!content
+                ? emptyState('(empty)')
+                : blocks.length
+                  ? blocks.map((block, i) => {
+                      if (!block.record) {
+                        return (
+                          <div
+                            key={i}
+                            // Dimming stops a run of unowned lines reading as the tail of the record above.
+                            style={{
+                              borderLeft: '2px solid transparent',
+                              paddingLeft: 8,
+                              color: COLORS.stamp,
+                            }}
+                          >
+                            {block.lines.join('\n')}
+                          </div>
+                        );
+                      }
+                      const mc = severityColor(block.record.level);
+                      const bc = barColor(block.record.level, minLevel);
+                      return (
+                        <div
+                          key={i}
+                          style={{
+                            borderLeft: `2px solid ${bc}`,
+                            paddingLeft: `calc(8px + ${messageIndent}ch)`,
+                            textIndent: `-${messageIndent}ch`,
+                          }}
+                        >
+                          <span
+                            style={{
+                              ...columnStyle(cols.stamp),
+                              color: COLORS.stamp,
+                            }}
+                          >
+                            {block.record.stamp}
+                          </span>{' '}
+                          <span
+                            style={{
+                              ...columnStyle(cols.level),
+                              color: levelColor(block.record.level),
+                              fontWeight: 500,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                            }}
+                            title={block.record.level}
+                          >
+                            {levelLabel(block.record.level)}
+                          </span>{' '}
+                          <span
+                            style={{
+                              ...columnStyle(cols.module),
+                              color: COLORS.module,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                            }}
+                            title={block.record.source}
+                          >
+                            {block.record.module}
+                          </span>
+                          {block.record.sep}
+                          <span style={mc ? { color: mc } : undefined}>
+                            {block.record.message}
+                          </span>
+                          {block.continuations.length > 0 && (
+                            <div
+                              style={{
+                                textIndent: '0px',
+                                color: mc || undefined,
+                              }}
+                            >
+                              {renderContinuations(block.continuations)}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })
+                  : emptyState('(no records match the filters)')}
+            </div>
+          )}
+        </Box>
+      </Paper>
+    </Box>
+  );
+};
+
+export default LogFileViewPage;

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -133,6 +133,12 @@ const SEARCH_DEBOUNCE_MS = 200;
 // Bounds the DOM for low-end TV browsers.
 const MAX_RENDER_LINES = 5000;
 
+// Two bounds on the appended buffer, because they cap different resources:
+// bytes hold the retained text to what one tail used to be, lines hold the
+// per-entry object overhead a flood of very short lines would other run up.
+const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
+const MAX_BUFFER_LINES = 50000;
+
 // How close to the live edge still counts as watching it.
 const FOLLOW_SLACK_PX = 50;
 
@@ -164,9 +170,10 @@ const LEVEL_OPTIONS = [
 // Mirrors the collector's continuation rules.
 const TRACEBACK_HEAD = 'Traceback';
 
-const classifyLines = (lines) => {
+// Returns the trailing traceback state so the next chunk can resume in it: a
+// traceback split across two polls would otherwise lose its unindented tail.
+const classifyLines = (lines, inTraceback = false) => {
   const entries = [];
-  let inTraceback = false;
   for (const line of lines) {
     const record = parseRecord(line);
     if (record) {
@@ -185,7 +192,7 @@ const classifyLines = (lines) => {
       entries.push({ line, record: null, kind: 'standalone' });
     }
   }
-  return entries;
+  return { entries, inTraceback };
 };
 
 const groupEntries = (entries) => {
@@ -250,6 +257,25 @@ const columnStyle = (width) => ({
   verticalAlign: 'bottom',
 });
 
+const byteLength = (entries) => {
+  let bytes = 0;
+  for (const entry of entries) bytes += entry.line.length + 1;
+  return bytes;
+};
+
+// Drops from the head until both bounds hold, paying only for what it drops.
+const trimBuffer = (entries, bytes) => {
+  let drop = 0;
+  while (
+    drop < entries.length &&
+    (bytes > MAX_BUFFER_BYTES || entries.length - drop > MAX_BUFFER_LINES)
+  ) {
+    bytes -= entries[drop].line.length + 1;
+    drop += 1;
+  }
+  return drop ? { entries: entries.slice(drop), bytes } : { entries, bytes };
+};
+
 const emptyState = (message) => (
   <Text size="sm" c="dimmed" ta="center" py="md">
     {message}
@@ -274,7 +300,9 @@ const buildBlocks = (entries) => {
 
 const LogFileViewPage = () => {
   const { name } = useParams();
-  const [content, setContent] = useState('');
+  // The byte total rides with the entries so trimming never rescans them.
+  const [buffer, setBuffer] = useState({ entries: [], bytes: 0 });
+  const entries = buffer.entries;
   const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [refreshSetting, setRefreshSetting] = useBrowserStorage(
@@ -326,14 +354,15 @@ const LogFileViewPage = () => {
 
   const loadingRef = useRef(false);
   const failuresRef = useRef(0);
+  const cursorRef = useRef(null);
+  // Two loads can overlap (a click during a poll) carrying the same cursor,
+  // and the same delta would append twice. Only the newest may land.
+  const requestRef = useRef(0);
+  // classifyLines resumes from here so a split traceback keeps its tail.
+  const tracebackRef = useRef(false);
   const viewportRef = useRef(null);
   // Open at the live edge, and keep following until the reader scrolls away.
   const followingRef = useRef(true);
-
-  const entries = useMemo(
-    () => classifyLines(content ? content.split('\n') : []),
-    [content]
-  );
 
   // Widths come from every record; the filtered set would shift on each keystroke.
   const cols = useMemo(() => {
@@ -393,15 +422,49 @@ const LogFileViewPage = () => {
         ? 'Large file — showing the last 5 MB'
         : null;
 
+  // Only new bytes arrive once a cursor is held, so classify only those and
+  // append. A reset (rotation, first load, or a backend without the headers)
+  // replaces the buffer instead.
+  const applyResponse = useCallback((response) => {
+    cursorRef.current = response.cursor || null;
+    // Absent on an older backend: replace rather than append to a stale buffer.
+    if (response.reset !== false) {
+      const lines = response.content ? response.content.split('\n') : [];
+      const { entries: next, inTraceback } = classifyLines(lines);
+      tracebackRef.current = inTraceback;
+      setTruncated(response.truncated);
+      setBuffer({ entries: next, bytes: byteLength(next) });
+      return;
+    }
+    if (!response.content) return;
+    // The delta ends on a newline, so the split leaves a trailing empty line.
+    const lines = response.content.split('\n');
+    if (lines[lines.length - 1] === '') lines.pop();
+    const { entries: added, inTraceback } = classifyLines(
+      lines,
+      tracebackRef.current
+    );
+    tracebackRef.current = inTraceback;
+    setBuffer((prev) =>
+      trimBuffer(prev.entries.concat(added), prev.bytes + byteLength(added))
+    );
+  }, []);
+
   const load = useCallback(
     async (showLoading = true, { silent = false } = {}) => {
       loadingRef.current = true;
+      const version = (requestRef.current += 1);
       if (showLoading) setLoading(true);
       try {
-        const response = await API.getLogFile(name, { silent });
+        const response = await API.getLogFile(name, {
+          silent,
+          cursor: cursorRef.current,
+        });
+        // Superseded: a newer load owns the cursor, and applying this one
+        // would append a delta the newer response already carried.
+        if (version !== requestRef.current) return true;
         if (response) {
-          setContent(response.content);
-          setTruncated(response.truncated);
+          applyResponse(response);
           if (!silent) setLoadError(false);
           return true;
         }
@@ -417,10 +480,15 @@ const LogFileViewPage = () => {
         if (showLoading) setLoading(false);
       }
     },
-    [name]
+    [name, applyResponse]
   );
 
   useEffect(() => {
+    // A different file shares no offsets with the last one, and any response
+    // still in flight for the previous one must not land in this buffer.
+    requestRef.current += 1;
+    cursorRef.current = null;
+    tracebackRef.current = false;
     load();
   }, [load]);
 
@@ -564,9 +632,9 @@ const LogFileViewPage = () => {
           // Without minHeight:0 a flex item will not shrink below its content.
           style={{ flex: '1 1 auto', overflow: 'auto', minHeight: '0px' }}
         >
-          {loading && !content ? (
+          {loading && !entries.length ? (
             <Loader />
-          ) : !content && loadError ? (
+          ) : !entries.length && loadError ? (
             <Group gap="sm">
               <Text size="sm" c="red">
                 Failed to load {name}
@@ -588,7 +656,7 @@ const LogFileViewPage = () => {
                 overflowWrap: 'anywhere',
               }}
             >
-              {!content
+              {!entries.length
                 ? emptyState('(empty)')
                 : blocks.length
                   ? blocks.map((block, i) => {

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -34,7 +34,7 @@ const COLORS = {
   level: '#e4e4e7',
 };
 
-// Captures the separator so it is not re-invented; [\s\S] because '.' drops \r.
+// [\s\S] because '.' drops \r.
 const RECORD_TOKENS =
   /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?: [+-]\d{4})?) ([A-Z]+) (\S+)( ?)([\s\S]*)$/;
 
@@ -134,9 +134,7 @@ const SEARCH_DEBOUNCE_MS = 200;
 // Bounds the DOM for low-end TV browsers.
 const MAX_RENDER_LINES = 5000;
 
-// Two bounds on the appended buffer, because they cap different resources:
-// bytes hold the retained text to what one tail used to be, lines hold the
-// per-entry object overhead a flood of very short lines would other run up.
+// Bytes bound the retained text; lines bound the per-entry overhead.
 const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 const MAX_BUFFER_LINES = 50000;
 const EMPTY_BUFFER = { entries: [], bytes: 0, truncated: false };
@@ -164,11 +162,10 @@ const LEVEL_OPTIONS = [
 // Mirrors the collector's continuation rules.
 const TRACEBACK_HEAD = 'Traceback';
 
-// Returns the trailing traceback state so the next chunk can resume in it: a
-// traceback split across two polls would otherwise lose its unindented tail.
 // Ids survive the head slice and the reversal, so React inserts only new rows.
 let nextEntryId = 0;
 
+// Returns the traceback state so the next chunk can resume inside a split one.
 const classifyLines = (lines, inTraceback = false) => {
   const entries = [];
   for (const line of lines) {
@@ -190,13 +187,9 @@ const classifyLines = (lines, inTraceback = false) => {
   return { entries, inTraceback };
 };
 
-// Matching on a case-insensitive regex, not a lowercased copy per line: the
-// copies would double the retained text in memory for no extra speed.
 const escapeRegExp = (text) => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 // A record and the continuations trailing it are kept or dropped together.
-// Walked in place rather than grouped into arrays first: the groups were one
-// short-lived array per record, which is the bulk of a filter pass's garbage.
 const filterEntries = (entries, minRank, category, matcher) => {
   const out = [];
   let start = 0;
@@ -449,7 +442,6 @@ const LogFileViewPage = () => {
     CATEGORY_OPTIONS.some((option) => option.value === categorySetting)
       ? categorySetting
       : null;
-  // Ephemeral by design: searches are moments, not settings.
   const [search, setSearch] = useState('');
   // The box keeps up with typing; the filter waits for a pause.
   const query = useDebounce(search.trim(), SEARCH_DEBOUNCE_MS);
@@ -462,8 +454,7 @@ const LogFileViewPage = () => {
   const loadingRef = useRef(false);
   const failuresRef = useRef(0);
   const cursorRef = useRef(null);
-  // Two loads can overlap (a click during a poll) carrying the same cursor,
-  // and the same delta would append twice. Only the newest may land.
+  // Overlapping loads carry the same cursor; only the newest may land.
   const requestRef = useRef(0);
   // classifyLines resumes from here so a split traceback keeps its tail.
   const tracebackRef = useRef(false);
@@ -509,8 +500,7 @@ const LogFileViewPage = () => {
       : el.scrollHeight - el.scrollTop - el.clientHeight <= FOLLOW_SLACK_PX;
   }, [newestFirst]);
 
-  // A refresh replaces the content wholesale, so a fixed scrollTop drifts back
-  // through history. Re-pin to the live edge for a reader who was watching it.
+  // Re-pin to the live edge for a reader who was watching it.
   useLayoutEffect(() => {
     const el = viewportRef.current;
     if (!el || !followingRef.current) return;
@@ -534,8 +524,7 @@ const LogFileViewPage = () => {
         ? 'Large file — showing the last 5 MB'
         : null;
 
-  // Only new bytes arrive once a cursor is held, so classify only those and
-  // append. A reset (rotation or first load) replaces the buffer instead.
+  // A reset replaces the buffer; a delta is classified alone and appended.
   const applyResponse = useCallback((response) => {
     cursorRef.current = response.cursor || null;
     const lines = response.content ? response.content.split('\n') : [];
@@ -572,8 +561,7 @@ const LogFileViewPage = () => {
           silent,
           cursor: cursorRef.current,
         });
-        // Superseded: a newer load owns the cursor, and applying this one
-        // would append a delta the newer response already carried.
+        // Superseded by a newer load that already carried this delta.
         if (version !== requestRef.current) return true;
         // Silent polls resolve to undefined on failure.
         if (!response) return false;
@@ -593,8 +581,7 @@ const LogFileViewPage = () => {
   );
 
   useEffect(() => {
-    // A different file shares no offsets with the last one, and any response
-    // still in flight for the previous one must not land in this buffer.
+    // Offsets belong to one file, and a stale in-flight response must not land here.
     requestRef.current += 1;
     cursorRef.current = null;
     tracebackRef.current = false;

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -177,8 +177,7 @@ const classifyLines = (lines, inTraceback = false) => {
   for (const line of lines) {
     const record = parseRecord(line);
     if (record) {
-      // The collector stamps a traceback header but not its tail.
-      inTraceback = record.message.startsWith(TRACEBACK_HEAD);
+      inTraceback = false;
       entries.push({ line, record, kind: 'record' });
     } else if (RECORD_START.test(line)) {
       inTraceback = false;
@@ -456,9 +455,7 @@ const LogFileViewPage = () => {
   }, [entries]);
 
   const { blocks, hiddenLines } = useMemo(() => {
-    let kept = entries;
-    if (minLevel || category !== null || matcher)
-      kept = filterEntries(entries, minLevel, category, matcher);
+    let kept = filterEntries(entries, minLevel, category, matcher);
     const hidden = Math.max(0, kept.length - MAX_RENDER_LINES);
     if (hidden) kept = kept.slice(hidden);
     // Reversed as blocks, not entries, so continuations stay with their record.
@@ -581,14 +578,11 @@ const LogFileViewPage = () => {
         // Superseded: a newer load owns the cursor, and applying this one
         // would append a delta the newer response already carried.
         if (version !== requestRef.current) return true;
-        if (response) {
-          applyResponse(response);
-          if (!silent) setLoadError(false);
-          return true;
-        }
         // Silent polls resolve to undefined on failure.
-        if (!silent) setLoadError(true);
-        return false;
+        if (!response) return false;
+        applyResponse(response);
+        if (!silent) setLoadError(false);
+        return true;
       } catch {
         // getLogFile has already toasted.
         if (!silent) setLoadError(true);

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -22,6 +22,7 @@ import {
 import { notifications } from '@mantine/notifications';
 import API from '../api';
 import DownloadLogButton from '../components/DownloadLogButton';
+import { REFRESH_INTERVAL_OPTIONS } from '../constants';
 import useBrowserStorage from '../hooks/useBrowserStorage';
 import { useDebounce } from '../utils';
 
@@ -145,14 +146,6 @@ const FOLLOW_SLACK_PX = 50;
 
 const LEVEL_COL_MAX = 12;
 const MODULE_COL_MAX = 12;
-
-const REFRESH_OPTIONS = [
-  { value: '0', label: 'Manual' },
-  { value: '5', label: '5s' },
-  { value: '10', label: '10s' },
-  { value: '30', label: '30s' },
-  { value: '60', label: '1m' },
-];
 
 const CATEGORY_OPTIONS = [
   { value: 'all', label: 'All categories' },
@@ -428,7 +421,7 @@ const LogFileViewPage = () => {
     0
   );
   // A stored value outside the options would render an empty select.
-  const refreshSeconds = REFRESH_OPTIONS.some(
+  const refreshSeconds = REFRESH_INTERVAL_OPTIONS.some(
     (option) => option.value === String(refreshSetting)
   )
     ? refreshSetting
@@ -714,7 +707,7 @@ const LogFileViewPage = () => {
                   setRefreshSetting(parseInt(value));
                 }}
                 allowDeselect={false}
-                data={REFRESH_OPTIONS}
+                data={REFRESH_INTERVAL_OPTIONS}
                 style={{ width: 120 }}
               />
               <Button

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -387,6 +387,7 @@ const LogFileViewPage = () => {
   )
     ? refreshSetting
     : 0;
+  const [paused, setPaused] = useState(false);
   const [newestFirst, setNewestFirst] = useBrowserStorage(
     'log-viewer-newest-first',
     false
@@ -612,7 +613,7 @@ const LogFileViewPage = () => {
   }, [load]);
 
   useEffect(() => {
-    if (!refreshSeconds) return undefined;
+    if (!refreshSeconds || paused) return undefined;
     failuresRef.current = 0;
     const id = setInterval(async () => {
       if (document.hidden || loadingRef.current) return;
@@ -622,11 +623,11 @@ const LogFileViewPage = () => {
       } else {
         failuresRef.current += 1;
         if (failuresRef.current >= 3) {
-          setRefreshSetting(0);
+          setPaused(true);
           notifications.show({
             title: 'Auto-refresh paused',
             message:
-              'Stopped auto-refresh after repeated errors loading the log.',
+              'Paused auto-refresh after repeated errors loading the log.',
             color: 'yellow',
             autoClose: 6000,
           });
@@ -634,7 +635,7 @@ const LogFileViewPage = () => {
       }
     }, refreshSeconds * 1000);
     return () => clearInterval(id);
-  }, [refreshSeconds, setRefreshSetting, load]);
+  }, [refreshSeconds, paused, load]);
 
   return (
     <Box p="md">
@@ -709,8 +710,11 @@ const LogFileViewPage = () => {
               <Select
                 size="xs"
                 label="Auto Refresh"
-                value={refreshSeconds.toString()}
-                onChange={(value) => setRefreshSetting(parseInt(value))}
+                value={paused ? '0' : refreshSeconds.toString()}
+                onChange={(value) => {
+                  setPaused(false);
+                  setRefreshSetting(parseInt(value));
+                }}
                 allowDeselect={false}
                 data={REFRESH_OPTIONS}
                 style={{ width: 120 }}

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -303,6 +303,72 @@ const buildBlocks = (entries) => {
   return blocks;
 };
 
+const LogBody = React.memo(
+  ({ name, blocks, styles, loading, empty, loadError, onRetry }) => {
+    if (loading && empty) return <Loader />;
+    if (empty && loadError) {
+      return (
+        <Group gap="sm">
+          <Text size="sm" c="red">
+            Failed to load {name}
+          </Text>
+          <Button size="xs" variant="subtle" onClick={() => onRetry()}>
+            Retry
+          </Button>
+        </Group>
+      );
+    }
+    return (
+      <div
+        style={{
+          margin: 0,
+          fontFamily:
+            'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+          fontSize: 12,
+          lineHeight: 1.45,
+          // anywhere breaks unbroken tokens like URLs and SQL dumps.
+          whiteSpace: 'pre-wrap',
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {empty
+          ? emptyState('(empty)')
+          : blocks.length
+            ? blocks.map((block, i) => {
+                if (!block.record) {
+                  return (
+                    // Dimming marks these lines as unowned.
+                    <div key={i} style={styles.plain}>
+                      {block.lines.join('\n')}
+                    </div>
+                  );
+                }
+                const rowStyle = styles.forLevel(block.record.level);
+                return (
+                  <div key={i} style={rowStyle.row}>
+                    <span style={styles.stamp}>{block.record.stamp}</span>{' '}
+                    <span style={rowStyle.level} title={block.record.level}>
+                      {levelLabel(block.record.level)}
+                    </span>{' '}
+                    <span style={styles.module} title={block.record.source}>
+                      {block.record.module}
+                    </span>
+                    {block.record.sep}
+                    <span style={rowStyle.message}>{block.record.message}</span>
+                    {block.continuations.length > 0 && (
+                      <div style={rowStyle.continuations}>
+                        {renderContinuations(block.continuations)}
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            : emptyState('(no records match the filters)')}
+      </div>
+    );
+  }
+);
+
 const LogFileViewPage = () => {
   const { name } = useParams();
   // The byte total rides with the entries so trimming never rescans them.
@@ -682,73 +748,15 @@ const LogFileViewPage = () => {
           // Without minHeight:0 a flex item will not shrink below its content.
           style={{ flex: '1 1 auto', overflow: 'auto', minHeight: '0px' }}
         >
-          {loading && !entries.length ? (
-            <Loader />
-          ) : !entries.length && loadError ? (
-            <Group gap="sm">
-              <Text size="sm" c="red">
-                Failed to load {name}
-              </Text>
-              <Button size="xs" variant="subtle" onClick={() => load()}>
-                Retry
-              </Button>
-            </Group>
-          ) : (
-            <div
-              style={{
-                margin: 0,
-                fontFamily:
-                  'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-                fontSize: 12,
-                lineHeight: 1.45,
-                // anywhere breaks unbroken tokens like URLs and SQL dumps.
-                whiteSpace: 'pre-wrap',
-                overflowWrap: 'anywhere',
-              }}
-            >
-              {!entries.length
-                ? emptyState('(empty)')
-                : blocks.length
-                  ? blocks.map((block, i) => {
-                      if (!block.record) {
-                        return (
-                          // Dimming marks these lines as unowned.
-                          <div key={i} style={styles.plain}>
-                            {block.lines.join('\n')}
-                          </div>
-                        );
-                      }
-                      const rowStyle = styles.forLevel(block.record.level);
-                      return (
-                        <div key={i} style={rowStyle.row}>
-                          <span style={styles.stamp}>{block.record.stamp}</span>{' '}
-                          <span
-                            style={rowStyle.level}
-                            title={block.record.level}
-                          >
-                            {levelLabel(block.record.level)}
-                          </span>{' '}
-                          <span
-                            style={styles.module}
-                            title={block.record.source}
-                          >
-                            {block.record.module}
-                          </span>
-                          {block.record.sep}
-                          <span style={rowStyle.message}>
-                            {block.record.message}
-                          </span>
-                          {block.continuations.length > 0 && (
-                            <div style={rowStyle.continuations}>
-                              {renderContinuations(block.continuations)}
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })
-                  : emptyState('(no records match the filters)')}
-            </div>
-          )}
+          <LogBody
+            name={name}
+            blocks={blocks}
+            styles={styles}
+            loading={loading}
+            empty={!entries.length}
+            loadError={loadError}
+            onRetry={load}
+          />
         </Box>
       </Paper>
     </Box>

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -34,7 +34,7 @@ const COLORS = {
 
 // Captures the separator so it is not re-invented; [\s\S] because '.' drops \r.
 const RECORD_TOKENS =
-  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?: [+-]\d{4})?) (\S+) (\S+)( ?)([\s\S]*)$/;
+  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?: [+-]\d{4})?) ([A-Z]+) (\S+)( ?)([\s\S]*)$/;
 
 const LEVEL_RANK = {
   TRACE: 10,

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -172,24 +172,26 @@ const TRACEBACK_HEAD = 'Traceback';
 
 // Returns the trailing traceback state so the next chunk can resume in it: a
 // traceback split across two polls would otherwise lose its unindented tail.
+// Ids survive the head slice and the reversal, so React inserts only new rows.
+let nextEntryId = 0;
+
 const classifyLines = (lines, inTraceback = false) => {
   const entries = [];
   for (const line of lines) {
     const record = parseRecord(line);
+    let kind = 'standalone';
     if (record) {
       inTraceback = false;
-      entries.push({ line, record, kind: 'record' });
+      kind = 'record';
     } else if (RECORD_START.test(line)) {
       inTraceback = false;
-      entries.push({ line, record: null, kind: 'standalone' });
     } else if (line.startsWith(TRACEBACK_HEAD)) {
       inTraceback = true;
-      entries.push({ line, record: null, kind: 'continuation' });
+      kind = 'continuation';
     } else if (inTraceback || /^[ \t]/.test(line) || line === '') {
-      entries.push({ line, record: null, kind: 'continuation' });
-    } else {
-      entries.push({ line, record: null, kind: 'standalone' });
+      kind = 'continuation';
     }
+    entries.push({ id: nextEntryId++, line, record, kind });
   }
   return { entries, inTraceback };
 };
@@ -293,12 +295,12 @@ const buildBlocks = (entries) => {
   for (const entry of entries) {
     const last = blocks[blocks.length - 1];
     if (entry.record) {
-      blocks.push({ record: entry.record, continuations: [] });
+      blocks.push({ id: entry.id, record: entry.record, continuations: [] });
     } else if (entry.kind === 'continuation' && last) {
       if (last.record) last.continuations.push(entry.line);
       else last.lines.push(entry.line);
     } else {
-      blocks.push({ lines: [entry.line] });
+      blocks.push({ id: entry.id, lines: [entry.line] });
     }
   }
   return blocks;
@@ -335,18 +337,18 @@ const LogBody = React.memo(
         {empty
           ? emptyState('(empty)')
           : blocks.length
-            ? blocks.map((block, i) => {
+            ? blocks.map((block) => {
                 if (!block.record) {
                   return (
                     // Dimming marks these lines as unowned.
-                    <div key={i} style={styles.plain}>
+                    <div key={block.id} style={styles.plain}>
                       {block.lines.join('\n')}
                     </div>
                   );
                 }
                 const rowStyle = styles.forLevel(block.record.level);
                 return (
-                  <div key={i} style={rowStyle.row}>
+                  <div key={block.id} style={rowStyle.row}>
                     <span style={styles.stamp}>{block.record.stamp}</span>{' '}
                     <span style={rowStyle.level} title={block.record.level}>
                       {levelLabel(block.record.level)}

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -41,7 +41,7 @@ const LEVEL_RANK = {
   INFO: 20,
   WARNING: 30,
   ERROR: 40,
-  CRITICAL: 50,
+  CRITICAL: 40,
 };
 
 const FIRST_PARTY = new Set([
@@ -120,9 +120,7 @@ const levelColor = (level) => {
 const barColor = (level, minRank) => {
   const color = severityColor(level);
   if (!color) return 'transparent';
-  // CRITICAL displays as ERROR, so it answers to ERROR's floor.
-  const rank = level === 'CRITICAL' ? LEVEL_RANK.ERROR : LEVEL_RANK[level];
-  return rank > minRank ? color : 'transparent';
+  return LEVEL_RANK[level] > minRank ? color : 'transparent';
 };
 
 const RECORD_START =

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -131,6 +132,9 @@ const SEARCH_DEBOUNCE_MS = 200;
 
 // Bounds the DOM for low-end TV browsers.
 const MAX_RENDER_LINES = 5000;
+
+// How close to the live edge still counts as watching it.
+const FOLLOW_SLACK_PX = 50;
 
 const LEVEL_COL_MAX = 12;
 const MODULE_COL_MAX = 12;
@@ -320,6 +324,9 @@ const LogFileViewPage = () => {
 
   const loadingRef = useRef(false);
   const failuresRef = useRef(0);
+  const viewportRef = useRef(null);
+  // Open at the live edge, and keep following until the reader scrolls away.
+  const followingRef = useRef(true);
 
   const entries = useMemo(
     () => classifyLines(content ? content.split('\n') : []),
@@ -356,6 +363,23 @@ const LogFileViewPage = () => {
     if (newestFirst) built.reverse();
     return { blocks: built, hiddenLines: hidden };
   }, [entries, newestFirst, minLevel, category, query]);
+
+  // Newest sits at whichever end the order puts it.
+  const onViewportScroll = useCallback(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    followingRef.current = newestFirst
+      ? el.scrollTop <= FOLLOW_SLACK_PX
+      : el.scrollHeight - el.scrollTop - el.clientHeight <= FOLLOW_SLACK_PX;
+  }, [newestFirst]);
+
+  // A refresh replaces the content wholesale, so a fixed scrollTop drifts back
+  // through history. Re-pin to the live edge for a reader who was watching it.
+  useLayoutEffect(() => {
+    const el = viewportRef.current;
+    if (!el || !followingRef.current) return;
+    el.scrollTop = newestFirst ? 0 : el.scrollHeight;
+  }, [blocks, newestFirst]);
 
   // Wrapped lines and continuations hang under the message column.
   const messageIndent = cols.stamp + cols.level + cols.module + 3;
@@ -525,6 +549,8 @@ const LogFileViewPage = () => {
 
         <Box
           p="sm"
+          ref={viewportRef}
+          onScroll={onViewportScroll}
           // Without minHeight:0 a flex item will not shrink below its content.
           style={{ flex: '1 1 auto', overflow: 'auto', minHeight: '0px' }}
         >

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -124,14 +124,6 @@ const barColor = (level, minRank) => {
   return rank > minRank ? color : 'transparent';
 };
 
-// Sources the collector assigns when a line has no level.
-const INVENTED_LEVEL = new Set([
-  'stdout',
-  'entrypoint',
-  'uwsgi',
-  'nginx.access',
-]);
-
 const RECORD_START =
   /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?: [+-]\d{4})? /;
 
@@ -209,10 +201,7 @@ const filterEntries = (entries, minRank, category, query) => {
   for (const group of groupEntries(entries)) {
     const record = group[0].record;
     if (record) {
-      // An invented level is the collector's own, so the floor must not gate on it.
-      const rank = INVENTED_LEVEL.has(record.source)
-        ? undefined
-        : LEVEL_RANK[record.level];
+      const rank = LEVEL_RANK[record.level];
       if (rank !== undefined && rank < minRank) continue;
       if (category !== null && record.tier !== category) continue;
     }

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -30,7 +30,7 @@ const COLORS = {
   level: '#e4e4e7',
 };
 
-// Captures the separator so an absent one is not re-invented; [\s\S] because JS '.' excludes the \r real messages carry.
+// Captures the separator so it is not re-invented; [\s\S] because '.' drops \r.
 const RECORD_TOKENS =
   /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?: [+-]\d{4})?) (\S+) (\S+)( ?)([\s\S]*)$/;
 
@@ -51,11 +51,11 @@ const FIRST_PARTY = new Set([
   'proxy',
 ]);
 
-// Anything that is neither Dispatcharr's own code nor a plugin is Services, which keeps the category vocabulary closed.
+// Anything neither first-party nor a plugin is Services.
 const parseSource = (source) => {
   if (source.startsWith('apps.')) {
     const module = source.split('.')[1] || source;
-    // apps.plugins is the plugin system itself, renamed so a plugins token always means third-party code.
+    // apps.plugins is the plugin system itself, not a third-party plugin.
     if (module === 'plugins') return { module: 'plugin_sys', tier: 'plugins' };
     return { module, tier: 'app' };
   }
@@ -115,7 +115,7 @@ const levelColor = (level) => {
   return severityColor(level) || COLORS.level;
 };
 
-// The bar marks what rises above the floor: at a Warning floor every row would wear one and stop meaning anything.
+// The bar marks what rises above the floor, not everything severe.
 const barColor = (level, minRank) => {
   const color = severityColor(level);
   if (!color) return 'transparent';
@@ -124,7 +124,7 @@ const barColor = (level, minRank) => {
   return rank > minRank ? color : 'transparent';
 };
 
-// Sources the collector assigns when a line carries no level of its own.
+// Sources the collector assigns when a line has no level.
 const INVENTED_LEVEL = new Set([
   'stdout',
   'entrypoint',
@@ -165,7 +165,7 @@ const LEVEL_OPTIONS = [
   { value: '40', label: 'Error' },
 ];
 
-// Mirrors the collector's continuation rules: an open traceback claims its tail, indented and blank lines join the record above, and any other column-0 line stands alone.
+// Mirrors the collector's continuation rules.
 const TRACEBACK_HEAD = 'Traceback';
 
 const classifyLines = (lines) => {
@@ -174,7 +174,7 @@ const classifyLines = (lines) => {
   for (const line of lines) {
     const record = parseRecord(line);
     if (record) {
-      // The collector stamps an unstamped traceback header but leaves its tail at column 0.
+      // The collector stamps a traceback header but not its tail.
       inTraceback = record.message.startsWith(TRACEBACK_HEAD);
       entries.push({ line, record, kind: 'record' });
     } else if (RECORD_START.test(line)) {
@@ -209,7 +209,7 @@ const filterEntries = (entries, minRank, category, query) => {
   for (const group of groupEntries(entries)) {
     const record = group[0].record;
     if (record) {
-      // An invented level is the collector's, not the producer's: gating on it would hide the tail of a traceback the floor kept.
+      // An invented level is the collector's own, so the floor must not gate on it.
       const rank = INVENTED_LEVEL.has(record.source)
         ? undefined
         : LEVEL_RANK[record.level];
@@ -229,7 +229,7 @@ const renderContinuations = (lines) => {
   let blank = null;
   const flush = () => {
     if (!run.length) return;
-    // join() alone loses a lone blank line: React renders no text node for '', and the byte leaves the DOM and the copy buffer with it.
+    // React renders no text node for '', so a lone blank line needs its own '\n'.
     const text = run.join('\n') + (blank ? '\n' : '');
     out.push(
       <div key={out.length} style={blank ? { lineHeight: 0.35 } : undefined}>
@@ -248,7 +248,7 @@ const renderContinuations = (lines) => {
   return out;
 };
 
-// whiteSpace and textIndent inherit from the hanging block, so every column cell has to reset them.
+// whiteSpace and textIndent inherit from the hanging block; reset them here.
 const columnStyle = (width) => ({
   display: 'inline-block',
   width: `${width}ch`,
@@ -318,7 +318,7 @@ const LogFileViewPage = () => {
       : null;
   // Ephemeral by design: searches are moments, not settings.
   const [search, setSearch] = useState('');
-  // The box keeps up with typing; the filter waits for a pause, or every keystroke re-filters the whole file.
+  // The box keeps up with typing; the filter waits for a pause.
   const [query, setQuery] = useState('');
   useEffect(() => {
     const id = setTimeout(
@@ -337,7 +337,7 @@ const LogFileViewPage = () => {
     [content]
   );
 
-  // Widths come from every record, not the visible ones: tracking the filtered set would slide the message column on each keystroke.
+  // Widths come from every record; the filtered set would shift on each keystroke.
   const cols = useMemo(() => {
     let stamp = 0;
     let level = 0;
@@ -350,7 +350,7 @@ const LogFileViewPage = () => {
     }
     return {
       stamp,
-      // Floored at ERROR's display width so the column stays put while tailing.
+      // Floored at ERROR's width so the column stays put while tailing.
       level: Math.min(Math.max(level, 5), LEVEL_COL_MAX),
       module: Math.min(module, MODULE_COL_MAX),
     };
@@ -362,13 +362,13 @@ const LogFileViewPage = () => {
       kept = filterEntries(entries, minLevel, category, query);
     const hidden = Math.max(0, kept.length - MAX_RENDER_LINES);
     if (hidden) kept = kept.slice(hidden);
-    // Reversed as blocks, not entries: reversing entries first would strand an ownerless continuation run against an unrelated record.
+    // Reversed as blocks, not entries, so continuations stay with their record.
     const built = buildBlocks(kept);
     if (newestFirst) built.reverse();
     return { blocks: built, hiddenLines: hidden };
   }, [entries, newestFirst, minLevel, category, query]);
 
-  // Wrapped lines and continuations both hang under the message column.
+  // Wrapped lines and continuations hang under the message column.
   const messageIndent = cols.stamp + cols.level + cols.module + 3;
 
   const notice =
@@ -390,7 +390,7 @@ const LogFileViewPage = () => {
           if (!silent) setLoadError(false);
           return true;
         }
-        // Silent polls resolve to undefined on failure (no toast, no throw).
+        // Silent polls resolve to undefined on failure.
         if (!silent) setLoadError(true);
         return false;
       } catch {
@@ -536,7 +536,7 @@ const LogFileViewPage = () => {
 
         <Box
           p="sm"
-          // Without minHeight:0 a flex item refuses to shrink below its content and the panel grows instead of scrolling.
+          // Without minHeight:0 a flex item will not shrink below its content.
           style={{ flex: '1 1 auto', overflow: 'auto', minHeight: '0px' }}
         >
           {loading && !content ? (
@@ -558,7 +558,7 @@ const LogFileViewPage = () => {
                   'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
                 fontSize: 12,
                 lineHeight: 1.45,
-                // anywhere breaks the unbroken tokens (URLs, SQL dumps) that no space would ever break.
+                // anywhere breaks unbroken tokens like URLs and SQL dumps.
                 whiteSpace: 'pre-wrap',
                 overflowWrap: 'anywhere',
               }}
@@ -571,7 +571,7 @@ const LogFileViewPage = () => {
                         return (
                           <div
                             key={i}
-                            // Dimming stops a run of unowned lines reading as the tail of the record above.
+                            // Dimming marks these lines as unowned.
                             style={{
                               borderLeft: '2px solid transparent',
                               paddingLeft: 8,

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -138,6 +138,7 @@ const MAX_RENDER_LINES = 5000;
 // per-entry object overhead a flood of very short lines would other run up.
 const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 const MAX_BUFFER_LINES = 50000;
+const EMPTY_BUFFER = { entries: [], bytes: 0, truncated: false };
 
 // How close to the live edge still counts as watching it.
 const FOLLOW_SLACK_PX = 50;
@@ -269,7 +270,7 @@ const byteLength = (entries) => {
 };
 
 // Drops from the head until both bounds hold, paying only for what it drops.
-const trimBuffer = (entries, bytes) => {
+const trimBuffer = (entries, bytes, truncated) => {
   let drop = 0;
   while (
     drop < entries.length &&
@@ -278,7 +279,9 @@ const trimBuffer = (entries, bytes) => {
     bytes -= entries[drop].line.length + 1;
     drop += 1;
   }
-  return drop ? { entries: entries.slice(drop), bytes } : { entries, bytes };
+  return drop
+    ? { entries: entries.slice(drop), bytes, truncated: true }
+    : { entries, bytes, truncated };
 };
 
 const emptyState = (message) => (
@@ -372,9 +375,8 @@ const LogBody = React.memo(
 const LogFileViewPage = () => {
   const { name } = useParams();
   // The byte total rides with the entries so trimming never rescans them.
-  const [buffer, setBuffer] = useState({ entries: [], bytes: 0 });
+  const [buffer, setBuffer] = useState(EMPTY_BUFFER);
   const entries = buffer.entries;
-  const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [refreshSetting, setRefreshSetting] = useBrowserStorage(
     'log-viewer-refresh-interval',
@@ -536,7 +538,7 @@ const LogFileViewPage = () => {
   const notice =
     hiddenLines > 0
       ? `Showing the last ${MAX_RENDER_LINES.toLocaleString()} lines`
-      : truncated
+      : buffer.truncated
         ? 'Large file — showing the last 5 MB'
         : null;
 
@@ -548,8 +550,7 @@ const LogFileViewPage = () => {
       const lines = response.content ? response.content.split('\n') : [];
       const { entries: next, inTraceback } = classifyLines(lines);
       tracebackRef.current = inTraceback;
-      setTruncated(response.truncated);
-      setBuffer({ entries: next, bytes: byteLength(next) });
+      setBuffer(trimBuffer(next, byteLength(next), response.truncated));
       return;
     }
     if (!response.content) return;
@@ -562,7 +563,11 @@ const LogFileViewPage = () => {
     );
     tracebackRef.current = inTraceback;
     setBuffer((prev) =>
-      trimBuffer(prev.entries.concat(added), prev.bytes + byteLength(added))
+      trimBuffer(
+        prev.entries.concat(added),
+        prev.bytes + byteLength(added),
+        prev.truncated
+      )
     );
   }, []);
 
@@ -605,6 +610,8 @@ const LogFileViewPage = () => {
     requestRef.current += 1;
     cursorRef.current = null;
     tracebackRef.current = false;
+    setBuffer(EMPTY_BUFFER);
+    setLoadError(false);
     load();
   }, [load]);
 

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -321,6 +321,8 @@ const LogFileViewPage = () => {
     return () => clearTimeout(id);
   }, [search]);
   const [loadError, setLoadError] = useState(false);
+  // The whole body arrives before the browser saves anything; say so.
+  const [downloading, setDownloading] = useState(false);
 
   const loadingRef = useRef(false);
   const failuresRef = useRef(0);
@@ -538,7 +540,15 @@ const LogFileViewPage = () => {
               <Button
                 size="xs"
                 variant="subtle"
-                onClick={() => API.downloadLogFile(name)}
+                loading={downloading}
+                onClick={async () => {
+                  setDownloading(true);
+                  try {
+                    await API.downloadLogFile(name);
+                  } finally {
+                    setDownloading(false);
+                  }
+                }}
                 style={{ marginTop: 'auto' }}
               >
                 Download

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -263,6 +263,50 @@ const columnStyle = (width) => ({
   verticalAlign: 'bottom',
 });
 
+// One table per column layout and floor, so a few objects cover every row.
+const buildStyles = (stampW, levelW, moduleW, indent, minLevel) => {
+  const cache = new Map();
+  return {
+    stamp: { ...columnStyle(stampW), color: COLORS.stamp },
+    module: {
+      ...columnStyle(moduleW),
+      color: COLORS.module,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
+    plain: {
+      borderLeft: '2px solid transparent',
+      paddingLeft: 8,
+      color: COLORS.stamp,
+    },
+    // Built on first sight of a level, so an unexpected one still renders.
+    forLevel: (level) => {
+      let style = cache.get(level);
+      if (!style) {
+        const severity = severityColor(level);
+        style = {
+          row: {
+            borderLeft: `2px solid ${barColor(level, minLevel)}`,
+            paddingLeft: `calc(8px + ${indent}ch)`,
+            textIndent: `-${indent}ch`,
+          },
+          level: {
+            ...columnStyle(levelW),
+            color: levelColor(level),
+            fontWeight: 500,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          },
+          message: severity ? { color: severity } : undefined,
+          continuations: { textIndent: '0px', color: severity || undefined },
+        };
+        cache.set(level, style);
+      }
+      return style;
+    },
+  };
+};
+
 const byteLength = (entries) => {
   let bytes = 0;
   for (const entry of entries) bytes += entry.line.length + 1;
@@ -486,51 +530,12 @@ const LogFileViewPage = () => {
   // Wrapped lines and continuations hang under the message column.
   const messageIndent = cols.stamp + cols.level + cols.module + 3;
 
-  // Every row style derives from the columns, the indent and the floor, so a
-  // handful of objects covers thousands of rows instead of six per row. Keyed
-  // off the primitives, not the cols object, so the identities survive a poll.
-  const styles = useMemo(() => {
-    const cache = new Map();
-    return {
-      stamp: { ...columnStyle(cols.stamp), color: COLORS.stamp },
-      module: {
-        ...columnStyle(cols.module),
-        color: COLORS.module,
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-      },
-      plain: {
-        borderLeft: '2px solid transparent',
-        paddingLeft: 8,
-        color: COLORS.stamp,
-      },
-      // Built on first sight of a level, so an unexpected one still renders.
-      forLevel: (level) => {
-        let style = cache.get(level);
-        if (!style) {
-          const severity = severityColor(level);
-          style = {
-            row: {
-              borderLeft: `2px solid ${barColor(level, minLevel)}`,
-              paddingLeft: `calc(8px + ${messageIndent}ch)`,
-              textIndent: `-${messageIndent}ch`,
-            },
-            level: {
-              ...columnStyle(cols.level),
-              color: levelColor(level),
-              fontWeight: 500,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            },
-            message: severity ? { color: severity } : undefined,
-            continuations: { textIndent: '0px', color: severity || undefined },
-          };
-          cache.set(level, style);
-        }
-        return style;
-      },
-    };
-  }, [cols.stamp, cols.level, cols.module, messageIndent, minLevel]);
+  // Keyed off the primitives so the style identities survive a poll.
+  const styles = useMemo(
+    () =>
+      buildStyles(cols.stamp, cols.level, cols.module, messageIndent, minLevel),
+    [cols.stamp, cols.level, cols.module, messageIndent, minLevel]
+  );
 
   const notice =
     hiddenLines > 0

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -23,6 +23,7 @@ import { notifications } from '@mantine/notifications';
 import API from '../api';
 import DownloadLogButton from '../components/DownloadLogButton';
 import useBrowserStorage from '../hooks/useBrowserStorage';
+import { useDebounce } from '../utils';
 
 const COLORS = {
   error: '#ff6b6b',
@@ -458,11 +459,7 @@ const LogFileViewPage = () => {
   // Ephemeral by design: searches are moments, not settings.
   const [search, setSearch] = useState('');
   // The box keeps up with typing; the filter waits for a pause.
-  const [query, setQuery] = useState('');
-  useEffect(() => {
-    const id = setTimeout(() => setQuery(search.trim()), SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(id);
-  }, [search]);
+  const query = useDebounce(search.trim(), SEARCH_DEBOUNCE_MS);
   const matcher = useMemo(
     () => (query ? new RegExp(escapeRegExp(query), 'i') : null),
     [query]

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -31,6 +31,7 @@ import DownloadLogButton from '../components/DownloadLogButton';
 import { REFRESH_INTERVAL_OPTIONS } from '../constants';
 import useBrowserStorage from '../hooks/useBrowserStorage';
 import { useDebounce } from '../utils';
+import { formatBytes } from '../utils/networkUtils.js';
 
 const COLORS = {
   error: '#ff6b6b',
@@ -137,12 +138,9 @@ const RECORD_START =
 
 const SEARCH_DEBOUNCE_MS = 200;
 
-// Bytes bound the retained text; lines bound the per-entry overhead.
+// Bytes hold one full response from the API; lines bound the entry overhead.
 const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const MAX_BUFFER_LINES = 200000;
-
-// Mirrors MAX_VIEW_BYTES in core/log_files.py.
-const VIEW_CAP_LABEL = '10 MB';
 const EMPTY_BUFFER = { entries: [], bytes: 0, truncated: false };
 
 // How close to the live edge still counts as watching it.
@@ -605,8 +603,9 @@ const LogFileViewPage = () => {
     [cols.stamp, cols.level, cols.module, messageIndent, minLevel]
   );
 
+  // What is held, not what either cap says: both ends can do the trimming.
   const notice = buffer.truncated
-    ? `Showing the last ${VIEW_CAP_LABEL} of the file`
+    ? `Showing the last ${formatBytes(buffer.bytes)} of the log`
     : null;
 
   // A reset replaces the buffer; a delta is classified alone and appended.

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -1,7 +1,6 @@
 import React, {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -20,6 +19,13 @@ import {
   Title,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
+import {
+  AutoSizer,
+  CellMeasurer,
+  CellMeasurerCache,
+  List,
+} from 'react-virtualized';
+import 'react-virtualized/styles.css';
 import API from '../api';
 import DownloadLogButton from '../components/DownloadLogButton';
 import { REFRESH_INTERVAL_OPTIONS } from '../constants';
@@ -131,12 +137,12 @@ const RECORD_START =
 
 const SEARCH_DEBOUNCE_MS = 200;
 
-// Bounds the DOM for low-end TV browsers.
-const MAX_RENDER_LINES = 5000;
-
 // Bytes bound the retained text; lines bound the per-entry overhead.
 const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
 const MAX_BUFFER_LINES = 50000;
+
+// Mirrors MAX_VIEW_BYTES in core/log_files.py.
+const VIEW_CAP_LABEL = '5 MB';
 const EMPTY_BUFFER = { entries: [], bytes: 0, truncated: false };
 
 // How close to the live edge still counts as watching it.
@@ -337,12 +343,139 @@ const buildBlocks = (entries) => {
   return blocks;
 };
 
+// One row per block: a record with its continuations, or a run of plain lines.
+const renderBlock = (block, styles) => {
+  if (!block.record) {
+    // Dimming marks these lines as unowned.
+    return <div style={styles.plain}>{block.lines.join('\n')}</div>;
+  }
+  const rowStyle = styles.forLevel(block.record.level);
+  return (
+    <div style={rowStyle.row}>
+      <span style={styles.stamp}>{block.record.stamp}</span>{' '}
+      <span style={rowStyle.level} title={block.record.level}>
+        {levelLabel(block.record.level)}
+      </span>{' '}
+      <span style={styles.module} title={block.record.source}>
+        {block.record.module}
+      </span>
+      {block.record.sep}
+      <span style={rowStyle.message}>{block.record.message}</span>
+      {block.continuations.length > 0 && (
+        <div style={rowStyle.continuations}>
+          {renderContinuations(block.continuations)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Set on the list container so every measured row inherits the same metrics.
+const BODY_FONT = {
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+  fontSize: 12,
+  lineHeight: 1.45,
+  // The scroller owns the gutter, so the scrollbar stays at the panel edge.
+  paddingInline: 'var(--mantine-spacing-sm)',
+  // anywhere breaks unbroken tokens like URLs and SQL dumps.
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
+};
+
 const LogBody = React.memo(
-  ({ name, blocks, styles, loading, empty, loadError, onRetry }) => {
-    if (loading && empty) return <Loader />;
+  ({
+    name,
+    blocks,
+    styles,
+    loading,
+    empty,
+    loadError,
+    onRetry,
+    newestFirst,
+  }) => {
+    const listRef = useRef(null);
+    const blocksRef = useRef(blocks);
+    blocksRef.current = blocks;
+    // Heights key off the block id, so a reversal or a head trim keeps them.
+    const cache = useMemo(
+      () =>
+        new CellMeasurerCache({
+          fixedWidth: true,
+          defaultHeight: 18,
+          keyMapper: (index) => blocksRef.current[index]?.id ?? index,
+        }),
+      []
+    );
+    // Open at the live edge, and keep following until the reader scrolls away.
+    const [following, setFollowing] = useState(true);
+    const followingRef = useRef(true);
+    // The grid opens at the top and reports it, which is not the reader moving.
+    const reachedRef = useRef(false);
+
+    // The columns move the wrap point, so every stored height is stale.
+    const remeasure = useCallback(() => {
+      cache.clearAll();
+      listRef.current?.recomputeRowHeights();
+    }, [cache]);
+    useEffect(remeasure, [remeasure, styles]);
+
+    // A flipped order pins the other end, which has to be reached in turn.
+    useEffect(() => {
+      reachedRef.current = false;
+    }, [newestFirst, name]);
+
+    // Newest sits at whichever end the order puts it.
+    const onScroll = useCallback(
+      ({ clientHeight, scrollHeight, scrollTop }) => {
+        // A list shorter than its viewport cannot say where the reader is.
+        if (scrollHeight <= clientHeight) return;
+        const next = newestFirst
+          ? scrollTop <= FOLLOW_SLACK_PX
+          : scrollHeight - scrollTop - clientHeight <= FOLLOW_SLACK_PX;
+        // Until the pin has landed once, a report is the list catching up.
+        if (!reachedRef.current) {
+          reachedRef.current = next;
+          return;
+        }
+        // A ref first: scrolling fires far more often than the answer changes.
+        if (next === followingRef.current) return;
+        followingRef.current = next;
+        setFollowing(next);
+      },
+      [newestFirst]
+    );
+
+    // Declared rather than scrolled to, so it survives the rows being measured.
+    const pinned =
+      following && blocks.length
+        ? newestFirst
+          ? 0
+          : blocks.length - 1
+        : undefined;
+
+    const rowRenderer = useCallback(
+      ({ index, key, parent, style }) => (
+        <CellMeasurer
+          cache={cache}
+          columnIndex={0}
+          key={key}
+          parent={parent}
+          rowIndex={index}
+        >
+          {({ registerChild }) => (
+            <div ref={registerChild} style={style}>
+              {renderBlock(blocks[index], styles)}
+            </div>
+          )}
+        </CellMeasurer>
+      ),
+      [blocks, cache, styles]
+    );
+
+    if (loading && empty) return <Loader ml="sm" />;
     if (empty && loadError) {
       return (
-        <Group gap="sm">
+        <Group gap="sm" px="sm">
           <Text size="sm" c="red">
             Failed to load {name}
           </Text>
@@ -352,53 +485,29 @@ const LogBody = React.memo(
         </Group>
       );
     }
+    if (empty) return emptyState('(empty)');
+    if (!blocks.length) return emptyState('(no records match the filters)');
+
     return (
-      <div
-        style={{
-          margin: 0,
-          fontFamily:
-            'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-          fontSize: 12,
-          lineHeight: 1.45,
-          // anywhere breaks unbroken tokens like URLs and SQL dumps.
-          whiteSpace: 'pre-wrap',
-          overflowWrap: 'anywhere',
-        }}
-      >
-        {empty
-          ? emptyState('(empty)')
-          : blocks.length
-            ? blocks.map((block) => {
-                if (!block.record) {
-                  return (
-                    // Dimming marks these lines as unowned.
-                    <div key={block.id} style={styles.plain}>
-                      {block.lines.join('\n')}
-                    </div>
-                  );
-                }
-                const rowStyle = styles.forLevel(block.record.level);
-                return (
-                  <div key={block.id} style={rowStyle.row}>
-                    <span style={styles.stamp}>{block.record.stamp}</span>{' '}
-                    <span style={rowStyle.level} title={block.record.level}>
-                      {levelLabel(block.record.level)}
-                    </span>{' '}
-                    <span style={styles.module} title={block.record.source}>
-                      {block.record.module}
-                    </span>
-                    {block.record.sep}
-                    <span style={rowStyle.message}>{block.record.message}</span>
-                    {block.continuations.length > 0 && (
-                      <div style={rowStyle.continuations}>
-                        {renderContinuations(block.continuations)}
-                      </div>
-                    )}
-                  </div>
-                );
-              })
-            : emptyState('(no records match the filters)')}
-      </div>
+      // A narrower viewport rewraps every line, so the heights go with it.
+      <AutoSizer onResize={remeasure}>
+        {({ height, width }) => (
+          <List
+            deferredMeasurementCache={cache}
+            height={height}
+            onScroll={onScroll}
+            overscanRowCount={12}
+            ref={listRef}
+            rowCount={blocks.length}
+            rowHeight={cache.rowHeight}
+            rowRenderer={rowRenderer}
+            scrollToAlignment={newestFirst ? 'start' : 'end'}
+            scrollToIndex={pinned}
+            style={BODY_FONT}
+            width={width}
+          />
+        )}
+      </AutoSizer>
     );
   }
 );
@@ -458,9 +567,6 @@ const LogFileViewPage = () => {
   const requestRef = useRef(0);
   // classifyLines resumes from here so a split traceback keeps its tail.
   const tracebackRef = useRef(false);
-  const viewportRef = useRef(null);
-  // Open at the live edge, and keep following until the reader scrolls away.
-  const followingRef = useRef(true);
 
   // Widths come from every record; the filtered set would shift on each keystroke.
   const cols = useMemo(() => {
@@ -481,31 +587,13 @@ const LogFileViewPage = () => {
     };
   }, [entries]);
 
-  const { blocks, hiddenLines } = useMemo(() => {
-    let kept = filterEntries(entries, minLevel, category, matcher);
-    const hidden = Math.max(0, kept.length - MAX_RENDER_LINES);
-    if (hidden) kept = kept.slice(hidden);
+  const blocks = useMemo(() => {
+    const kept = filterEntries(entries, minLevel, category, matcher);
     // Reversed as blocks, not entries, so continuations stay with their record.
     const built = buildBlocks(kept);
     if (newestFirst) built.reverse();
-    return { blocks: built, hiddenLines: hidden };
+    return built;
   }, [entries, newestFirst, minLevel, category, matcher]);
-
-  // Newest sits at whichever end the order puts it.
-  const onViewportScroll = useCallback(() => {
-    const el = viewportRef.current;
-    if (!el) return;
-    followingRef.current = newestFirst
-      ? el.scrollTop <= FOLLOW_SLACK_PX
-      : el.scrollHeight - el.scrollTop - el.clientHeight <= FOLLOW_SLACK_PX;
-  }, [newestFirst]);
-
-  // Re-pin to the live edge for a reader who was watching it.
-  useLayoutEffect(() => {
-    const el = viewportRef.current;
-    if (!el || !followingRef.current) return;
-    el.scrollTop = newestFirst ? 0 : el.scrollHeight;
-  }, [blocks, newestFirst]);
 
   // Wrapped lines and continuations hang under the message column.
   const messageIndent = cols.stamp + cols.level + cols.module + 3;
@@ -517,12 +605,9 @@ const LogFileViewPage = () => {
     [cols.stamp, cols.level, cols.module, messageIndent, minLevel]
   );
 
-  // Both bounds can bite at once; naming only the inner one hides the truncation.
-  const limits = [];
-  if (buffer.truncated) limits.push('the last 5 MB of the file');
-  if (hiddenLines > 0)
-    limits.push(`the last ${MAX_RENDER_LINES.toLocaleString()} lines`);
-  const notice = limits.length ? `Showing ${limits.join(', then ')}` : null;
+  const notice = buffer.truncated
+    ? `Showing the last ${VIEW_CAP_LABEL} of the file`
+    : null;
 
   // A reset replaces the buffer; a delta is classified alone and appended.
   const applyResponse = useCallback((response) => {
@@ -712,11 +797,9 @@ const LogFileViewPage = () => {
         </Box>
 
         <Box
-          p="sm"
-          ref={viewportRef}
-          onScroll={onViewportScroll}
+          py="sm"
           // Without minHeight:0 a flex item will not shrink below its content.
-          style={{ flex: '1 1 auto', overflow: 'auto', minHeight: '0px' }}
+          style={{ flex: '1 1 auto', overflow: 'hidden', minHeight: '0px' }}
         >
           <LogBody
             name={name}
@@ -726,6 +809,7 @@ const LogFileViewPage = () => {
             empty={!entries.length}
             loadError={loadError}
             onRetry={load}
+            newestFirst={newestFirst}
           />
         </Box>
       </Paper>

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -584,6 +584,7 @@ const LogBody = React.memo(
       <AutoSizer>
         {({ height, width }) => (
           <List
+            className="log-body"
             // Every collapsed row is exactly this height.
             estimatedRowSize={ROW_HEIGHT}
             height={height}

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -138,11 +138,11 @@ const RECORD_START =
 const SEARCH_DEBOUNCE_MS = 200;
 
 // Bytes bound the retained text; lines bound the per-entry overhead.
-const MAX_BUFFER_BYTES = 5 * 1024 * 1024;
-const MAX_BUFFER_LINES = 50000;
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const MAX_BUFFER_LINES = 200000;
 
 // Mirrors MAX_VIEW_BYTES in core/log_files.py.
-const VIEW_CAP_LABEL = '5 MB';
+const VIEW_CAP_LABEL = '10 MB';
 const EMPTY_BUFFER = { entries: [], bytes: 0, truncated: false };
 
 // How close to the live edge still counts as watching it.

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -1,6 +1,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -19,12 +20,8 @@ import {
   Title,
 } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import {
-  AutoSizer,
-  CellMeasurer,
-  CellMeasurerCache,
-  List,
-} from 'react-virtualized';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { AutoSizer, List } from 'react-virtualized';
 import 'react-virtualized/styles.css';
 import API from '../api';
 import DownloadLogButton from '../components/DownloadLogButton';
@@ -220,31 +217,6 @@ const filterEntries = (entries, minRank, category, matcher) => {
   return out;
 };
 
-const renderContinuations = (lines) => {
-  const out = [];
-  let run = [];
-  let blank = null;
-  const flush = () => {
-    if (!run.length) return;
-    // React renders no text node for '', so a lone blank line needs its own '\n'.
-    const text = run.join('\n') + (blank ? '\n' : '');
-    out.push(
-      <div key={out.length} style={blank ? { lineHeight: 0.35 } : undefined}>
-        {text}
-      </div>
-    );
-    run = [];
-  };
-  for (const line of lines) {
-    const isBlank = line.trim() === '';
-    if (blank !== null && isBlank !== blank) flush();
-    blank = isBlank;
-    run.push(line);
-  }
-  flush();
-  return out;
-};
-
 // whiteSpace and textIndent inherit from the hanging block; reset them here.
 const columnStyle = (width) => ({
   display: 'inline-block',
@@ -258,6 +230,7 @@ const columnStyle = (width) => ({
 const buildStyles = (stampW, levelW, moduleW, indent, minLevel) => {
   const cache = new Map();
   return {
+    indent,
     stamp: { ...columnStyle(stampW), color: COLORS.stamp },
     module: {
       ...columnStyle(moduleW),
@@ -276,10 +249,15 @@ const buildStyles = (stampW, levelW, moduleW, indent, minLevel) => {
       if (!style) {
         const severity = severityColor(level);
         style = {
-          row: {
+          line: {
+            borderLeft: `2px solid ${barColor(level, minLevel)}`,
+            paddingLeft: 8,
+          },
+          // Continuations start under the message column.
+          continuation: {
             borderLeft: `2px solid ${barColor(level, minLevel)}`,
             paddingLeft: `calc(8px + ${indent}ch)`,
-            textIndent: `-${indent}ch`,
+            color: severity || undefined,
           },
           level: {
             ...columnStyle(levelW),
@@ -289,7 +267,6 @@ const buildStyles = (stampW, levelW, moduleW, indent, minLevel) => {
             textOverflow: 'ellipsis',
           },
           message: severity ? { color: severity } : undefined,
-          continuations: { textIndent: '0px', color: severity || undefined },
         };
         cache.set(level, style);
       }
@@ -341,44 +318,151 @@ const buildBlocks = (entries) => {
   return blocks;
 };
 
-// One row per block: a record with its continuations, or a run of plain lines.
-const renderBlock = (block, styles) => {
-  if (!block.record) {
-    // Dimming marks these lines as unowned.
-    return <div style={styles.plain}>{block.lines.join('\n')}</div>;
+// One row per line; a continuation keeps its record's level for colour.
+const flattenBlocks = (blocks) => {
+  const rows = [];
+  for (const block of blocks) {
+    if (!block.record) {
+      block.lines.forEach((text, i) =>
+        rows.push({ id: `${block.id}.${i}`, text })
+      );
+      continue;
+    }
+    rows.push({ id: `${block.id}`, record: block.record });
+    block.continuations.forEach((text, i) =>
+      rows.push({ id: `${block.id}.${i}`, text, level: block.record.level })
+    );
   }
-  const rowStyle = styles.forLevel(block.record.level);
-  return (
-    <div style={rowStyle.row}>
-      <span style={styles.stamp}>{block.record.stamp}</span>{' '}
-      <span style={rowStyle.level} title={block.record.level}>
-        {levelLabel(block.record.level)}
-      </span>{' '}
-      <span style={styles.module} title={block.record.source}>
-        {block.record.module}
-      </span>
-      {block.record.sep}
-      <span style={rowStyle.message}>{block.record.message}</span>
-      {block.continuations.length > 0 && (
-        <div style={rowStyle.continuations}>
-          {renderContinuations(block.continuations)}
-        </div>
-      )}
-    </div>
-  );
+  return rows;
 };
 
-// Set on the list container so every measured row inherits the same metrics.
+// One visual line per row.
+const ROW_HEIGHT = 18;
+
+// Set on the list container; every row inherits the metrics.
 const BODY_FONT = {
   fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
   fontSize: 12,
-  lineHeight: 1.45,
+  lineHeight: `${ROW_HEIGHT}px`,
   // The scroller owns the gutter, so the scrollbar stays at the panel edge.
   paddingInline: 'var(--mantine-spacing-sm)',
-  // anywhere breaks unbroken tokens like URLs and SQL dumps.
+};
+
+const CLIPPED = {
+  flex: '1 1 auto',
+  minWidth: 0,
+  overflow: 'hidden',
+  whiteSpace: 'pre',
+};
+
+// anywhere breaks unbroken tokens like URLs and SQL dumps.
+const WRAPPED = {
+  flex: '1 1 auto',
+  minWidth: 0,
   whiteSpace: 'pre-wrap',
   overflowWrap: 'anywhere',
 };
+
+const ExpandToggle = ({ expanded, hidden, onClick }) => (
+  <Button
+    size="compact-xs"
+    variant="default"
+    h={16}
+    px={6}
+    mt={1}
+    ml={6}
+    fz={10}
+    ff="text"
+    style={{
+      flex: 'none',
+      '--button-color': COLORS.stamp,
+      '--button-hover-color': COLORS.level,
+    }}
+    leftSection={expanded ? <ChevronUp size={11} /> : <ChevronDown size={11} />}
+    aria-expanded={expanded}
+    onClick={onClick}
+  >
+    <span style={{ textBox: 'trim-both cap alphabetic' }}>
+      +{hidden.toLocaleString()} chars
+    </span>
+  </Button>
+);
+
+const LogRow = React.memo(
+  ({ row, styles, width, expanded, opened, onToggle, onMeasure }) => {
+    const frameRef = useRef(null);
+    const textRef = useRef(null);
+    const [hidden, setHidden] = useState(0);
+    const cut = hidden > 0;
+    // Collapsed, a row reads widths only.
+    useLayoutEffect(() => {
+      if (expanded) {
+        onMeasure(row.id, frameRef.current.offsetHeight);
+        return;
+      }
+      const el = textRef.current;
+      const over = el.scrollWidth - el.clientWidth;
+      setHidden(
+        over > 1
+          ? Math.ceil((over * el.textContent.length) / el.scrollWidth)
+          : 0
+      );
+    }, [row, width, expanded, cut, onMeasure]);
+
+    const level = row.record ? row.record.level : row.level;
+    const tone = level ? styles.forLevel(level) : null;
+    const frame = !tone
+      ? styles.plain
+      : row.record
+        ? tone.line
+        : tone.continuation;
+    const text = !expanded
+      ? CLIPPED
+      : row.record
+        ? {
+            ...WRAPPED,
+            paddingLeft: `${styles.indent}ch`,
+            textIndent: `-${styles.indent}ch`,
+          }
+        : WRAPPED;
+    return (
+      <div
+        ref={frameRef}
+        style={{
+          ...frame,
+          display: 'flex',
+          alignItems: 'flex-start',
+          height: expanded ? 'auto' : ROW_HEIGHT,
+        }}
+      >
+        <span ref={textRef} style={text}>
+          {row.record ? (
+            <>
+              <span style={styles.stamp}>{row.record.stamp}</span>{' '}
+              <span style={tone.level} title={row.record.level}>
+                {levelLabel(row.record.level)}
+              </span>{' '}
+              <span style={styles.module} title={row.record.source}>
+                {row.record.module}
+              </span>
+              {row.record.sep}
+              <span style={tone.message}>{row.record.message}</span>
+            </>
+          ) : (
+            row.text
+          )}
+        </span>
+        {(cut || expanded) && (
+          <ExpandToggle
+            expanded={expanded}
+            hidden={expanded ? opened : hidden}
+            onClick={() => onToggle(row.id, hidden)}
+          />
+        )}
+      </div>
+    );
+  }
+);
 
 const LogBody = React.memo(
   ({
@@ -392,35 +476,65 @@ const LogBody = React.memo(
     newestFirst,
   }) => {
     const listRef = useRef(null);
-    const blocksRef = useRef(blocks);
-    blocksRef.current = blocks;
-    // Heights key off the block id, so a reversal or a head trim keeps them.
-    const cache = useMemo(
-      () =>
-        new CellMeasurerCache({
-          fixedWidth: true,
-          defaultHeight: 18,
-          keyMapper: (index) => blocksRef.current[index]?.id ?? `row-${index}`,
-        }),
-      []
-    );
-    // Open at the live edge, and keep following until the reader scrolls away.
+    const rows = useMemo(() => flattenBlocks(blocks), [blocks]);
+    // Expanded row id -> its hidden count; only these rows are ever taller.
+    const [expanded, setExpanded] = useState(() => new Map());
+    const heightsRef = useRef(new Map());
+    // Follow the live edge until the reader scrolls away or toggles a row.
     const [following, setFollowing] = useState(true);
     const followingRef = useRef(true);
     // The grid opens at the top and reports it, which is not the reader moving.
     const reachedRef = useRef(false);
 
-    // The columns move the wrap point, so every stored height is stale.
-    const remeasure = useCallback(() => {
-      cache.clearAll();
-      listRef.current?.recomputeRowHeights();
-    }, [cache]);
-    useEffect(remeasure, [remeasure, styles]);
-
     // A flipped order pins the other end, which has to be reached in turn.
     useEffect(() => {
       reachedRef.current = false;
     }, [newestFirst, name]);
+
+    useEffect(() => {
+      setExpanded(new Map());
+      heightsRef.current.clear();
+    }, [name]);
+
+    // Summed from rowHeight, not the DOM.
+    const resize = useCallback(() => {
+      listRef.current?.recomputeRowHeights();
+      listRef.current?.measureAllRows();
+    }, []);
+    const resizedRef = useRef(false);
+    useEffect(() => {
+      // Nothing expanded now or before: every row is ROW_HEIGHT already.
+      if (!expanded.size && !resizedRef.current) return;
+      resizedRef.current = expanded.size > 0;
+      resize();
+    }, [expanded, rows, resize]);
+
+    const toggle = useCallback((id, hidden) => {
+      followingRef.current = false;
+      setFollowing(false);
+      setExpanded((prev) => {
+        const next = new Map(prev);
+        if (!next.delete(id)) next.set(id, hidden);
+        return next;
+      });
+    }, []);
+
+    const measure = useCallback(
+      (id, height) => {
+        if (heightsRef.current.get(id) === height) return;
+        heightsRef.current.set(id, height);
+        resize();
+      },
+      [resize]
+    );
+
+    const rowHeight = useCallback(
+      ({ index }) => {
+        const id = rows[index]?.id;
+        return (expanded.has(id) && heightsRef.current.get(id)) || ROW_HEIGHT;
+      },
+      [rows, expanded]
+    );
 
     // Newest sits at whichever end the order puts it.
     const onScroll = useCallback(
@@ -443,33 +557,12 @@ const LogBody = React.memo(
       [newestFirst]
     );
 
-    // Declared rather than scrolled to, so it survives the rows being measured.
     const pinned =
-      following && blocks.length
+      following && rows.length
         ? newestFirst
           ? 0
-          : blocks.length - 1
+          : rows.length - 1
         : undefined;
-
-    const rowRenderer = useCallback(
-      ({ index, key, parent, style }) => (
-        <CellMeasurer
-          cache={cache}
-          columnIndex={0}
-          key={key}
-          parent={parent}
-          rowIndex={index}
-        >
-          {({ registerChild }) => (
-            // The grid's height would measure back as itself; content sets it.
-            <div ref={registerChild} style={{ ...style, height: 'auto' }}>
-              {renderBlock(blocks[index], styles)}
-            </div>
-          )}
-        </CellMeasurer>
-      ),
-      [blocks, cache, styles]
-    );
 
     if (loading && empty) return <Loader ml="sm" />;
     if (empty && loadError) {
@@ -485,22 +578,34 @@ const LogBody = React.memo(
       );
     }
     if (empty) return emptyState('(empty)');
-    if (!blocks.length) return emptyState('(no records match the filters)');
+    if (!rows.length) return emptyState('(no records match the filters)');
 
     return (
-      // A narrower viewport rewraps every line, so the heights go with it.
-      <AutoSizer onResize={remeasure}>
+      <AutoSizer>
         {({ height, width }) => (
           <List
-            deferredMeasurementCache={cache}
-            estimatedRowSize={cache.defaultHeight}
+            // Every collapsed row is exactly this height.
+            estimatedRowSize={ROW_HEIGHT}
             height={height}
             onScroll={onScroll}
             overscanRowCount={12}
             ref={listRef}
-            rowCount={blocks.length}
-            rowHeight={cache.rowHeight}
-            rowRenderer={rowRenderer}
+            rowCount={rows.length}
+            rowHeight={rowHeight}
+            rowRenderer={({ index, key, style }) => (
+              <div key={key} style={style}>
+                <LogRow
+                  key={rows[index].id}
+                  row={rows[index]}
+                  styles={styles}
+                  width={width}
+                  expanded={expanded.has(rows[index].id)}
+                  opened={expanded.get(rows[index].id)}
+                  onToggle={toggle}
+                  onMeasure={measure}
+                />
+              </div>
+            )}
             scrollToAlignment={newestFirst ? 'start' : 'end'}
             scrollToIndex={pinned}
             style={BODY_FONT}
@@ -711,6 +816,7 @@ const LogFileViewPage = () => {
           display: 'flex',
           flexDirection: 'column',
           height: 'calc(100vh - var(--mantine-spacing-md) * 2)',
+          overflow: 'hidden',
         }}
       >
         <Box
@@ -798,7 +904,6 @@ const LogFileViewPage = () => {
         </Box>
 
         <Box
-          py="sm"
           // Without minHeight:0 a flex item will not shrink below its content.
           style={{ flex: '1 1 auto', overflow: 'hidden', minHeight: '0px' }}
         >

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -517,12 +517,12 @@ const LogFileViewPage = () => {
     [cols.stamp, cols.level, cols.module, messageIndent, minLevel]
   );
 
-  const notice =
-    hiddenLines > 0
-      ? `Showing the last ${MAX_RENDER_LINES.toLocaleString()} lines`
-      : buffer.truncated
-        ? 'Large file — showing the last 5 MB'
-        : null;
+  // Both bounds can bite at once; naming only the inner one hides the truncation.
+  const limits = [];
+  if (buffer.truncated) limits.push('the last 5 MB of the file');
+  if (hiddenLines > 0)
+    limits.push(`the last ${MAX_RENDER_LINES.toLocaleString()} lines`);
+  const notice = limits.length ? `Showing ${limits.join(', then ')}` : null;
 
   // A reset replaces the buffer; a delta is classified alone and appended.
   const applyResponse = useCallback((response) => {

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -139,8 +139,8 @@ const RECORD_START =
 const SEARCH_DEBOUNCE_MS = 200;
 
 // Bytes hold one full response from the API; lines bound the entry overhead.
-const MAX_BUFFER_BYTES = 10 * 1024 * 1024;
-const MAX_BUFFER_LINES = 200000;
+const MAX_BUFFER_BYTES = 24 * 1024 * 1024;
+const MAX_BUFFER_LINES = 300000;
 const EMPTY_BUFFER = { entries: [], bytes: 0, truncated: false };
 
 // How close to the live edge still counts as watching it.

--- a/frontend/src/pages/LogFileView.jsx
+++ b/frontend/src/pages/LogFileView.jsx
@@ -400,7 +400,7 @@ const LogBody = React.memo(
         new CellMeasurerCache({
           fixedWidth: true,
           defaultHeight: 18,
-          keyMapper: (index) => blocksRef.current[index]?.id ?? index,
+          keyMapper: (index) => blocksRef.current[index]?.id ?? `row-${index}`,
         }),
       []
     );
@@ -461,7 +461,8 @@ const LogBody = React.memo(
           rowIndex={index}
         >
           {({ registerChild }) => (
-            <div ref={registerChild} style={style}>
+            // The grid's height would measure back as itself; content sets it.
+            <div ref={registerChild} style={{ ...style, height: 'auto' }}>
               {renderBlock(blocks[index], styles)}
             </div>
           )}
@@ -492,6 +493,7 @@ const LogBody = React.memo(
         {({ height, width }) => (
           <List
             deferredMeasurementCache={cache}
+            estimatedRowSize={cache.defaultHeight}
             height={height}
             onScroll={onScroll}
             overscanRowCount={12}

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -28,7 +28,7 @@ const LogFilesPage = () => {
       const response = await API.getLogFiles();
       if (response) {
         setFiles(response.files || []);
-        // Absent on an older backend: assume running rather than cry wolf.
+        // A missing flag counts as running.
         setCollectorRunning(response.collector_running !== false);
         setLoadError(false);
       }

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -12,12 +12,7 @@ import {
 } from '@mantine/core';
 import API from '../api';
 import { useDateTimeFormat, format } from '../utils/dateTimeUtils.js';
-
-const humanSize = (bytes) => {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
+import { formatBytes } from '../utils/networkUtils.js';
 
 const LogFilesPage = () => {
   const [files, setFiles] = useState([]);
@@ -96,7 +91,7 @@ const LogFilesPage = () => {
               </Table.Td>
               <Table.Td ta="right">
                 <Text size="sm" title={`${file.size.toLocaleString()} bytes`}>
-                  {humanSize(file.size)}
+                  {formatBytes(file.size)}
                 </Text>
               </Table.Td>
               <Table.Td align="right">

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Alert,
+  Anchor,
+  Box,
+  Button,
+  Group,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+import API from '../api';
+import { useDateTimeFormat, format } from '../utils/dateTimeUtils.js';
+
+const humanSize = (bytes) => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const LogFilesPage = () => {
+  const [files, setFiles] = useState([]);
+  const [collectorRunning, setCollectorRunning] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const { fullDateTimeFormat } = useDateTimeFormat();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await API.getLogFiles();
+      if (response) {
+        setFiles(response.files || []);
+        // Absent on an older backend: assume running rather than cry wolf.
+        setCollectorRunning(response.collector_running !== false);
+      }
+    } catch {
+      // errorNotification already surfaced the failure
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Box p="md" maw={1100} mx="auto">
+      <Group justify="space-between" mb="md">
+        <Title order={3}>Logs</Title>
+        <Button size="xs" variant="subtle" onClick={load} loading={loading}>
+          Refresh
+        </Button>
+      </Group>
+
+      {!collectorRunning && (
+        <Alert
+          variant="light"
+          color="yellow"
+          mb="md"
+          title="Log collector not running"
+        >
+          These files are not being written to, and log settings saved now will
+          not take effect until it restarts. Container output is unaffected.
+        </Alert>
+      )}
+
+      <Table highlightOnHover>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Filename</Table.Th>
+            <Table.Th>Last Write Time</Table.Th>
+            <Table.Th ta="right">Size</Table.Th>
+            <Table.Th />
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {files.map((file) => (
+            <Table.Tr key={file.name}>
+              <Table.Td>
+                <Anchor
+                  component={Link}
+                  to={`/logs/${encodeURIComponent(file.name)}`}
+                  size="sm"
+                >
+                  {file.name}
+                </Anchor>
+              </Table.Td>
+              <Table.Td>
+                <Text size="sm">
+                  {format(file.modified, fullDateTimeFormat)}
+                </Text>
+              </Table.Td>
+              <Table.Td ta="right">
+                <Text size="sm" title={`${file.size.toLocaleString()} bytes`}>
+                  {humanSize(file.size)}
+                </Text>
+              </Table.Td>
+              <Table.Td align="right">
+                <Button
+                  variant="subtle"
+                  size="xs"
+                  onClick={() => API.downloadLogFile(file.name)}
+                >
+                  Download
+                </Button>
+              </Table.Td>
+            </Table.Tr>
+          ))}
+          {files.length === 0 && !loading && (
+            <Table.Tr>
+              <Table.Td colSpan={4}>
+                <Text size="sm" c="dimmed" ta="center" py="md">
+                  No log files yet
+                </Text>
+              </Table.Td>
+            </Table.Tr>
+          )}
+        </Table.Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default LogFilesPage;

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -18,6 +18,7 @@ const LogFilesPage = () => {
   const [files, setFiles] = useState([]);
   const [collectorRunning, setCollectorRunning] = useState(true);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState(false);
   // The whole body arrives before the browser saves anything; say so.
   const [downloading, setDownloading] = useState(null);
   const { fullDateTimeFormat } = useDateTimeFormat();
@@ -30,9 +31,11 @@ const LogFilesPage = () => {
         setFiles(response.files || []);
         // Absent on an older backend: assume running rather than cry wolf.
         setCollectorRunning(response.collector_running !== false);
+        setLoadError(false);
       }
     } catch {
       // errorNotification already surfaced the failure
+      setLoadError(true);
     } finally {
       setLoading(false);
     }
@@ -116,8 +119,13 @@ const LogFilesPage = () => {
           {files.length === 0 && !loading && (
             <Table.Tr>
               <Table.Td colSpan={4}>
-                <Text size="sm" c="dimmed" ta="center" py="md">
-                  No log files yet
+                <Text
+                  size="sm"
+                  c={loadError ? 'red' : 'dimmed'}
+                  ta="center"
+                  py="md"
+                >
+                  {loadError ? 'Failed to load log files' : 'No log files yet'}
                 </Text>
               </Table.Td>
             </Table.Tr>

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -61,8 +61,8 @@ const LogFilesPage = () => {
           mb="md"
           title="Log collector not running"
         >
-          These files are not being written to, and log settings saved now will
-          not take effect until it restarts. Container output is unaffected.
+          These files are not being written to, and log settings will not take
+          effect until a collector is running. Process output is unaffected.
         </Alert>
       )}
 

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -23,6 +23,8 @@ const LogFilesPage = () => {
   const [files, setFiles] = useState([]);
   const [collectorRunning, setCollectorRunning] = useState(true);
   const [loading, setLoading] = useState(false);
+  // The whole body arrives before the browser saves anything; say so.
+  const [downloading, setDownloading] = useState(null);
   const { fullDateTimeFormat } = useDateTimeFormat();
 
   const load = useCallback(async () => {
@@ -101,7 +103,15 @@ const LogFilesPage = () => {
                 <Button
                   variant="subtle"
                   size="xs"
-                  onClick={() => API.downloadLogFile(file.name)}
+                  loading={downloading === file.name}
+                  onClick={async () => {
+                    setDownloading(file.name);
+                    try {
+                      await API.downloadLogFile(file.name);
+                    } finally {
+                      setDownloading(null);
+                    }
+                  }}
                 >
                   Download
                 </Button>

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -11,6 +11,7 @@ import {
   Title,
 } from '@mantine/core';
 import API from '../api';
+import DownloadLogButton from '../components/DownloadLogButton';
 import { useDateTimeFormat, format } from '../utils/dateTimeUtils.js';
 import { formatBytes } from '../utils/networkUtils.js';
 
@@ -19,8 +20,6 @@ const LogFilesPage = () => {
   const [collectorRunning, setCollectorRunning] = useState(true);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState(false);
-  // The whole body arrives before the browser saves anything; say so.
-  const [downloading, setDownloading] = useState(null);
   const { fullDateTimeFormat } = useDateTimeFormat();
 
   const load = useCallback(async () => {
@@ -97,22 +96,8 @@ const LogFilesPage = () => {
                   {formatBytes(file.size)}
                 </Text>
               </Table.Td>
-              <Table.Td align="right">
-                <Button
-                  variant="subtle"
-                  size="xs"
-                  loading={downloading === file.name}
-                  onClick={async () => {
-                    setDownloading(file.name);
-                    try {
-                      await API.downloadLogFile(file.name);
-                    } finally {
-                      setDownloading(null);
-                    }
-                  }}
-                >
-                  Download
-                </Button>
+              <Table.Td ta="right">
+                <DownloadLogButton name={file.name} />
               </Table.Td>
             </Table.Tr>
           ))}

--- a/frontend/src/pages/LogFiles.jsx
+++ b/frontend/src/pages/LogFiles.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   Alert,
@@ -6,12 +6,13 @@ import {
   Box,
   Button,
   Group,
-  Table,
+  Loader,
   Text,
   Title,
 } from '@mantine/core';
 import API from '../api';
 import DownloadLogButton from '../components/DownloadLogButton';
+import { CustomTable, useTable } from '../components/tables/CustomTable';
 import { useDateTimeFormat, format } from '../utils/dateTimeUtils.js';
 import { formatBytes } from '../utils/networkUtils.js';
 
@@ -44,6 +45,80 @@ const LogFilesPage = () => {
     load();
   }, [load]);
 
+  const columns = useMemo(
+    () => [
+      {
+        header: 'Filename',
+        accessorKey: 'name',
+        grow: true,
+        minSize: 200,
+        cell: ({ cell }) => (
+          <Anchor
+            component={Link}
+            to={`/logs/${encodeURIComponent(cell.getValue())}`}
+            size="sm"
+          >
+            {cell.getValue()}
+          </Anchor>
+        ),
+      },
+      {
+        header: 'Last Write Time',
+        accessorKey: 'modified',
+        minSize: 190,
+        cell: ({ cell }) => (
+          <Text size="sm" style={{ whiteSpace: 'nowrap' }}>
+            {format(cell.getValue(), fullDateTimeFormat)}
+          </Text>
+        ),
+      },
+      {
+        header: 'Size',
+        accessorKey: 'size',
+        size: 110,
+        cell: ({ cell }) => (
+          <Text size="sm" title={`${cell.getValue().toLocaleString()} bytes`}>
+            {formatBytes(cell.getValue())}
+          </Text>
+        ),
+      },
+      {
+        id: 'actions',
+        header: '',
+        size: 120,
+      },
+    ],
+    [fullDateTimeFormat]
+  );
+
+  const allRowIds = useMemo(() => files.map((file) => file.name), [files]);
+
+  const renderHeaderCell = (header) => (
+    <Text size="sm" name={header.id}>
+      {header.column.columnDef.header}
+    </Text>
+  );
+
+  const renderBodyCell = ({ cell, row }) => {
+    switch (cell.column.id) {
+      case 'actions':
+        return <DownloadLogButton name={row.original.name} />;
+    }
+  };
+
+  const table = useTable({
+    columns,
+    data: files,
+    allRowIds,
+    bodyCellRenderFns: { actions: renderBodyCell },
+    headerCellRenderFns: {
+      name: renderHeaderCell,
+      modified: renderHeaderCell,
+      size: renderHeaderCell,
+      actions: renderHeaderCell,
+    },
+  });
+
   return (
     <Box p="md" maw={1100} mx="auto">
       <Group justify="space-between" mb="md">
@@ -65,58 +140,26 @@ const LogFilesPage = () => {
         </Alert>
       )}
 
-      <Table highlightOnHover>
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>Filename</Table.Th>
-            <Table.Th>Last Write Time</Table.Th>
-            <Table.Th ta="right">Size</Table.Th>
-            <Table.Th />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {files.map((file) => (
-            <Table.Tr key={file.name}>
-              <Table.Td>
-                <Anchor
-                  component={Link}
-                  to={`/logs/${encodeURIComponent(file.name)}`}
-                  size="sm"
-                >
-                  {file.name}
-                </Anchor>
-              </Table.Td>
-              <Table.Td>
-                <Text size="sm">
-                  {format(file.modified, fullDateTimeFormat)}
-                </Text>
-              </Table.Td>
-              <Table.Td ta="right">
-                <Text size="sm" title={`${file.size.toLocaleString()} bytes`}>
-                  {formatBytes(file.size)}
-                </Text>
-              </Table.Td>
-              <Table.Td ta="right">
-                <DownloadLogButton name={file.name} />
-              </Table.Td>
-            </Table.Tr>
-          ))}
-          {files.length === 0 && !loading && (
-            <Table.Tr>
-              <Table.Td colSpan={4}>
-                <Text
-                  size="sm"
-                  c={loadError ? 'red' : 'dimmed'}
-                  ta="center"
-                  py="md"
-                >
-                  {loadError ? 'Failed to load log files' : 'No log files yet'}
-                </Text>
-              </Table.Td>
-            </Table.Tr>
-          )}
-        </Table.Tbody>
-      </Table>
+      <Box
+        style={{
+          overflowX: 'auto',
+          overflowY: 'auto',
+          border: 'solid 1px rgb(68,68,68)',
+          borderRadius: 'var(--mantine-radius-default)',
+        }}
+      >
+        {loading && files.length === 0 ? (
+          <Box p="xl" style={{ display: 'flex', justifyContent: 'center' }}>
+            <Loader />
+          </Box>
+        ) : files.length === 0 ? (
+          <Text size="sm" c={loadError ? 'red' : 'dimmed'} p="md" ta="center">
+            {loadError ? 'Failed to load log files' : 'No log files yet'}
+          </Text>
+        ) : (
+          <CustomTable table={table} />
+        )}
+      </Box>
     </Box>
   );
 };

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -251,8 +251,8 @@ describe('LogFileViewPage', () => {
   });
 
   it('shows a load error with Retry and recovers when Retry succeeds', async () => {
-    // getLogFile resolves undefined on failure (see api.js catch path).
-    API.getLogFile.mockResolvedValue(undefined);
+    // A non-silent failure rejects once errorNotification has toasted.
+    API.getLogFile.mockRejectedValue(new Error('HTTP error! Status: 500'));
     renderPage();
     await waitFor(() => {
       expect(screen.getByText(/Failed to load/)).toBeInTheDocument();
@@ -782,10 +782,11 @@ describe('LogFileViewPage', () => {
     );
   });
 
-  it('claims the column-0 tail of a traceback the collector stamped', async () => {
+  it('claims the column-0 tail of an unstamped traceback', async () => {
     API.getLogFile.mockResolvedValue({
       content: [
-        '2026-08-21 10:00:00,000 INFO stdout Traceback (most recent call last):',
+        '2026-08-21 10:00:00,000 INFO stdout unhandled error in worker',
+        'Traceback (most recent call last):',
         '  File "/app/x.py", line 12, in run',
         'ValueError: bad feed',
         'During handling of the above exception, another exception occurred:',
@@ -853,7 +854,8 @@ describe('LogFileViewPage', () => {
     // Joined to '' a lone blank renders no text node and drops from the copy buffer.
     API.getLogFile.mockResolvedValue({
       content: [
-        '2026-08-21 10:00:00,000 ERROR core.tasks Traceback (most recent call last):',
+        '2026-08-21 10:00:00,000 ERROR core.tasks refresh failed',
+        'Traceback (most recent call last):',
         '',
         'ValueError: bad feed',
       ].join('\n'),
@@ -862,7 +864,7 @@ describe('LogFileViewPage', () => {
     renderPage();
     await screen.findByText(/Traceback/);
     const segments = screen.getByText(/ValueError/).parentElement;
-    const blank = segments.children[0];
+    const blank = segments.children[1];
     expect(blank).toHaveStyle({ lineHeight: '0.35' });
     expect(blank.textContent).toBe('\n');
   });
@@ -1158,7 +1160,8 @@ describe('LogFileViewPage', () => {
   it('keeps a traceback whole when it straddles two deltas', async () => {
     API.getLogFile.mockResolvedValue({
       content:
-        '2026-08-21 10:00:00,000 ERROR apps.epg Traceback (most recent call last):\n' +
+        '2026-08-21 10:00:00,000 ERROR apps.epg refresh failed\n' +
+        'Traceback (most recent call last):\n' +
         '  File "/app/x.py", line 1, in run\n',
       truncated: false,
       cursor: '99-80',

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -321,7 +321,7 @@ describe('LogFileViewPage', () => {
     API.getLogFile.mockResolvedValue({ content, truncated: true });
 
     renderPage();
-    // No wall-clock assertion: a loaded machine must not fail this, and a real hang still trips the timeout.
+    // No wall-clock assertion: slowness must not fail this, but a hang still will.
     await screen.findByText(
       /END-OF-SYNTHETIC-LOG-MARKER/,
       {},
@@ -553,7 +553,7 @@ describe('LogFileViewPage', () => {
     });
     renderPage();
     await screen.findByText(/scan slow/);
-    // Without both, the token wraps inside its own box or draws at the block's negative indent, off the left edge.
+    // Without both, the token wraps in its box or draws off the left edge.
     const opts = { whiteSpace: 'nowrap', textIndent: '0px' };
     expect(screen.getByText('2026-08-21 10:00:00,000')).toHaveStyle(opts);
     expect(screen.getByText('WARN')).toHaveStyle(opts);
@@ -780,7 +780,7 @@ describe('LogFileViewPage', () => {
   });
 
   it('keeps a record whose level the collector invented, at any floor', async () => {
-    // The collector stamps an unattributable line INFO stdout; honouring that invented level hides the tail of an ERROR traceback.
+    // INFO stdout is the collector's invention; gating on it hides an ERROR tail.
     API.getLogFile.mockResolvedValue({
       content: [
         '2026-08-21 10:00:00,000 ERROR core.tasks Traceback (most recent call last):',
@@ -802,7 +802,7 @@ describe('LogFileViewPage', () => {
   });
 
   it('leaves an unowned continuation run unowned when the order flips', async () => {
-    // Reversing entries would graft a headless continuation onto an unrelated record, inside its block and behind its bar.
+    // Reversing entries would graft a headless continuation onto another record.
     API.getLogFile.mockResolvedValue({
       content: [
         '  orphaned frame from a record the tail cut off',
@@ -823,7 +823,7 @@ describe('LogFileViewPage', () => {
   });
 
   it('keeps the byte of a single blank continuation line', async () => {
-    // Joined to '' a lone blank renders no text node, and a div with no line box drops the byte from the DOM and the copy buffer.
+    // Joined to '' a lone blank renders no text node and drops from the copy buffer.
     API.getLogFile.mockResolvedValue({
       content: [
         '2026-08-21 10:00:00,000 ERROR core.tasks Traceback (most recent call last):',
@@ -923,7 +923,7 @@ describe('LogFileViewPage', () => {
     fireEvent.change(screen.getByLabelText('Category'), {
       target: { value: 'plugins' },
     });
-    // Plugin infrastructure files with the plugins it manages, renamed so the plugins token stays third-party.
+    // Plugin infrastructure files with its plugins; the token stays third-party.
     expect(screen.getByText(/Discovered 5 plugin/)).toBeInTheDocument();
     expect(screen.getByText(/Sweep done/)).toBeInTheDocument();
     expect(screen.queryByText(/epg tick/)).not.toBeInTheDocument();
@@ -959,7 +959,7 @@ describe('LogFileViewPage', () => {
   });
 
   it('does not re-filter on every keystroke', async () => {
-    // Each pass rebuilds up to MAX_RENDER_LINES blocks, so a typed word must cost one filter, not one per letter.
+    // A pass rebuilds up to MAX_RENDER_LINES blocks: one filter per word, not letter.
     API.getLogFile.mockResolvedValue({
       content: [
         '2026-08-21 10:00:00,000 INFO core.tasks alpha',

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -911,6 +911,16 @@ describe('LogFileViewPage', () => {
     expect(screen.getByText(/frame=1/).textContent).toContain('frame=30');
   });
 
+  it('does not read a torn offset as the level', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: '2026-08-21 10:00:00,000 +1200 INFO',
+      truncated: false,
+    });
+    renderPage();
+    expect(await screen.findByText(/\+1200 INFO/)).toBeInTheDocument();
+    expect(screen.queryByTitle('+1200')).toBeNull();
+  });
+
   it('does not invent a separator the file lacks', async () => {
     API.getLogFile.mockResolvedValue({
       content: '2026-08-21 10:00:00,000 INFO core.tasks',

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -845,6 +845,18 @@ describe('LogFileViewPage', () => {
     expect(blank.textContent).toBe('\n');
   });
 
+  it('does not render the newline that ends the body as a blank line', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: '2026-08-21 10:00:00,000 INFO core.tasks hello there\n',
+      truncated: false,
+    });
+    const { container } = renderPage();
+    await screen.findByText(/hello there/);
+    expect(
+      container.querySelector('div[style*="line-height: 0.35"]')
+    ).toBeNull();
+  });
+
   it('never hides the collector pass-through records behind a filter', async () => {
     // A known source shape with an unparseable date reaches the viewer unstamped.
     API.getLogFile.mockResolvedValue({

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -23,7 +23,12 @@ vi.mock('@mantine/notifications', () => ({
 
 vi.mock('@mantine/core', () => ({
   Anchor: ({ children, to }) => <a href={to || '#'}>{children}</a>,
-  Box: ({ children, style }) => <div style={style}>{children}</div>,
+  // ref/onScroll pass through: the viewer pins itself to the live edge.
+  Box: ({ children, style, onScroll, ref }) => (
+    <div style={style} ref={ref} onScroll={onScroll}>
+      {children}
+    </div>
+  ),
   Button: ({ children, onClick }) => (
     <button onClick={onClick}>{children}</button>
   ),
@@ -1051,5 +1056,102 @@ describe('LogFileViewPage', () => {
     expect(text.indexOf('first failure')).toBeLessThan(
       text.indexOf('continuation of the first record')
     );
+  });
+  // jsdom performs no layout, so the scroll box reports zero for every metric.
+  // Stub the geometry and let scrollTop behave like a real settable property.
+  const stubViewport = (el, { scrollHeight, clientHeight }) => {
+    let top = 0;
+    Object.defineProperty(el, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+      configurable: true,
+      get: () => clientHeight,
+    });
+    Object.defineProperty(el, 'scrollTop', {
+      configurable: true,
+      get: () => top,
+      set: (v) => {
+        top = v;
+      },
+    });
+    return el;
+  };
+
+  const findViewport = () => {
+    let el = screen.getByText(/Scanning disk/).parentElement;
+    while (el && getComputedStyle(el).overflow !== 'auto') {
+      el = el.parentElement;
+    }
+    return el;
+  };
+
+  it('opens at the live edge instead of the oldest retained line', async () => {
+    renderPage();
+    await screen.findByText(/Scanning disk/);
+    const viewport = stubViewport(findViewport(), {
+      scrollHeight: 5000,
+      clientHeight: 500,
+    });
+
+    API.getLogFile.mockResolvedValue({
+      content:
+        'Info|DiskScanService|Scanning disk\nInfo|core.tasks|later line\n',
+      truncated: false,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Refresh'));
+    });
+
+    expect(viewport.scrollTop).toBe(5000);
+  });
+
+  it('keeps following the tail across a refresh', async () => {
+    renderPage();
+    await screen.findByText(/Scanning disk/);
+    const viewport = stubViewport(findViewport(), {
+      scrollHeight: 5000,
+      clientHeight: 500,
+    });
+    // The reader is sitting at the bottom, watching.
+    viewport.scrollTop = 4500;
+    fireEvent.scroll(viewport);
+
+    API.getLogFile.mockResolvedValue({
+      content:
+        'Info|DiskScanService|Scanning disk\nInfo|core.tasks|fresh line\n',
+      truncated: false,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Refresh'));
+    });
+
+    await screen.findByText(/fresh line/);
+    expect(viewport.scrollTop).toBe(5000);
+  });
+
+  it('leaves a reader who scrolled back where they were', async () => {
+    renderPage();
+    await screen.findByText(/Scanning disk/);
+    const viewport = stubViewport(findViewport(), {
+      scrollHeight: 5000,
+      clientHeight: 500,
+    });
+    // Scrolled up to read history: a refresh must not yank them to the bottom.
+    viewport.scrollTop = 1200;
+    fireEvent.scroll(viewport);
+
+    API.getLogFile.mockResolvedValue({
+      content:
+        'Info|DiskScanService|Scanning disk\nInfo|core.tasks|fresh line\n',
+      truncated: false,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Refresh'));
+    });
+
+    await screen.findByText(/fresh line/);
+    expect(viewport.scrollTop).toBe(1200);
   });
 });

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -272,7 +272,7 @@ describe('LogFileViewPage', () => {
   });
 
   it('renders a near-ceiling log (~50k lines / ~5MB, many colour switches) without hanging', async () => {
-    // Interleaves every category to hit colorizeLines's worst case: frequent colour switches.
+    // Interleaves every level so the colour changes on most rows.
     const LEVELS = [
       {
         tag: 'INFO',
@@ -310,7 +310,7 @@ describe('LogFileViewPage', () => {
       lines.push(
         `2026-07-15 ${hh}:${mm}:${ss},000 ${level.tag} ${level.logger} ${level.msg} record-${i}`
       );
-      // Continuations exercise colorizeLines's inherit-colour path.
+      // Continuations exercise the inherited-colour path.
       if (i % 6 === 0) {
         lines.push(
           `    caused by: nested detail for record ${i} with additional padding text to widen the payload`

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -453,6 +453,28 @@ describe('LogFileViewPage', () => {
     }
   });
 
+  it('pauses after three failed polls without touching the stored interval', async () => {
+    vi.useFakeTimers();
+    try {
+      renderPage();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      fireEvent.change(screen.getByLabelText('Auto Refresh'), {
+        target: { value: '5' },
+      });
+      API.getLogFile.mockResolvedValue(undefined);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(16000);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(4);
+      expect(localStorage.getItem('log-viewer-refresh-interval')).toBe('5');
+      expect(screen.getByLabelText('Auto Refresh')).toHaveValue('0');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('defaults the level floor to Info', async () => {
     API.getLogFile.mockResolvedValue({
       content: [

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -1,0 +1,1054 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import LogFileViewPage from '../LogFileView';
+import API from '../../api';
+
+vi.mock('../../api', () => ({
+  default: {
+    getLogFile: vi.fn(),
+    downloadLogFile: vi.fn(),
+  },
+}));
+
+vi.mock('@mantine/notifications', () => ({
+  notifications: { show: vi.fn() },
+}));
+
+vi.mock('@mantine/core', () => ({
+  Anchor: ({ children, to }) => <a href={to || '#'}>{children}</a>,
+  Box: ({ children, style }) => <div style={style}>{children}</div>,
+  Button: ({ children, onClick }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  Group: ({ children }) => <div>{children}</div>,
+  Loader: () => <div data-testid="loader" />,
+  Paper: ({ children }) => <div>{children}</div>,
+  Select: ({ label, value, onChange, data }) => (
+    <select
+      aria-label={label}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {data.map((option) => (
+        <option
+          key={option.value}
+          value={option.value}
+          disabled={option.disabled}
+        >
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+  Text: ({ children, c }) => <span data-colour={c}>{children}</span>,
+  TextInput: ({ label, value, onChange, placeholder }) => (
+    <input
+      aria-label={label}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+    />
+  ),
+  Title: ({ children }) => <h4>{children}</h4>,
+}));
+
+const renderPage = (name = 'dispatcharr.log') =>
+  render(
+    <MemoryRouter initialEntries={[`/logs/${name}`]}>
+      <Routes>
+        <Route path="/logs/:name" element={<LogFileViewPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('LogFileViewPage', () => {
+  beforeEach(() => {
+    // useBrowserStorage persists between cases, so the interval leaks otherwise.
+    localStorage.clear();
+    vi.clearAllMocks();
+    API.getLogFile.mockResolvedValue({
+      content: 'Info|DiskScanService|Scanning disk\n',
+      truncated: false,
+    });
+  });
+
+  it('fetches and renders the raw log content', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/DiskScanService\|Scanning disk/)
+      ).toBeInTheDocument();
+    });
+    expect(API.getLogFile).toHaveBeenCalledWith('dispatcharr.log', {
+      silent: false,
+    });
+    expect(screen.getByText('dispatcharr.log')).toBeInTheDocument();
+  });
+
+  it('shows the truncation notice for large files', async () => {
+    API.getLogFile.mockResolvedValue({ content: 'tail', truncated: true });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/showing the last 5 MB/i)).toBeInTheDocument();
+    });
+  });
+
+  it('downloads the file from the toolbar', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Download')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Download'));
+    expect(API.downloadLogFile).toHaveBeenCalledWith('dispatcharr.log');
+  });
+
+  it('re-fetches when Refresh is clicked', async () => {
+    renderPage();
+    await waitFor(() => expect(API.getLogFile).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Refresh'));
+    await waitFor(() => expect(API.getLogFile).toHaveBeenCalledTimes(2));
+  });
+
+  it('colours a record by severity alone, level token and message together', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-07-15 10:00:00,000 INFO core.tasks routine tick',
+        '2026-07-15 10:00:01,000 ERROR apps.epg boom failure',
+        '2026-07-15 10:00:02,000 WARNING core.utils cache miss',
+        '2026-07-15 10:00:03,000 INFO plugins.iptv_checker sweep done',
+        '2026-07-15 10:00:04,000 ERROR plugins.iptv_checker sweep died',
+        '2026-07-15 10:00:05,000 WARNING django.request Unauthorized: /api/x/',
+        '2026-07-15 10:00:06,000 INFO apps.accounts.api_views Login success: user=demo ip=192.0.2.7',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/boom failure/)).toBeInTheDocument();
+    });
+    screen
+      .getAllByText('ERROR')
+      .forEach((token) => expect(token).toHaveStyle({ color: '#ff6b6b' }));
+    expect(screen.getByText(/boom failure/)).toHaveStyle({ color: '#ff6b6b' });
+    screen
+      .getAllByText('WARN')
+      .forEach((token) => expect(token).toHaveStyle({ color: '#ffd43b' }));
+    expect(screen.getByText(/cache miss/)).toHaveStyle({ color: '#ffd43b' });
+    expect(screen.getByText(/Unauthorized/)).toHaveStyle({ color: '#ffd43b' });
+    expect(screen.getByText(/routine tick/)).not.toHaveStyle({
+      color: '#ff6b6b',
+    });
+    expect(screen.getByText(/sweep done/)).not.toHaveStyle({
+      color: '#74c0fc',
+    });
+    expect(screen.getByText(/sweep died/)).toHaveStyle({ color: '#ff6b6b' });
+    expect(screen.getByText(/Login success/)).not.toHaveStyle({
+      color: '#51cf66',
+    });
+  });
+
+  it('renders a traceback inside its record block behind the level bar', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-07-15 10:00:07,000 ERROR apps.epg refresh failed',
+        'Traceback (most recent call last):',
+        '  File "/app/x.py", line 214, in refresh',
+        'ValueError: bad feed',
+        '2026-07-15 10:00:08,000 INFO core.tasks back to normal',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/refresh failed/)).toBeInTheDocument();
+    });
+    expect(screen.getByText('ERROR')).toHaveStyle({ color: '#ff6b6b' });
+    expect(screen.getByText('ERROR').closest('div')).toHaveStyle({
+      borderLeft: '2px solid #ff6b6b',
+    });
+    // The traceback, its column-0 tail included, is one joined text node.
+    expect(screen.getByText(/Traceback/).textContent).toContain(
+      'ValueError: bad feed'
+    );
+    expect(screen.getByText(/back to normal/).closest('div')).not.toHaveStyle({
+      borderLeft: '2px solid #ff6b6b',
+    });
+  });
+
+  it('displays the module token with the raw source on hover', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO apps.epg.tasks Processed 3133 channels',
+        '2026-08-21 10:00:01,000 INFO plugins.event_channel_managarr Scheduled scan completed',
+        '2026-08-21 10:00:02,000 INFO nginx.access 192.0.2.7 - - "GET / HTTP/1.1" 200',
+        '2026-08-21 10:00:03,000 INFO postgres [312] LOG:  checkpoint complete',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/Processed 3133/);
+    expect(screen.getByTitle('apps.epg.tasks')).toHaveTextContent('epg');
+    expect(
+      screen.getByTitle('plugins.event_channel_managarr')
+    ).toHaveTextContent('event_channel_managarr');
+    expect(screen.getByTitle('nginx.access')).toHaveTextContent('nginx');
+    expect(screen.getByTitle('postgres')).toHaveTextContent('postgres');
+    expect(screen.queryByText('apps.epg.tasks')).not.toBeInTheDocument();
+    expect(screen.getByText('2026-08-21 10:00:00,000')).toHaveStyle({
+      color: '#a1a1aa',
+    });
+  });
+
+  it('spells the numeric offset out as a UTC label', async () => {
+    // The file keeps "+1200" for external tooling; only the display changes.
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 21:35:01,472 +1200 INFO core.tasks southern hemisphere',
+        '2026-08-21 09:35:01,472 -0330 INFO core.tasks half hour zone',
+        '2026-08-21 09:35:01,472 INFO core.tasks no offset at all',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/southern hemisphere/);
+    expect(
+      screen.getByText('2026-08-21 21:35:01,472 [UTC+12]')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('2026-08-21 09:35:01,472 [UTC-3:30]')
+    ).toBeInTheDocument();
+    // Offset-less stamps come from the pre-collector boot window.
+    expect(screen.getByText('2026-08-21 09:35:01,472')).toBeInTheDocument();
+    expect(screen.queryByText(/\+1200/)).not.toBeInTheDocument();
+  });
+
+  it('does not redden an INFO line whose message body mentions ERROR', async () => {
+    API.getLogFile.mockResolvedValue({
+      content:
+        '2026-07-19 22:52:20,931 INFO live_proxy.manager Updated channel abc state to ERROR in Redis after stream failure',
+      truncated: false,
+    });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/state to ERROR in Redis/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/state to ERROR in Redis/)).not.toHaveStyle({
+      color: '#ff6b6b',
+    });
+  });
+
+  it('shows a load error with Retry and recovers when Retry succeeds', async () => {
+    // getLogFile resolves undefined on failure (see api.js catch path).
+    API.getLogFile.mockResolvedValue(undefined);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load/)).toBeInTheDocument();
+    });
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+    expect(screen.queryByText('(empty)')).not.toBeInTheDocument();
+
+    API.getLogFile.mockResolvedValue({
+      content: 'recovered log line\n',
+      truncated: false,
+    });
+    fireEvent.click(screen.getByText('Retry'));
+    await waitFor(() => {
+      expect(screen.getByText(/recovered log line/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Failed to load/)).not.toBeInTheDocument();
+  });
+
+  it('renders a near-ceiling log (~50k lines / ~5MB, many colour switches) without hanging', async () => {
+    // Interleaves every category to hit colorizeLines's worst case: frequent colour switches.
+    const LEVELS = [
+      {
+        tag: 'INFO',
+        logger: 'core.tasks',
+        msg: 'routine tick, nothing to report this cycle',
+      },
+      {
+        tag: 'WARNING',
+        logger: 'core.utils',
+        msg: 'cache miss while resolving stream metadata lookup',
+      },
+      {
+        tag: 'ERROR',
+        logger: 'apps.epg',
+        msg: 'boom failure refreshing programme guide data source',
+      },
+      {
+        tag: 'INFO',
+        logger: 'apps.accounts.api_views',
+        msg: 'Login success: user=demo ip=192.0.2.7 session=abcdef',
+      },
+      {
+        tag: 'INFO',
+        logger: 'plugins.iptv_checker',
+        msg: 'sweep tick probing configured channel groups',
+      },
+    ];
+    const RECORD_COUNT = 45000;
+    const lines = [];
+    for (let i = 0; i < RECORD_COUNT; i += 1) {
+      const level = LEVELS[i % LEVELS.length];
+      const hh = String(Math.floor(i / 3600) % 24).padStart(2, '0');
+      const mm = String(Math.floor(i / 60) % 60).padStart(2, '0');
+      const ss = String(i % 60).padStart(2, '0');
+      lines.push(
+        `2026-07-15 ${hh}:${mm}:${ss},000 ${level.tag} ${level.logger} ${level.msg} record-${i}`
+      );
+      // Continuations exercise colorizeLines's inherit-colour path.
+      if (i % 6 === 0) {
+        lines.push(
+          `    caused by: nested detail for record ${i} with additional padding text to widen the payload`
+        );
+      }
+    }
+    lines.push(
+      '2026-07-15 23:59:59,000 INFO core.tasks END-OF-SYNTHETIC-LOG-MARKER'
+    );
+    const content = lines.join('\n');
+    // The payload must genuinely approach the 5 MB truncation ceiling.
+    expect(content.length).toBeGreaterThan(4 * 1024 * 1024);
+
+    API.getLogFile.mockResolvedValue({ content, truncated: true });
+
+    renderPage();
+    // No wall-clock assertion: a loaded machine must not fail this, and a real hang still trips the timeout.
+    await screen.findByText(
+      /END-OF-SYNTHETIC-LOG-MARKER/,
+      {},
+      { timeout: 30000 }
+    );
+    expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+    expect(screen.queryByText('(empty)')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Showing the last [\d,]+ lines/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/record-0\b/)).not.toBeInTheDocument();
+  }, 60000);
+
+  it('does not poll while the tab is hidden', async () => {
+    vi.useFakeTimers();
+    let hidden = true;
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+    try {
+      renderPage();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(1);
+
+      fireEvent.change(screen.getByLabelText('Auto Refresh'), {
+        target: { value: '5' },
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(11000);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(1);
+
+      hidden = false;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+      delete document.hidden;
+    }
+  });
+
+  it('renders newest last by default and flips to newest first', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-07-15 10:00:00,000 INFO core.tasks alpha',
+        '2026-07-15 10:00:01,000 INFO core.tasks omega',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/alpha/);
+    // File order by default, so boot banners and tracebacks read top-down.
+    const before = document.body.textContent;
+    expect(before.indexOf('alpha')).toBeLessThan(before.indexOf('omega'));
+
+    fireEvent.change(screen.getByLabelText('Order'), {
+      target: { value: 'newest' },
+    });
+    const after = document.body.textContent;
+    expect(after.indexOf('omega')).toBeLessThan(after.indexOf('alpha'));
+  });
+
+  it('does not poll while the interval is zero', async () => {
+    vi.useFakeTimers();
+    try {
+      renderPage();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60000);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to Manual when the stored interval is not an option', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem('log-viewer-refresh-interval', '7');
+    try {
+      renderPage();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.getByLabelText('Auto Refresh')).toHaveValue('0');
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60000);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('polls at the chosen interval', async () => {
+    vi.useFakeTimers();
+    try {
+      renderPage();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      fireEvent.change(screen.getByLabelText('Auto Refresh'), {
+        target: { value: '10' },
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(9000);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+      });
+      expect(API.getLogFile).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('defaults the level floor to Info', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 DEBUG core.tasks chatter',
+        '2026-08-21 10:00:01,000 INFO core.tasks visible line',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/visible line/);
+    expect(screen.getByLabelText('Level')).toHaveValue('20');
+    expect(screen.queryByText(/chatter/)).not.toBeInTheDocument();
+  });
+
+  it('filters records below the chosen level with their continuations', async () => {
+    // Start from the Debug floor so the DEBUG fixture is visible before filtering.
+    localStorage.setItem('log-viewer-min-level', '10');
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-07-15 10:00:00,000 DEBUG core.tasks noisy tick',
+        '    noisy continuation detail',
+        '2026-07-15 10:00:01,000 INFO core.tasks routine note',
+        '2026-07-15 10:00:02,000 ERROR apps.epg boom failure',
+        '2026-07-15 10:00:03,000 NOTE core.tasks unknown level survives',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/noisy tick/);
+
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '30' },
+    });
+    expect(screen.queryByText(/noisy tick/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/noisy continuation/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/routine note/)).not.toBeInTheDocument();
+    expect(screen.getByText(/boom failure/)).toBeInTheDocument();
+    expect(screen.getByText(/unknown level survives/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '10' },
+    });
+    expect(screen.getByText(/noisy tick/)).toBeInTheDocument();
+  });
+
+  it('bundles TRACE into DEBUG for display and filtering', async () => {
+    localStorage.setItem('log-viewer-min-level', '10');
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 TRACE core.utils Redis persistence disabled',
+        '2026-08-21 10:00:01,000 INFO core.tasks routine tick',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/routine tick/);
+    expect(screen.getByText(/Redis persistence disabled/)).toBeInTheDocument();
+    expect(screen.getByText('DEBUG')).toHaveAttribute('title', 'TRACE');
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '20' },
+    });
+    expect(
+      screen.queryByText(/Redis persistence disabled/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps a whole traceback when filtering, and reports an empty result', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-07-15 10:00:00,000 ERROR apps.epg refresh failed',
+        'Traceback (most recent call last):',
+        '  File "/app/x.py", line 1, in run',
+        'ValueError: bad m3u',
+        '2026-07-15 10:00:01,000 DEBUG core.tasks quiet',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/refresh failed/);
+
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '40' },
+    });
+    expect(screen.getByText(/ValueError: bad m3u/)).toBeInTheDocument();
+    expect(screen.queryByText(/quiet/)).not.toBeInTheDocument();
+
+    API.getLogFile.mockResolvedValue({
+      content: '2026-07-15 10:00:01,000 DEBUG core.tasks quiet\n',
+      truncated: false,
+    });
+    fireEvent.click(screen.getByText('Refresh'));
+    await waitFor(() => {
+      expect(
+        screen.getByText('(no records match the filters)')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the columns out of the wrap and the hanging indent', async () => {
+    API.getLogFile.mockResolvedValue({
+      content:
+        '2026-08-21 10:00:00,000 WARNING plugins.event_channel_managarr scan slow',
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/scan slow/);
+    // Without both, the token wraps inside its own box or draws at the block's negative indent, off the left edge.
+    const opts = { whiteSpace: 'nowrap', textIndent: '0px' };
+    expect(screen.getByText('2026-08-21 10:00:00,000')).toHaveStyle(opts);
+    expect(screen.getByText('WARN')).toHaveStyle(opts);
+    expect(screen.getByTitle('plugins.event_channel_managarr')).toHaveStyle(
+      opts
+    );
+    expect(screen.getByText(/scan slow/)).not.toHaveStyle({
+      whiteSpace: 'nowrap',
+    });
+  });
+
+  it('wraps a long line under the message column instead of scrolling', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 ERROR postgres [312] STATEMENT:  ' +
+          'x'.repeat(4000),
+        '  continuation tail',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    const message = await screen.findByText(/STATEMENT/);
+    const pane = message.closest('div').parentElement;
+    expect(pane).toHaveStyle({
+      whiteSpace: 'pre-wrap',
+      overflowWrap: 'anywhere',
+    });
+    // 39ch = stamp 23 + level 5 + module 8 + 3 gaps.
+    const block = message.closest('div');
+    expect(block).toHaveStyle({
+      paddingLeft: 'calc(8px + 39ch)',
+      textIndent: '-39ch',
+    });
+    // Continuations already sit at that column, so they cancel the hang.
+    expect(screen.getByText(/continuation tail/).parentElement).toHaveStyle({
+      textIndent: '0px',
+    });
+  });
+
+  it('scrolls the records inside the panel, not the page', async () => {
+    renderPage();
+    await screen.findByText(/Scanning disk/);
+    // control group -> header row -> the panel header itself.
+    const header = screen.getByLabelText('Level').closest('div')
+      .parentElement.parentElement;
+    let scroller = screen.getByText(/Scanning disk/).parentElement;
+    while (scroller && getComputedStyle(scroller).overflow !== 'auto') {
+      scroller = scroller.parentElement;
+    }
+    expect(scroller).not.toBeNull();
+    expect(scroller.contains(header)).toBe(false);
+    expect(header.parentElement).toBe(scroller.parentElement);
+    expect(scroller).toHaveStyle({ flex: '1 1 auto', minHeight: '0px' });
+  });
+
+  it('holds the message column still while the filters change', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO plugins.event_channel_managarr scan done',
+        '2026-08-21 10:00:01,000 INFO core.tasks tick',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/scan done/);
+    // 23 stamp + 5 level + 12 module (capped) + 3 separators.
+    const indent = { paddingLeft: 'calc(8px + 43ch)', textIndent: '-43ch' };
+    expect(screen.getByText(/tick/).closest('div')).toHaveStyle(indent);
+    // Filtering the long module out of view must not re-measure the columns.
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: 'tick' },
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(/scan done/)).not.toBeInTheDocument()
+    );
+    expect(screen.getByText(/tick/).closest('div')).toHaveStyle(indent);
+  });
+
+  it('dims the lines no record owns', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 ERROR apps.vod batch failed',
+        'raw daemon chatter nothing stamped',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/batch failed/);
+    expect(screen.getByText(/raw daemon chatter/)).toHaveStyle({
+      color: '#a1a1aa',
+    });
+    expect(screen.getByText(/batch failed/)).toHaveStyle({ color: '#ff6b6b' });
+  });
+
+  it('drops the severity bar once every visible row would wear one', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO core.tasks tick',
+        '2026-08-21 10:00:01,000 WARNING core.utils cache miss',
+        '2026-08-21 10:00:02,000 ERROR apps.epg boom',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/boom/);
+    const bar = (text) => screen.getByText(text).closest('div');
+    expect(bar(/cache miss/)).toHaveStyle({ borderLeft: '2px solid #ffd43b' });
+    expect(bar(/boom/)).toHaveStyle({ borderLeft: '2px solid #ff6b6b' });
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '30' },
+    });
+    expect(bar(/cache miss/)).not.toHaveStyle({
+      borderLeft: '2px solid #ffd43b',
+    });
+    expect(bar(/boom/)).toHaveStyle({ borderLeft: '2px solid #ff6b6b' });
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '40' },
+    });
+    expect(bar(/boom/)).not.toHaveStyle({ borderLeft: '2px solid #ff6b6b' });
+    expect(screen.getByText(/boom/)).toHaveStyle({ color: '#ff6b6b' });
+  });
+
+  it('states an empty result in the app voice, not the log font', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: '2026-08-21 10:00:00,000 INFO core.tasks tick',
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/tick/);
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: 'nothing matches this' },
+    });
+    expect(
+      await screen.findByText('(no records match the filters)')
+    ).toHaveAttribute('data-colour', 'dimmed');
+  });
+
+  it('aligns tokens in equal-width columns', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO core.tasks short module line',
+        '2026-08-21 10:00:01,000 ERROR plugins.event_channel_managarr long module line',
+        '    trailing continuation detail',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/short module line/);
+    // The module column caps at 12ch however long the module is.
+    expect(screen.getByTitle('core.tasks')).toHaveStyle({ width: '12ch' });
+    expect(screen.getByTitle('plugins.event_channel_managarr')).toHaveStyle({
+      width: '12ch',
+    });
+    expect(screen.getByText(/long module line/).closest('div')).toHaveStyle({
+      paddingLeft: 'calc(8px + 43ch)',
+      textIndent: '-43ch',
+    });
+    expect(
+      screen.getByText(/trailing continuation detail/).parentElement
+    ).toHaveStyle({ textIndent: '0px' });
+  });
+
+  it('compresses level display names without touching their rank', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 CRITICAL core.tasks meltdown',
+        '2026-08-21 10:00:01,000 WARNING core.utils toasty',
+        '2026-08-21 10:00:02,000 DEBUG core.utils chatter',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/meltdown/);
+    expect(screen.getByText('ERROR')).toHaveAttribute('title', 'CRITICAL');
+    expect(screen.getByText('WARN')).toHaveAttribute('title', 'WARNING');
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '40' },
+    });
+    expect(screen.getByText(/meltdown/)).toBeInTheDocument();
+    expect(screen.queryByText(/toasty/)).not.toBeInTheDocument();
+  });
+
+  it('keeps a plugin submodule under its plugin key', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO plugins.iptv_checker sweep started',
+        '2026-08-21 10:00:01,000 INFO plugins.iptv_checker.scheduled nightly run',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/sweep started/);
+    expect(
+      screen.getByTitle('plugins.iptv_checker.scheduled').textContent
+    ).toBe('iptv_checker');
+    expect(screen.getByTitle('plugins.iptv_checker').textContent).toBe(
+      'iptv_checker'
+    );
+  });
+
+  it('claims the column-0 tail of a traceback the collector stamped', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO stdout Traceback (most recent call last):',
+        '  File "/app/x.py", line 12, in run',
+        'ValueError: bad feed',
+        'During handling of the above exception, another exception occurred:',
+        '2026-08-21 10:00:01,000 INFO core.tasks back to normal',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/back to normal/);
+    const tail = screen.getByText(/ValueError: bad feed/);
+    expect(tail.textContent).toContain(
+      'During handling of the above exception'
+    );
+    expect(tail.parentElement).toHaveStyle({ textIndent: '0px' });
+    fireEvent.change(screen.getByLabelText('Category'), {
+      target: { value: 'app' },
+    });
+    expect(screen.queryByText(/ValueError: bad feed/)).not.toBeInTheDocument();
+    expect(screen.getByText(/back to normal/)).toBeInTheDocument();
+  });
+
+  it('keeps a record whose level the collector invented, at any floor', async () => {
+    // The collector stamps an unattributable line INFO stdout; honouring that invented level hides the tail of an ERROR traceback.
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 ERROR core.tasks Traceback (most recent call last):',
+        '  File "/app/x.py", line 3, in run',
+        '2026-08-21 10:00:00,001 INFO stdout ValueError: the actual failure',
+        '2026-08-21 10:00:01,000 INFO core.tasks routine tick',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/routine tick/);
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '40' },
+    });
+    expect(screen.queryByText(/routine tick/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/ValueError: the actual failure/)
+    ).toBeInTheDocument();
+  });
+
+  it('leaves an unowned continuation run unowned when the order flips', async () => {
+    // Reversing entries would graft a headless continuation onto an unrelated record, inside its block and behind its bar.
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '  orphaned frame from a record the tail cut off',
+        '2026-08-21 10:00:01,000 ERROR apps.epg refresh failed',
+      ].join('\n'),
+      truncated: true,
+    });
+    renderPage();
+    await screen.findByText(/orphaned frame/);
+    const owner = screen.getByText(/refresh failed/).closest('div');
+    expect(owner.textContent).not.toContain('orphaned frame');
+    fireEvent.change(screen.getByLabelText('Order'), {
+      target: { value: 'newest' },
+    });
+    const afterFlip = screen.getByText(/refresh failed/).closest('div');
+    expect(afterFlip.textContent).not.toContain('orphaned frame');
+    expect(screen.getByText(/orphaned frame/)).toBeInTheDocument();
+  });
+
+  it('keeps the byte of a single blank continuation line', async () => {
+    // Joined to '' a lone blank renders no text node, and a div with no line box drops the byte from the DOM and the copy buffer.
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 ERROR core.tasks Traceback (most recent call last):',
+        '',
+        'ValueError: bad feed',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/Traceback/);
+    const segments = screen.getByText(/ValueError/).parentElement;
+    const blank = segments.children[0];
+    expect(blank).toHaveStyle({ lineHeight: '0.35' });
+    expect(blank.textContent).toBe('\n');
+  });
+
+  it('never hides the collector pass-through records behind a filter', async () => {
+    // A known source shape with an unparseable date reaches the viewer unstamped.
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 DEBUG core.utils quiet tick',
+        '345:M 99 Xxx 2026 01:00:07.211 # Memory overcommit must be enabled',
+        '2026-08-21 10:00:01,000 ERROR apps.epg boom failure',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/boom failure/);
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '30' },
+    });
+    expect(screen.queryByText(/quiet tick/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Memory overcommit/)).toBeInTheDocument();
+  });
+
+  it('tokenizes a record whose message carries a bare carriage return', async () => {
+    API.getLogFile.mockResolvedValue({
+      content:
+        '2026-08-21 10:00:00,000 INFO stdout frame=1 fps=0\rframe=30 fps=29',
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/frame=1/);
+    // JS '.' excludes \r; the [\s\S] body keeps this one record.
+    expect(screen.getByTitle('stdout')).toHaveTextContent('stdout');
+    expect(screen.getByText(/frame=1/).textContent).toContain('frame=30');
+  });
+
+  it('does not invent a separator the file lacks', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: '2026-08-21 10:00:00,000 INFO core.tasks',
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText('INFO');
+    expect(screen.getByText('INFO').closest('div').textContent).toBe(
+      '2026-08-21 10:00:00,000 INFO core'
+    );
+  });
+
+  it('filters by category, the only record filter besides level and text', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO apps.epg.tasks app line',
+        '2026-08-21 10:00:01,000 INFO postgres [312] LOG:  daemon line',
+        '2026-08-21 10:00:02,000 INFO celery.beat framework line',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/app line/);
+    expect(screen.queryByLabelText('Module')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Category'), {
+      target: { value: 'services' },
+    });
+    // Services covers native daemons and third-party Python alike.
+    expect(screen.getByText(/daemon line/)).toBeInTheDocument();
+    expect(screen.getByText(/framework line/)).toBeInTheDocument();
+    expect(screen.queryByText(/app line/)).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Level'), {
+      target: { value: '10' },
+    });
+    expect(screen.queryByLabelText('Module')).not.toBeInTheDocument();
+  });
+
+  it('collects the plugin infrastructure under the Plugins category', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO apps.plugins.loader Discovered 5 plugin(s)',
+        '2026-08-21 10:00:01,000 INFO plugins.epg_watchdog Sweep done',
+        '2026-08-21 10:00:02,000 INFO apps.epg.tasks epg tick',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/epg tick/);
+    fireEvent.change(screen.getByLabelText('Category'), {
+      target: { value: 'plugins' },
+    });
+    // Plugin infrastructure files with the plugins it manages, renamed so the plugins token stays third-party.
+    expect(screen.getByText(/Discovered 5 plugin/)).toBeInTheDocument();
+    expect(screen.getByText(/Sweep done/)).toBeInTheDocument();
+    expect(screen.queryByText(/epg tick/)).not.toBeInTheDocument();
+    expect(screen.getByTitle('apps.plugins.loader')).toHaveTextContent(
+      'plugin_sys'
+    );
+  });
+
+  it('maps the loader import name to the plugin key under Plugins', async () => {
+    localStorage.setItem('log-viewer-min-level', '10');
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO _dispatcharr_plugin_epg_watchdog.plugin Sweep done',
+        '2026-08-21 10:00:01,000 DEBUG django.geventpool DB connection reused',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/Sweep done/);
+    // getLogger(__name__) inside a plugin wears the loader's import name.
+    expect(
+      screen.getByTitle('_dispatcharr_plugin_epg_watchdog.plugin')
+    ).toHaveTextContent('epg_watchdog');
+    // First-party pool code under the django namespace files with App.
+    expect(screen.getByTitle('django.geventpool')).toHaveTextContent(
+      'geventpool'
+    );
+    fireEvent.change(screen.getByLabelText('Category'), {
+      target: { value: 'app' },
+    });
+    expect(screen.getByText(/DB connection reused/)).toBeInTheDocument();
+    expect(screen.queryByText(/Sweep done/)).not.toBeInTheDocument();
+  });
+
+  it('does not re-filter on every keystroke', async () => {
+    // Each pass rebuilds up to MAX_RENDER_LINES blocks, so a typed word must cost one filter, not one per letter.
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO core.tasks alpha',
+        '2026-08-21 10:00:01,000 INFO core.tasks beta',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/alpha/);
+    const box = screen.getByLabelText('Search');
+    for (const value of ['b', 'be', 'bet', 'beta']) {
+      fireEvent.change(box, { target: { value } });
+    }
+    // Mid-word the list is untouched: no intermediate filter ran.
+    expect(screen.getByText(/alpha/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText(/alpha/)).not.toBeInTheDocument()
+    );
+    expect(screen.getByText(/beta/)).toBeInTheDocument();
+  });
+
+  it('filters by free text across whole record blocks', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 INFO core.tasks alpha event',
+        '2026-08-21 10:00:01,000 ERROR apps.epg refresh failed',
+        'Traceback (most recent call last):',
+        'ValueError: beta marker',
+        '2026-08-21 10:00:02,000 INFO core.tasks gamma event',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/alpha event/);
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: 'beta' },
+    });
+    await waitFor(() =>
+      expect(screen.queryByText(/alpha event/)).not.toBeInTheDocument()
+    );
+    expect(screen.getByText(/refresh failed/)).toBeInTheDocument();
+    expect(screen.getByText(/Traceback/).textContent).toContain('beta marker');
+    expect(screen.queryByText(/gamma event/)).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: '' },
+    });
+    expect(await screen.findByText(/alpha event/)).toBeInTheDocument();
+  });
+
+  it('renders blank continuation runs at reduced height', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-08-21 10:00:00,000 ERROR apps.epg boom',
+        'Traceback (most recent call last):',
+        'ValueError: first',
+        '',
+        'During handling of the above exception, another exception occurred:',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/ValueError: first/);
+    const padded = screen.getByText(/ValueError: first/).parentElement;
+    // Three segments: text, the compressed blank run, text.
+    expect(padded.children).toHaveLength(3);
+    expect(padded.children[1]).toHaveStyle({ lineHeight: '0.35' });
+    expect(screen.getByText(/During handling/)).toBeInTheDocument();
+  });
+
+  it('keeps a multi-line record intact when reversed', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: [
+        '2026-07-15 10:00:00,000 ERROR apps.epg first failure',
+        '    continuation of the first record',
+        '2026-07-15 10:00:01,000 ERROR apps.epg second failure',
+      ].join('\n'),
+      truncated: false,
+    });
+    renderPage();
+    await screen.findByText(/second failure/);
+    fireEvent.change(screen.getByLabelText('Order'), {
+      target: { value: 'newest' },
+    });
+    const text = document.body.textContent;
+    expect(text.indexOf('second failure')).toBeLessThan(
+      text.indexOf('first failure')
+    );
+    expect(text.indexOf('first failure')).toBeLessThan(
+      text.indexOf('continuation of the first record')
+    );
+  });
+});

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -779,13 +779,13 @@ describe('LogFileViewPage', () => {
     expect(screen.getByText(/back to normal/)).toBeInTheDocument();
   });
 
-  it('keeps a record whose level the collector invented, at any floor', async () => {
-    // INFO stdout is the collector's invention; gating on it hides an ERROR tail.
+  it('gates a record whose level the collector invented like any other', async () => {
+    // The floor exemption belongs to the sinks; a filtered view is reversible.
     API.getLogFile.mockResolvedValue({
       content: [
         '2026-08-21 10:00:00,000 ERROR core.tasks Traceback (most recent call last):',
         '  File "/app/x.py", line 3, in run',
-        '2026-08-21 10:00:00,001 INFO stdout ValueError: the actual failure',
+        '2026-08-21 10:00:00,001 INFO stdout Setting up PostgreSQL...',
         '2026-08-21 10:00:01,000 INFO core.tasks routine tick',
       ].join('\n'),
       truncated: false,
@@ -797,8 +797,9 @@ describe('LogFileViewPage', () => {
     });
     expect(screen.queryByText(/routine tick/)).not.toBeInTheDocument();
     expect(
-      screen.getByText(/ValueError: the actual failure/)
-    ).toBeInTheDocument();
+      screen.queryByText(/Setting up PostgreSQL/)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Traceback/)).toBeInTheDocument();
   });
 
   it('leaves an unowned continuation run unowned when the order flips', async () => {

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -58,7 +58,12 @@ vi.mock('react-virtualized', async () => {
       const rows = [];
       for (let i = start; i < Math.min(end, props.rowCount); i += 1) {
         rows.push(
-          props.rowRenderer({ index: i, key: i, parent: null, style: {} })
+          props.rowRenderer({
+            index: i,
+            key: i,
+            parent: null,
+            style: { position: 'absolute', height: 18 },
+          })
         );
       }
       return (
@@ -1391,13 +1396,17 @@ describe('LogFileViewPage', () => {
     expect(list.recompute).toHaveBeenCalled();
   });
 
-  it('measures by block id rather than by position', async () => {
+  it('measures by block id, and lets content set the height', async () => {
     renderPage();
     await screen.findByText(/Scanning disk/);
     expect(list.cache.fixedWidth).toBe(true);
     // Ids climb from a module counter, so a first block never keys as its index.
     expect(list.cache.keyMapper(0)).toBeGreaterThan(0);
-    // Past the end there is no block to key on and the index has to do.
-    expect(list.cache.keyMapper(9999)).toBe(9999);
+    // Ids are integers, so a past-the-end fallback must not read as one.
+    expect(list.cache.keyMapper(9999)).toBe('row-9999');
+    // Measuring an element the grid already sized returns that size back.
+    expect(screen.getByTestId('log-list').firstElementChild.style.height).toBe(
+      'auto'
+    );
   });
 });

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -146,7 +146,10 @@ describe('LogFileViewPage', () => {
     API.getLogFile.mockResolvedValue({ content: 'tail', truncated: true });
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText(/showing the last 10 MB/i)).toBeInTheDocument();
+      // The size itself is asserted where the payload is big enough to show one.
+      expect(
+        screen.getByText(/Showing the last [\d.]+ (Bytes|KB|MB) of the log/)
+      ).toBeInTheDocument();
     });
   });
 
@@ -381,7 +384,7 @@ describe('LogFileViewPage', () => {
     expect(screen.queryByText('(empty)')).not.toBeInTheDocument();
     // The fetch cap is the only bound left that can hide records.
     expect(
-      screen.getByText(/Showing the last 10 MB of the file/)
+      screen.getByText(/Showing the last [\d.]+ MB of the log/)
     ).toBeInTheDocument();
     expect(screen.queryByText(/record-0\b/)).not.toBeInTheDocument();
   }, 60000);

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -335,8 +335,11 @@ describe('LogFileViewPage', () => {
     );
     expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
     expect(screen.queryByText('(empty)')).not.toBeInTheDocument();
+    // Both bounds bite here, so the truncation must not be shadowed by the window.
     expect(
-      screen.getByText(/Showing the last [\d,]+ lines/)
+      screen.getByText(
+        /Showing the last 5 MB of the file, then the last [\d,]+ lines/
+      )
     ).toBeInTheDocument();
     expect(screen.queryByText(/record-0\b/)).not.toBeInTheDocument();
   }, 60000);

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -25,32 +25,45 @@ vi.mock('@mantine/notifications', () => ({
 const list = vi.hoisted(() => ({
   scrollToRow: vi.fn(),
   recompute: vi.fn(),
-  cache: null,
+  measureAll: vi.fn(),
   props: null,
   ROWS: 46,
 }));
 
 vi.mock('react-virtualized/styles.css', () => ({}));
 
+// jsdom lays nothing out: text gets a width so a long line overflows its span.
+const mockOverflow = ({ offsetHeight = 0 } = {}) => {
+  const saved = {};
+  const define = (key, get) => {
+    saved[key] = Object.getOwnPropertyDescriptor(HTMLElement.prototype, key);
+    Object.defineProperty(HTMLElement.prototype, key, {
+      configurable: true,
+      get,
+    });
+  };
+  define('scrollWidth', function () {
+    return this.textContent.length * 7;
+  });
+  define('clientWidth', () => 700);
+  define('offsetHeight', () => offsetHeight);
+  return () => {
+    for (const [key, desc] of Object.entries(saved)) {
+      if (desc) Object.defineProperty(HTMLElement.prototype, key, desc);
+      else delete HTMLElement.prototype[key];
+    }
+  };
+};
+
 vi.mock('react-virtualized', async () => {
   const React = await vi.importActual('react');
   return {
-    AutoSizer: ({ children, onResize }) => {
-      list.onResize = onResize;
-      return children({ width: 1000, height: 600 });
-    },
-    CellMeasurer: ({ children }) => children({ registerChild: () => {} }),
-    CellMeasurerCache: class {
-      constructor(options) {
-        list.cache = options;
-        this.rowHeight = () => 18;
-      }
-      clearAll() {}
-    },
+    AutoSizer: ({ children }) => children({ width: 1000, height: 600 }),
     List: React.forwardRef((props, ref) => {
       list.props = props;
       React.useImperativeHandle(ref, () => ({
         recomputeRowHeights: list.recompute,
+        measureAllRows: list.measureAll,
       }));
       const anchor = props.scrollToIndex;
       const end = anchor ? anchor + 1 : Math.min(list.ROWS, props.rowCount);
@@ -231,10 +244,12 @@ describe('LogFileViewPage', () => {
     expect(screen.getByText('ERROR').closest('div')).toHaveStyle({
       borderLeft: '2px solid #ff6b6b',
     });
-    // The traceback, its column-0 tail included, is one joined text node.
-    expect(screen.getByText(/Traceback/).textContent).toContain(
-      'ValueError: bad feed'
-    );
+    // Every traceback line, its column-0 tail included, rides the record's bar.
+    for (const line of [/Traceback/, /line 214, in refresh/, /bad feed/]) {
+      expect(screen.getByText(line).closest('div')).toHaveStyle({
+        borderLeft: '2px solid #ff6b6b',
+      });
+    }
     expect(screen.getByText(/back to normal/).closest('div')).not.toHaveStyle({
       borderLeft: '2px solid #ff6b6b',
     });
@@ -646,31 +661,41 @@ describe('LogFileViewPage', () => {
     });
   });
 
-  it('wraps a long line under the message column instead of scrolling', async () => {
-    API.getLogFile.mockResolvedValue({
-      content: [
-        '2026-08-21 10:00:00,000 ERROR postgres [312] STATEMENT:  ' +
-          'x'.repeat(4000),
-        '  continuation tail',
-      ].join('\n'),
-      truncated: false,
-    });
-    renderPage();
-    const message = await screen.findByText(/STATEMENT/);
-    expect(screen.getByTestId('log-list')).toHaveStyle({
-      whiteSpace: 'pre-wrap',
-      overflowWrap: 'anywhere',
-    });
-    // 39ch = stamp 23 + level 5 + module 8 + 3 gaps.
-    const block = message.closest('div');
-    expect(block).toHaveStyle({
-      paddingLeft: 'calc(8px + 39ch)',
-      textIndent: '-39ch',
-    });
-    // Continuations already sit at that column, so they cancel the hang.
-    expect(screen.getByText(/continuation tail/).parentElement).toHaveStyle({
-      textIndent: '0px',
-    });
+  it('clips a long line to one row, and wraps it under the message column on demand', async () => {
+    const restore = mockOverflow();
+    try {
+      API.getLogFile.mockResolvedValue({
+        content: [
+          '2026-08-21 10:00:00,000 ERROR postgres [312] STATEMENT:  ' +
+            'x'.repeat(4000),
+          '  continuation tail',
+        ].join('\n'),
+        truncated: false,
+      });
+      renderPage();
+      const message = await screen.findByText(/STATEMENT/);
+      const text = message.parentElement;
+      expect(message.closest('div')).toHaveStyle({ height: '18px' });
+      expect(text).toHaveStyle({ whiteSpace: 'pre', overflow: 'hidden' });
+      fireEvent.click(
+        await screen.findByRole('button', {
+          name: /^\+[\d,]+ chars$/,
+        })
+      );
+      // 39ch = stamp 23 + level 5 + module 8 + 3 gaps.
+      expect(text).toHaveStyle({
+        whiteSpace: 'pre-wrap',
+        overflowWrap: 'anywhere',
+        paddingLeft: '39ch',
+        textIndent: '-39ch',
+      });
+      // Continuations already sit at that column.
+      expect(screen.getByText(/continuation tail/).closest('div')).toHaveStyle({
+        paddingLeft: 'calc(8px + 39ch)',
+      });
+    } finally {
+      restore();
+    }
   });
 
   it('scrolls the records inside the panel, not the page', async () => {
@@ -699,9 +724,9 @@ describe('LogFileViewPage', () => {
     });
     renderPage();
     await screen.findByText(/scan done/);
-    // 23 stamp + 5 level + 12 module (capped) + 3 separators.
-    const indent = { paddingLeft: 'calc(8px + 43ch)', textIndent: '-43ch' };
-    expect(screen.getByText(/tick/).closest('div')).toHaveStyle(indent);
+    // The long module sets the capped column every row keeps.
+    const column = { width: '12ch' };
+    expect(screen.getByTitle('core.tasks')).toHaveStyle(column);
     // Filtering the long module out of view must not re-measure the columns.
     fireEvent.change(screen.getByLabelText('Search'), {
       target: { value: 'tick' },
@@ -709,7 +734,7 @@ describe('LogFileViewPage', () => {
     await waitFor(() =>
       expect(screen.queryByText(/scan done/)).not.toBeInTheDocument()
     );
-    expect(screen.getByText(/tick/).closest('div')).toHaveStyle(indent);
+    expect(screen.getByTitle('core.tasks')).toHaveStyle(column);
   });
 
   it('dims the lines no record owns', async () => {
@@ -787,13 +812,10 @@ describe('LogFileViewPage', () => {
     expect(screen.getByTitle('plugins.event_channel_managarr')).toHaveStyle({
       width: '12ch',
     });
-    expect(screen.getByText(/long module line/).closest('div')).toHaveStyle({
-      paddingLeft: 'calc(8px + 43ch)',
-      textIndent: '-43ch',
-    });
+    // Continuations start at the message column the capped module sets.
     expect(
-      screen.getByText(/trailing continuation detail/).parentElement
-    ).toHaveStyle({ textIndent: '0px' });
+      screen.getByText(/trailing continuation detail/).closest('div')
+    ).toHaveStyle({ paddingLeft: 'calc(8px + 43ch)' });
   });
 
   it('compresses level display names without touching their rank', async () => {
@@ -848,11 +870,12 @@ describe('LogFileViewPage', () => {
     });
     renderPage();
     await screen.findByText(/back to normal/);
-    const tail = screen.getByText(/ValueError: bad feed/);
-    expect(tail.textContent).toContain(
-      'During handling of the above exception'
+    // Claimed, the column-0 tail sits at the traceback's column, not at 8px.
+    const row = (text) => screen.getByText(text).closest('div');
+    expect(row(/During handling/).style.paddingLeft).not.toBe('8px');
+    expect(row(/During handling/).style.paddingLeft).toBe(
+      row(/ValueError: bad feed/).style.paddingLeft
     );
-    expect(tail.parentElement).toHaveStyle({ textIndent: '0px' });
     fireEvent.change(screen.getByLabelText('Category'), {
       target: { value: 'app' },
     });
@@ -902,8 +925,7 @@ describe('LogFileViewPage', () => {
     expect(screen.getByText(/orphaned frame/)).toBeInTheDocument();
   });
 
-  it('keeps the byte of a single blank continuation line', async () => {
-    // Joined to '' a lone blank renders no text node and drops from the copy buffer.
+  it('gives a blank continuation line a row of its own', async () => {
     API.getLogFile.mockResolvedValue({
       content: [
         '2026-08-21 10:00:00,000 ERROR core.tasks refresh failed',
@@ -915,10 +937,10 @@ describe('LogFileViewPage', () => {
     });
     renderPage();
     await screen.findByText(/Traceback/);
-    const segments = screen.getByText(/ValueError/).parentElement;
-    const blank = segments.children[1];
-    expect(blank).toHaveStyle({ lineHeight: '0.35' });
-    expect(blank.textContent).toBe('\n');
+    const rows = screen.getByTestId('log-list').children;
+    expect(rows).toHaveLength(4);
+    expect(rows[2].textContent).toBe('');
+    expect(rows[2].firstChild).toHaveStyle({ height: '18px' });
   });
 
   it('does not render the newline that ends the body as a blank line', async () => {
@@ -926,11 +948,9 @@ describe('LogFileViewPage', () => {
       content: '2026-08-21 10:00:00,000 INFO core.tasks hello there\n',
       truncated: false,
     });
-    const { container } = renderPage();
+    renderPage();
     await screen.findByText(/hello there/);
-    expect(
-      container.querySelector('div[style*="line-height: 0.35"]')
-    ).toBeNull();
+    expect(screen.getByTestId('log-list').children).toHaveLength(1);
   });
 
   it('never hides the collector pass-through records behind a filter', async () => {
@@ -1104,32 +1124,14 @@ describe('LogFileViewPage', () => {
       expect(screen.queryByText(/alpha event/)).not.toBeInTheDocument()
     );
     expect(screen.getByText(/refresh failed/)).toBeInTheDocument();
-    expect(screen.getByText(/Traceback/).textContent).toContain('beta marker');
+    // Matching one continuation keeps the whole block.
+    expect(screen.getByText(/Traceback/)).toBeInTheDocument();
+    expect(screen.getByText(/beta marker/)).toBeInTheDocument();
     expect(screen.queryByText(/gamma event/)).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('Search'), {
       target: { value: '' },
     });
     expect(await screen.findByText(/alpha event/)).toBeInTheDocument();
-  });
-
-  it('renders blank continuation runs at reduced height', async () => {
-    API.getLogFile.mockResolvedValue({
-      content: [
-        '2026-08-21 10:00:00,000 ERROR apps.epg boom',
-        'Traceback (most recent call last):',
-        'ValueError: first',
-        '',
-        'During handling of the above exception, another exception occurred:',
-      ].join('\n'),
-      truncated: false,
-    });
-    renderPage();
-    await screen.findByText(/ValueError: first/);
-    const padded = screen.getByText(/ValueError: first/).parentElement;
-    // Three segments: text, the compressed blank run, text.
-    expect(padded.children).toHaveLength(3);
-    expect(padded.children[1]).toHaveStyle({ lineHeight: '0.35' });
-    expect(screen.getByText(/During handling/)).toBeInTheDocument();
   });
 
   it('keeps a multi-line record intact when reversed', async () => {
@@ -1234,11 +1236,12 @@ describe('LogFileViewPage', () => {
     });
     await screen.findByText(/ValueError: bad m3u/);
 
-    // Structure, not presence: the tail must land inside the record's block.
-    const block = screen
-      .getByText(/Traceback \(most recent call last\)/)
-      .closest('div');
-    expect(block.textContent).toContain('ValueError: bad m3u');
+    // Structure, not presence: a stray tail would sit at 8px as a plain line.
+    const row = (text) => screen.getByText(text).closest('div');
+    expect(row(/bad m3u/)).toHaveStyle({ borderLeft: '2px solid #ff6b6b' });
+    expect(row(/bad m3u/).style.paddingLeft).toBe(
+      row(/Traceback \(most recent call last\)/).style.paddingLeft
+    );
   });
 
   it('does not append the same delta twice when two loads overlap', async () => {
@@ -1386,27 +1389,80 @@ describe('LogFileViewPage', () => {
     expect(list.props.scrollToIndex).toBe(list.props.rowCount - 1);
   });
 
-  it('drops measured heights when the viewport rewraps the lines', async () => {
+  it('sizes every collapsed row exactly, so the extent is known before paint', async () => {
     renderPage();
     await screen.findByText(/Scanning disk/);
-    list.recompute.mockClear();
-    act(() => {
-      list.onResize({ width: 400, height: 600 });
-    });
-    expect(list.recompute).toHaveBeenCalled();
+    expect(list.props.estimatedRowSize).toBe(18);
+    for (let index = 0; index < list.props.rowCount; index += 1) {
+      expect(list.props.rowHeight({ index })).toBe(18);
+    }
   });
 
-  it('measures by block id, and lets content set the height', async () => {
-    renderPage();
-    await screen.findByText(/Scanning disk/);
-    expect(list.cache.fixedWidth).toBe(true);
-    // Ids climb from a module counter, so a first block never keys as its index.
-    expect(list.cache.keyMapper(0)).toBeGreaterThan(0);
-    // Ids are integers, so a past-the-end fallback must not read as one.
-    expect(list.cache.keyMapper(9999)).toBe('row-9999');
-    // Measuring an element the grid already sized returns that size back.
-    expect(screen.getByTestId('log-list').firstElementChild.style.height).toBe(
-      'auto'
-    );
+  it('sizes an expanded row by its content, and restores it on collapse', async () => {
+    const restore = mockOverflow({ offsetHeight: 90 });
+    try {
+      API.getLogFile.mockResolvedValue({
+        content:
+          '2026-08-21 10:00:00,000 ERROR postgres long ' + 'x'.repeat(4000),
+        truncated: false,
+      });
+      renderPage();
+      const toggle = await screen.findByRole('button', {
+        name: /^\+[\d,]+ chars$/,
+      });
+      list.recompute.mockClear();
+      expect(list.props.scrollToIndex).toBe(0);
+      fireEvent.click(toggle);
+      expect(list.props.scrollToIndex).toBeUndefined();
+      expect(list.props.rowHeight({ index: 0 })).toBe(90);
+      expect(list.recompute).toHaveBeenCalled();
+      // Summed over every row, so an expanded row below the view still counts.
+      expect(list.measureAll).toHaveBeenCalled();
+      fireEvent.click(toggle);
+      expect(list.props.rowHeight({ index: 0 })).toBe(18);
+    } finally {
+      restore();
+    }
+  });
+
+  it('keeps the count on an expanded row that leaves the window and returns', async () => {
+    const restore = mockOverflow({ offsetHeight: 90 });
+    try {
+      const lines = [];
+      for (let i = 0; i < list.ROWS + 5; i += 1) {
+        lines.push(`2026-08-21 10:00:00,000 INFO core.tasks line ${i}`);
+      }
+      lines.push('2026-08-21 10:00:01,000 ERROR postgres ' + 'x'.repeat(4000));
+      API.getLogFile.mockResolvedValue({
+        content: lines.join('\n'),
+        truncated: false,
+      });
+      renderPage();
+      const name = /^\+[\d,]+ chars$/;
+      const label = (await screen.findByRole('button', { name })).textContent;
+      // Stops following, so the window leaves the row and it unmounts.
+      fireEvent.click(screen.getByRole('button', { name }));
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
+      // Back at the live edge; the first report only lands the pin.
+      const edge = { clientHeight: 500, scrollHeight: 5000, scrollTop: 4500 };
+      act(() => list.props.onScroll(edge));
+      act(() => list.props.onScroll(edge));
+      expect(screen.getByRole('button', { name })).toHaveTextContent(label);
+    } finally {
+      restore();
+    }
+  });
+
+  it('offers no toggle for a line that fits', async () => {
+    const restore = mockOverflow();
+    try {
+      renderPage();
+      await screen.findByText(/Scanning disk/);
+      expect(
+        screen.queryByRole('button', { name: /^\+[\d,]+ chars$/ })
+      ).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
   });
 });

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -368,7 +368,7 @@ describe('LogFileViewPage', () => {
       '2026-07-15 23:59:59,000 INFO core.tasks END-OF-SYNTHETIC-LOG-MARKER'
     );
     const content = lines.join('\n');
-    // The payload must genuinely approach the 5 MB truncation ceiling.
+    // The payload must genuinely approach the truncation ceiling.
     expect(content.length).toBeGreaterThan(4 * 1024 * 1024);
 
     API.getLogFile.mockResolvedValue({ content, truncated: true });

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -93,6 +93,7 @@ describe('LogFileViewPage', () => {
     });
     expect(API.getLogFile).toHaveBeenCalledWith('dispatcharr.log', {
       silent: false,
+      cursor: null,
     });
     expect(screen.getByText('dispatcharr.log')).toBeInTheDocument();
   });
@@ -801,9 +802,7 @@ describe('LogFileViewPage', () => {
       target: { value: '40' },
     });
     expect(screen.queryByText(/routine tick/)).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/Setting up PostgreSQL/)
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Setting up PostgreSQL/)).not.toBeInTheDocument();
     expect(screen.getByText(/Traceback/)).toBeInTheDocument();
   });
 
@@ -1057,6 +1056,130 @@ describe('LogFileViewPage', () => {
       text.indexOf('continuation of the first record')
     );
   });
+  it('appends an incremental delta instead of replacing the buffer', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: 'Info|core.tasks|first line\n',
+      truncated: false,
+      cursor: '99-30',
+      reset: true,
+    });
+    renderPage();
+    await screen.findByText(/first line/);
+
+    // Only the new bytes come back, and the cursor rides along on the next ask.
+    API.getLogFile.mockResolvedValue({
+      content: 'Info|core.tasks|second line\n',
+      truncated: false,
+      cursor: '99-61',
+      reset: false,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Refresh'));
+    });
+
+    await screen.findByText(/second line/);
+    // The first line is still there: the delta was appended, not swapped in.
+    expect(screen.getByText(/first line/)).toBeInTheDocument();
+    expect(API.getLogFile).toHaveBeenLastCalledWith('dispatcharr.log', {
+      silent: false,
+      cursor: '99-30',
+    });
+  });
+
+  it('replaces the buffer when the server reports a reset', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: 'Info|core.tasks|from the old file\n',
+      truncated: false,
+      cursor: '99-40',
+      reset: true,
+    });
+    renderPage();
+    await screen.findByText(/from the old file/);
+
+    // A rotation: the server resets rather than resuming a meaningless offset.
+    API.getLogFile.mockResolvedValue({
+      content: 'Info|core.tasks|from the new file\n',
+      truncated: false,
+      cursor: '100-40',
+      reset: true,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Refresh'));
+    });
+
+    await screen.findByText(/from the new file/);
+    expect(screen.queryByText(/from the old file/)).not.toBeInTheDocument();
+  });
+
+  it('keeps a traceback whole when it straddles two deltas', async () => {
+    API.getLogFile.mockResolvedValue({
+      content:
+        '2026-08-21 10:00:00,000 ERROR apps.epg Traceback (most recent call last):\n' +
+        '  File "/app/x.py", line 1, in run\n',
+      truncated: false,
+      cursor: '99-80',
+      reset: true,
+    });
+    renderPage();
+    await screen.findByText(/Traceback \(most recent call last\)/);
+
+    // The unindented exception line arrives in the next poll, on its own.
+    API.getLogFile.mockResolvedValue({
+      content: 'ValueError: bad m3u\n',
+      truncated: false,
+      cursor: '99-100',
+      reset: false,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Refresh'));
+    });
+    await screen.findByText(/ValueError: bad m3u/);
+
+    // Structure, not presence: the tail must land inside the record's block.
+    const block = screen
+      .getByText(/Traceback \(most recent call last\)/)
+      .closest('div');
+    expect(block.textContent).toContain('ValueError: bad m3u');
+  });
+
+  it('does not append the same delta twice when two loads overlap', async () => {
+    API.getLogFile.mockResolvedValue({
+      content: '2026-08-21 10:00:00,000 INFO core.tasks base line\n',
+      truncated: false,
+      cursor: '7-50',
+      reset: true,
+    });
+    renderPage();
+    await screen.findByText(/base line/);
+
+    // Both polls are issued against cursor 7-50 and return the same delta.
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+    const delta = {
+      content: '2026-08-21 10:00:01,000 INFO core.tasks second line\n',
+      truncated: false,
+      cursor: '7-100',
+      reset: false,
+    };
+    API.getLogFile.mockImplementation(async () => {
+      await gate;
+      return delta;
+    });
+
+    const refresh = screen.getByText('Refresh');
+    await act(async () => {
+      fireEvent.click(refresh);
+      fireEvent.click(refresh);
+      release();
+      await Promise.resolve();
+    });
+    await screen.findByText(/second line/);
+
+    expect(screen.getAllByText(/second line/)).toHaveLength(1);
+  });
+
   // jsdom performs no layout, so the scroll box reports zero for every metric.
   // Stub the geometry and let scrollTop behave like a real settable property.
   const stubViewport = (el, { scrollHeight, clientHeight }) => {

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -146,7 +146,7 @@ describe('LogFileViewPage', () => {
     API.getLogFile.mockResolvedValue({ content: 'tail', truncated: true });
     renderPage();
     await waitFor(() => {
-      expect(screen.getByText(/showing the last 5 MB/i)).toBeInTheDocument();
+      expect(screen.getByText(/showing the last 10 MB/i)).toBeInTheDocument();
     });
   });
 
@@ -381,7 +381,7 @@ describe('LogFileViewPage', () => {
     expect(screen.queryByText('(empty)')).not.toBeInTheDocument();
     // The fetch cap is the only bound left that can hide records.
     expect(
-      screen.getByText(/Showing the last 5 MB of the file/)
+      screen.getByText(/Showing the last 10 MB of the file/)
     ).toBeInTheDocument();
     expect(screen.queryByText(/record-0\b/)).not.toBeInTheDocument();
   }, 60000);

--- a/frontend/src/pages/__tests__/LogFileView.test.jsx
+++ b/frontend/src/pages/__tests__/LogFileView.test.jsx
@@ -21,14 +21,58 @@ vi.mock('@mantine/notifications', () => ({
   notifications: { show: vi.fn() },
 }));
 
+// jsdom lays nothing out: fixed geometry, and the window a real list keeps.
+const list = vi.hoisted(() => ({
+  scrollToRow: vi.fn(),
+  recompute: vi.fn(),
+  cache: null,
+  props: null,
+  ROWS: 46,
+}));
+
+vi.mock('react-virtualized/styles.css', () => ({}));
+
+vi.mock('react-virtualized', async () => {
+  const React = await vi.importActual('react');
+  return {
+    AutoSizer: ({ children, onResize }) => {
+      list.onResize = onResize;
+      return children({ width: 1000, height: 600 });
+    },
+    CellMeasurer: ({ children }) => children({ registerChild: () => {} }),
+    CellMeasurerCache: class {
+      constructor(options) {
+        list.cache = options;
+        this.rowHeight = () => 18;
+      }
+      clearAll() {}
+    },
+    List: React.forwardRef((props, ref) => {
+      list.props = props;
+      React.useImperativeHandle(ref, () => ({
+        recomputeRowHeights: list.recompute,
+      }));
+      const anchor = props.scrollToIndex;
+      const end = anchor ? anchor + 1 : Math.min(list.ROWS, props.rowCount);
+      const start = Math.max(0, end - list.ROWS);
+      const rows = [];
+      for (let i = start; i < Math.min(end, props.rowCount); i += 1) {
+        rows.push(
+          props.rowRenderer({ index: i, key: i, parent: null, style: {} })
+        );
+      }
+      return (
+        <div data-testid="log-list" style={props.style}>
+          {rows}
+        </div>
+      );
+    }),
+  };
+});
+
 vi.mock('@mantine/core', () => ({
   Anchor: ({ children, to }) => <a href={to || '#'}>{children}</a>,
-  // ref/onScroll pass through: the viewer pins itself to the live edge.
-  Box: ({ children, style, onScroll, ref }) => (
-    <div style={style} ref={ref} onScroll={onScroll}>
-      {children}
-    </div>
-  ),
+  Box: ({ children, style }) => <div style={style}>{children}</div>,
   Button: ({ children, onClick }) => (
     <button onClick={onClick}>{children}</button>
   ),
@@ -335,11 +379,9 @@ describe('LogFileViewPage', () => {
     );
     expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
     expect(screen.queryByText('(empty)')).not.toBeInTheDocument();
-    // Both bounds bite here, so the truncation must not be shadowed by the window.
+    // The fetch cap is the only bound left that can hide records.
     expect(
-      screen.getByText(
-        /Showing the last 5 MB of the file, then the last [\d,]+ lines/
-      )
+      screen.getByText(/Showing the last 5 MB of the file/)
     ).toBeInTheDocument();
     expect(screen.queryByText(/record-0\b/)).not.toBeInTheDocument();
   }, 60000);
@@ -607,8 +649,7 @@ describe('LogFileViewPage', () => {
     });
     renderPage();
     const message = await screen.findByText(/STATEMENT/);
-    const pane = message.closest('div').parentElement;
-    expect(pane).toHaveStyle({
+    expect(screen.getByTestId('log-list')).toHaveStyle({
       whiteSpace: 'pre-wrap',
       overflowWrap: 'anywhere',
     });
@@ -630,14 +671,14 @@ describe('LogFileViewPage', () => {
     // control group -> header row -> the panel header itself.
     const header = screen.getByLabelText('Level').closest('div')
       .parentElement.parentElement;
-    let scroller = screen.getByText(/Scanning disk/).parentElement;
-    while (scroller && getComputedStyle(scroller).overflow !== 'auto') {
-      scroller = scroller.parentElement;
-    }
-    expect(scroller).not.toBeNull();
-    expect(scroller.contains(header)).toBe(false);
-    expect(header.parentElement).toBe(scroller.parentElement);
-    expect(scroller).toHaveStyle({ flex: '1 1 auto', minHeight: '0px' });
+    const pane = screen.getByTestId('log-list').parentElement;
+    expect(pane.contains(header)).toBe(false);
+    expect(header.parentElement).toBe(pane.parentElement);
+    expect(pane).toHaveStyle({
+      flex: '1 1 auto',
+      minHeight: '0px',
+      overflow: 'hidden',
+    });
   });
 
   it('holds the message column still while the filters change', async () => {
@@ -1230,43 +1271,9 @@ describe('LogFileViewPage', () => {
     expect(screen.getAllByText(/second line/)).toHaveLength(1);
   });
 
-  // jsdom performs no layout, so the scroll box reports zero for every metric.
-  // Stub the geometry and let scrollTop behave like a real settable property.
-  const stubViewport = (el, { scrollHeight, clientHeight }) => {
-    let top = 0;
-    Object.defineProperty(el, 'scrollHeight', {
-      configurable: true,
-      get: () => scrollHeight,
-    });
-    Object.defineProperty(el, 'clientHeight', {
-      configurable: true,
-      get: () => clientHeight,
-    });
-    Object.defineProperty(el, 'scrollTop', {
-      configurable: true,
-      get: () => top,
-      set: (v) => {
-        top = v;
-      },
-    });
-    return el;
-  };
-
-  const findViewport = () => {
-    let el = screen.getByText(/Scanning disk/).parentElement;
-    while (el && getComputedStyle(el).overflow !== 'auto') {
-      el = el.parentElement;
-    }
-    return el;
-  };
-
   it('opens at the live edge instead of the oldest retained line', async () => {
     renderPage();
     await screen.findByText(/Scanning disk/);
-    const viewport = stubViewport(findViewport(), {
-      scrollHeight: 5000,
-      clientHeight: 500,
-    });
 
     API.getLogFile.mockResolvedValue({
       content:
@@ -1277,19 +1284,22 @@ describe('LogFileViewPage', () => {
       fireEvent.click(screen.getByText('Refresh'));
     });
 
-    expect(viewport.scrollTop).toBe(5000);
+    await screen.findByText(/later line/);
+    expect(list.props.scrollToIndex).toBe(list.props.rowCount - 1);
+    expect(list.props.scrollToAlignment).toBe('end');
   });
 
   it('keeps following the tail across a refresh', async () => {
     renderPage();
     await screen.findByText(/Scanning disk/);
-    const viewport = stubViewport(findViewport(), {
-      scrollHeight: 5000,
-      clientHeight: 500,
-    });
     // The reader is sitting at the bottom, watching.
-    viewport.scrollTop = 4500;
-    fireEvent.scroll(viewport);
+    act(() => {
+      list.props.onScroll({
+        clientHeight: 500,
+        scrollHeight: 5000,
+        scrollTop: 4500,
+      });
+    });
 
     API.getLogFile.mockResolvedValue({
       content:
@@ -1301,19 +1311,28 @@ describe('LogFileViewPage', () => {
     });
 
     await screen.findByText(/fresh line/);
-    expect(viewport.scrollTop).toBe(5000);
+    expect(list.props.scrollToIndex).toBe(list.props.rowCount - 1);
   });
 
   it('leaves a reader who scrolled back where they were', async () => {
     renderPage();
     await screen.findByText(/Scanning disk/);
-    const viewport = stubViewport(findViewport(), {
-      scrollHeight: 5000,
-      clientHeight: 500,
+    // Reaching the edge first, because that is where the viewer opens.
+    act(() => {
+      list.props.onScroll({
+        clientHeight: 500,
+        scrollHeight: 5000,
+        scrollTop: 4500,
+      });
     });
     // Scrolled up to read history: a refresh must not yank them to the bottom.
-    viewport.scrollTop = 1200;
-    fireEvent.scroll(viewport);
+    act(() => {
+      list.props.onScroll({
+        clientHeight: 500,
+        scrollHeight: 5000,
+        scrollTop: 1200,
+      });
+    });
 
     API.getLogFile.mockResolvedValue({
       content:
@@ -1324,7 +1343,58 @@ describe('LogFileViewPage', () => {
       fireEvent.click(screen.getByText('Refresh'));
     });
 
-    await screen.findByText(/fresh line/);
-    expect(viewport.scrollTop).toBe(1200);
+    await waitFor(() => expect(list.props.rowCount).toBe(2));
+    expect(list.props.scrollToIndex).toBeUndefined();
+  });
+
+  it('renders a window of rows, not the whole buffer', async () => {
+    const lines = [];
+    for (let i = 0; i < 400; i += 1) {
+      lines.push(`Info|core.tasks|windowed record-${i}`);
+    }
+    API.getLogFile.mockResolvedValue({
+      content: lines.join('\n') + '\n',
+      truncated: false,
+    });
+    renderPage();
+
+    await screen.findByText(/windowed record-399/);
+    expect(list.props.rowCount).toBe(400);
+    expect(screen.queryByText(/windowed record-0\b/)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/windowed record-/).length).toBeLessThan(100);
+  });
+
+  it('ignores the opening scroll report so the tail still pins', async () => {
+    renderPage();
+    await screen.findByText(/Scanning disk/);
+    // The grid says "top of the list" before it has applied the pin.
+    act(() => {
+      list.props.onScroll({
+        clientHeight: 500,
+        scrollHeight: 5000,
+        scrollTop: 0,
+      });
+    });
+    expect(list.props.scrollToIndex).toBe(list.props.rowCount - 1);
+  });
+
+  it('drops measured heights when the viewport rewraps the lines', async () => {
+    renderPage();
+    await screen.findByText(/Scanning disk/);
+    list.recompute.mockClear();
+    act(() => {
+      list.onResize({ width: 400, height: 600 });
+    });
+    expect(list.recompute).toHaveBeenCalled();
+  });
+
+  it('measures by block id rather than by position', async () => {
+    renderPage();
+    await screen.findByText(/Scanning disk/);
+    expect(list.cache.fixedWidth).toBe(true);
+    // Ids climb from a module counter, so a first block never keys as its index.
+    expect(list.cache.keyMapper(0)).toBeGreaterThan(0);
+    // Past the end there is no block to key on and the index has to do.
+    expect(list.cache.keyMapper(9999)).toBe(9999);
   });
 });

--- a/frontend/src/pages/__tests__/LogFiles.test.jsx
+++ b/frontend/src/pages/__tests__/LogFiles.test.jsx
@@ -79,20 +79,20 @@ describe('LogFilesPage', () => {
       expect(screen.getByText('dispatcharr.log')).toBeInTheDocument();
     });
     expect(screen.getByText('dispatcharr.log.1')).toBeInTheDocument();
-    expect(screen.getByText('2.0 KB')).toBeInTheDocument();
-    expect(screen.getByText('5.0 MB')).toBeInTheDocument();
+    expect(screen.getByText('2.00 KB')).toBeInTheDocument();
+    expect(screen.getByText('5.00 MB')).toBeInTheDocument();
   });
 
   it('right-aligns sizes and keeps the exact count a hover away', async () => {
     API.getLogFiles.mockResolvedValue(files);
     renderPage();
-    await screen.findByText('2.0 KB');
+    await screen.findByText('2.00 KB');
     expect(screen.getByText('Size')).toHaveAttribute('data-align', 'right');
-    expect(screen.getByText('2.0 KB').closest('td')).toHaveAttribute(
+    expect(screen.getByText('2.00 KB').closest('td')).toHaveAttribute(
       'data-align',
       'right'
     );
-    expect(screen.getByText('5.0 MB')).toHaveAttribute(
+    expect(screen.getByText('5.00 MB')).toHaveAttribute(
       'title',
       '5,242,880 bytes'
     );

--- a/frontend/src/pages/__tests__/LogFiles.test.jsx
+++ b/frontend/src/pages/__tests__/LogFiles.test.jsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LogFilesPage from '../LogFiles';
+import API from '../../api';
+
+vi.mock('../../api', () => ({
+  default: {
+    getLogFiles: vi.fn(),
+    downloadLogFile: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/dateTimeUtils.js', () => ({
+  useDateTimeFormat: () => ({ fullDateTimeFormat: 'DD/MM/YYYY HH:mm:ss' }),
+  format: vi.fn(() => '14/07/2026 23:00:00'),
+}));
+
+vi.mock('@mantine/core', () => {
+  const TableStub = ({ children }) => <table>{children}</table>;
+  TableStub.Thead = ({ children }) => <thead>{children}</thead>;
+  TableStub.Tbody = ({ children }) => <tbody>{children}</tbody>;
+  TableStub.Tr = ({ children }) => <tr>{children}</tr>;
+  TableStub.Th = ({ children, ta }) => <th data-align={ta}>{children}</th>;
+  TableStub.Td = ({ children, ta }) => <td data-align={ta}>{children}</td>;
+
+  return {
+    Anchor: ({ children, onClick, to }) => (
+      <a href={to || '#'} onClick={onClick}>
+        {children}
+      </a>
+    ),
+    Alert: ({ title, children }) => (
+      <div role="alert">
+        {title}
+        {children}
+      </div>
+    ),
+    Box: ({ children }) => <div>{children}</div>,
+    Button: ({ children, onClick }) => (
+      <button onClick={onClick}>{children}</button>
+    ),
+    Group: ({ children }) => <div>{children}</div>,
+    Paper: ({ children }) => <div>{children}</div>,
+    Table: TableStub,
+    Text: ({ children, title }) => <span title={title}>{children}</span>,
+    Title: ({ children }) => <h3>{children}</h3>,
+  };
+});
+
+const files = {
+  path: '/data/logs',
+  files: [
+    { name: 'dispatcharr.log', size: 2048, modified: '2026-07-14T11:00:00Z' },
+    {
+      name: 'dispatcharr.log.1',
+      size: 5 * 1024 * 1024,
+      modified: '2026-07-13T11:00:00Z',
+    },
+  ],
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/logs']}>
+      <LogFilesPage />
+    </MemoryRouter>
+  );
+
+describe('LogFilesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    API.getLogFiles.mockResolvedValue(files);
+  });
+
+  it('lists log files with size and modified time', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('dispatcharr.log')).toBeInTheDocument();
+    });
+    expect(screen.getByText('dispatcharr.log.1')).toBeInTheDocument();
+    expect(screen.getByText('2.0 KB')).toBeInTheDocument();
+    expect(screen.getByText('5.0 MB')).toBeInTheDocument();
+  });
+
+  it('right-aligns sizes and keeps the exact count a hover away', async () => {
+    API.getLogFiles.mockResolvedValue(files);
+    renderPage();
+    await screen.findByText('2.0 KB');
+    expect(screen.getByText('Size')).toHaveAttribute('data-align', 'right');
+    expect(screen.getByText('2.0 KB').closest('td')).toHaveAttribute(
+      'data-align',
+      'right'
+    );
+    expect(screen.getByText('5.0 MB')).toHaveAttribute(
+      'title',
+      '5,242,880 bytes'
+    );
+  });
+
+  it('says so when nothing is writing the files', async () => {
+    API.getLogFiles.mockResolvedValue({ ...files, collector_running: false });
+    renderPage();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /Log collector not running/
+    );
+  });
+
+  it('stays quiet when the collector is running, and on an older backend', async () => {
+    API.getLogFiles.mockResolvedValue({ ...files, collector_running: true });
+    renderPage();
+    await screen.findByText('dispatcharr.log');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    API.getLogFiles.mockResolvedValue(files);
+    renderPage();
+    await screen.findAllByText('dispatcharr.log');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('links filenames to the raw view route', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('dispatcharr.log')).toBeInTheDocument();
+    });
+    expect(screen.getByText('dispatcharr.log').closest('a')).toHaveAttribute(
+      'href',
+      '/logs/dispatcharr.log'
+    );
+  });
+
+  it('downloads a file from its Download link', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('dispatcharr.log')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getAllByText('Download')[0]);
+    expect(API.downloadLogFile).toHaveBeenCalledWith('dispatcharr.log');
+  });
+
+  it('refresh re-fetches the list', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(API.getLogFiles).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(screen.getByText('Refresh'));
+    await waitFor(() => {
+      expect(API.getLogFiles).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('shows an empty state when there are no files', async () => {
+    API.getLogFiles.mockResolvedValue({ path: '/data/logs', files: [] });
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('No log files yet')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/LogFiles.test.jsx
+++ b/frontend/src/pages/__tests__/LogFiles.test.jsx
@@ -155,4 +155,13 @@ describe('LogFilesPage', () => {
       expect(screen.getByText('No log files yet')).toBeInTheDocument();
     });
   });
+
+  it('says the listing failed rather than that there are no files', async () => {
+    API.getLogFiles.mockRejectedValue(new Error('HTTP error! Status: 500'));
+    renderPage();
+    expect(
+      await screen.findByText('Failed to load log files')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No log files yet')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/__tests__/LogFiles.test.jsx
+++ b/frontend/src/pages/__tests__/LogFiles.test.jsx
@@ -49,7 +49,6 @@ vi.mock('@mantine/core', () => {
 });
 
 const files = {
-  path: '/data/logs',
   files: [
     { name: 'dispatcharr.log', size: 2048, modified: '2026-07-14T11:00:00Z' },
     {
@@ -149,7 +148,7 @@ describe('LogFilesPage', () => {
   });
 
   it('shows an empty state when there are no files', async () => {
-    API.getLogFiles.mockResolvedValue({ path: '/data/logs', files: [] });
+    API.getLogFiles.mockResolvedValue({ files: [] });
     renderPage();
     await waitFor(() => {
       expect(screen.getByText('No log files yet')).toBeInTheDocument();

--- a/frontend/src/pages/__tests__/LogFiles.test.jsx
+++ b/frontend/src/pages/__tests__/LogFiles.test.jsx
@@ -16,37 +16,55 @@ vi.mock('../../utils/dateTimeUtils.js', () => ({
   format: vi.fn(() => '14/07/2026 23:00:00'),
 }));
 
-vi.mock('@mantine/core', () => {
-  const TableStub = ({ children }) => <table>{children}</table>;
-  TableStub.Thead = ({ children }) => <thead>{children}</thead>;
-  TableStub.Tbody = ({ children }) => <tbody>{children}</tbody>;
-  TableStub.Tr = ({ children }) => <tr>{children}</tr>;
-  TableStub.Th = ({ children, ta }) => <th data-align={ta}>{children}</th>;
-  TableStub.Td = ({ children, ta }) => <td data-align={ta}>{children}</td>;
+// Stands in for the table chrome, running the real column definitions.
+vi.mock('../../components/tables/CustomTable', () => ({
+  useTable: (options) => options,
+  CustomTable: ({ table }) => (
+    <table data-testid="custom-table">
+      <tbody>
+        {table.data.map((row) => (
+          <tr key={row.name}>
+            {table.columns.map((column) => (
+              <td key={column.id || column.accessorKey}>
+                {column.cell
+                  ? column.cell({
+                      cell: { getValue: () => row[column.accessorKey] },
+                    })
+                  : table.bodyCellRenderFns[column.id]({
+                      cell: { column: { id: column.id } },
+                      row: { original: row },
+                    })}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
 
-  return {
-    Anchor: ({ children, onClick, to }) => (
-      <a href={to || '#'} onClick={onClick}>
-        {children}
-      </a>
-    ),
-    Alert: ({ title, children }) => (
-      <div role="alert">
-        {title}
-        {children}
-      </div>
-    ),
-    Box: ({ children }) => <div>{children}</div>,
-    Button: ({ children, onClick }) => (
-      <button onClick={onClick}>{children}</button>
-    ),
-    Group: ({ children }) => <div>{children}</div>,
-    Paper: ({ children }) => <div>{children}</div>,
-    Table: TableStub,
-    Text: ({ children, title }) => <span title={title}>{children}</span>,
-    Title: ({ children }) => <h3>{children}</h3>,
-  };
-});
+vi.mock('@mantine/core', () => ({
+  Anchor: ({ children, onClick, to }) => (
+    <a href={to || '#'} onClick={onClick}>
+      {children}
+    </a>
+  ),
+  Alert: ({ title, children }) => (
+    <div role="alert">
+      {title}
+      {children}
+    </div>
+  ),
+  Box: ({ children }) => <div>{children}</div>,
+  Button: ({ children, onClick }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  Group: ({ children }) => <div>{children}</div>,
+  Loader: () => <div data-testid="loader" />,
+  Paper: ({ children }) => <div>{children}</div>,
+  Text: ({ children, title }) => <span title={title}>{children}</span>,
+  Title: ({ children }) => <h3>{children}</h3>,
+}));
 
 const files = {
   files: [
@@ -80,17 +98,17 @@ describe('LogFilesPage', () => {
     expect(screen.getByText('dispatcharr.log.1')).toBeInTheDocument();
     expect(screen.getByText('2.00 KB')).toBeInTheDocument();
     expect(screen.getByText('5.00 MB')).toBeInTheDocument();
+    expect(screen.getAllByText('14/07/2026 23:00:00')).toHaveLength(2);
   });
 
-  it('right-aligns sizes and keeps the exact count a hover away', async () => {
-    API.getLogFiles.mockResolvedValue(files);
+  it('renders the listing through the project table', async () => {
+    renderPage();
+    expect(await screen.findByTestId('custom-table')).toBeInTheDocument();
+  });
+
+  it('keeps the exact byte count a hover away', async () => {
     renderPage();
     await screen.findByText('2.00 KB');
-    expect(screen.getByText('Size')).toHaveAttribute('data-align', 'right');
-    expect(screen.getByText('2.00 KB').closest('td')).toHaveAttribute(
-      'data-align',
-      'right'
-    );
     expect(screen.getByText('5.00 MB')).toHaveAttribute(
       'title',
       '5,242,880 bytes'
@@ -153,6 +171,7 @@ describe('LogFilesPage', () => {
     await waitFor(() => {
       expect(screen.getByText('No log files yet')).toBeInTheDocument();
     });
+    expect(screen.queryByTestId('custom-table')).not.toBeInTheDocument();
   });
 
   it('says the listing failed rather than that there are no files', async () => {

--- a/frontend/src/utils/pages/SettingsUtils.js
+++ b/frontend/src/utils/pages/SettingsUtils.js
@@ -73,7 +73,7 @@ const GROUP_CONFIG = {
     fields: {
       time_zone: { type: 'string', default: '' },
       max_system_events: { type: 'int', default: 100 },
-      log_max_mb: { type: 'int', default: 10 },
+      log_max_mb: { type: 'int', default: 5 },
       log_keep: { type: 'int', default: 5 },
       log_persist: { type: 'bool', default: true },
       preferred_region: { type: 'nullable', default: null },


### PR DESCRIPTION
## Description

Adds an in-app log browser so operators can read Dispatcharr's log without shell access to the container. This is the second half of a split: [logging 1] produces the files, this PR reads them.

- **An API** to list the collected files, read one, and download it: `GET /api/core/logs/`, `GET /api/core/logs/{name}/`, `GET /api/core/logs/{name}/download/`.
- **Two pages** — a list of log files, and a viewer with severity colouring, wrapping, filtering, search and auto-refresh — reached from **System → Logs** in the sidebar.

### Non-obvious decisions

- **Every path resolves through one containment gate.** `_resolve()` joins the requested name onto the log dir and compares `os.path.realpath` of both, so a symlink pointing outside the directory is rejected. The *list* endpoint resolves through the same gate rather than trusting `os.listdir`, so an escaping symlink is never shown, let alone opened.

- **Only the collector's own file family is served.** An operator who points `DISPATCHARR_LOG_DIR` at a data root cannot turn these endpoints into a general file reader; the collector's own `collector.conf` and `collector.pid` are not served either. The family's base name is imported from the collector, so a rename in one place cannot silently empty the page. A console-only install, where settings could not create the log directory, reports no files rather than falling back to a default path.

- **Tails are hard-capped** at 5 MiB and read by seeking to `size - cap`, so opening a multi-gigabyte log streams the tail rather than loading the file. The response flags `truncated` so the UI can say so.

- **Size and identity come from the open file handle, never the path.** The collector rotates by rename, so `os.path.getsize(path)` followed by a separate `open(path)` can straddle a rotation: the stale size then seeks past the end of a fresh, near-empty file and the viewer shows an empty log. `os.fstat(f.fileno())` makes both come from one handle. A file the collector prunes between resolution and open answers 404 rather than 500.

- **Auto-refresh fetches only what was written since the last poll.** A full re-read was about a megabyte a second per open viewer, and a re-parse of every retained line, to show a couple of hundred new ones. The tail endpoint answers a JSON envelope of `content`, `cursor`, `reset` and `truncated`; a client holding a cursor of `inode-offset` sends it back as `?cursor=` and is served only the bytes past it, with `reset` saying whether to append or replace. The envelope goes through the shared request helper like every other endpoint, is declared in the OpenAPI schema, and needs no CORS exposure for the Vite dev server, which custom headers would have.

  The offset alone would be unsafe. Byte *n* of the rotated-away file and byte *n* of the new one are unrelated, so resuming there either skips content and presents it as continuous, or freezes the view. The inode proves the file is the same one; and because rotation frees inodes for reuse, an offset that does not sit on a line boundary is treated as proof it came from somewhere else, as is an offset beyond the end of the file, which an append-only file cannot produce. Four cases override the client and reset it: a rotation, an offset past the end, a gap wider than the view cap (a tab that slept must not be handed half a gigabyte), and no cursor at all. A line still being written is withheld until it is complete, on fresh loads and deltas alike, so every cursor sits on a line boundary and the client never sees a torn line.

- **Downloads go over the authenticated session**, not a signed URL, so no secret ever rides in a URL and the route is plainly `IsAdmin` like the others. The cost is that the whole body is buffered before the browser saves it, so the button shows its loading state for the duration rather than appearing dead.

- **The viewer follows the log's live edge.** Auto-refresh replaces content while `scrollTop` stays fixed in pixels, so a reader watching the newest lines would otherwise drift backwards through history as the log grew. The view re-pins only for a reader already at the edge; someone who scrolled back to read history is left where they were.

- **The viewer's auto-refresh pauses when the tab is hidden**, and pauses after three consecutive failed polls without touching the stored interval, so a forgotten open tab does not poll forever and a restart does not rewrite the reader's preference; choosing an interval again resumes. A response is discarded if a newer request has superseded it, since two overlapping loads carry the same cursor and would otherwise append the same delta twice.

- **The level floor gates the levels the collector invents** for unlabelled output. The floor exemption belongs to the sinks, where gating is permanent data loss; the viewer is a reversible filter over a file that already has everything, and a Warning floor that still showed the whole boot narration read as broken rather than protective.

- **The Logs page hides itself where there is nothing to browse.** A deployment with no collector has no files, so the nav entry declares the flag it requires and the ordering helper drops it the way it drops DVR and VOD; the page itself still explains the situation if reached directly.

## Related Issue

N/A

## How was it tested?

Built the image from this branch and ran a container against a fresh volume (`TZ=Pacific/Auckland`), then:

**Frontend:** `npx vitest run` — **6405 tests / 209 files pass**. This branch's own two page files contribute 63 of them (`LogFileView.test.jsx` 54, `LogFiles.test.jsx` 9): classification, grouping of continuations, ordering, filtering, search debounce, refresh backoff, the pause leaving the stored interval alone, hidden-tab pause, tail-following, incremental append versus reset, a traceback split across two polls, overlapping loads, the trailing newline never rendering as a blank row, a torn offset never parsing as a level, a failed listing reported as such, and a 4 MB payload render. The navigation and sidebar tests cover the entry disappearing without a collector.

**Backend:** full suite in the container — `core.tests` **199 tests, OK**. `core/tests/test_log_files.py` contributes 22: listing, tailing, the truncation flag, rejection of symlinks escaping the log dir, traversal attempts, the log-family filter, sizing from the open handle across a rotation, a file pruned after resolution, a console-only install, exact 401 and 403 codes on every route, and the cursor's cases — resumption, a withheld partial line on both a fresh load and a delta, a rotation, a gap past the cap, an offset past the end of the same inode, a mid-line offset, and malformed cursors including a Unicode digit and one longer than `int()` accepts.

Each new test was checked to fail against the unfixed code rather than pass vacuously. The rotation-race test fails with `'' != 'new\n'` through the real endpoint; the rotation-cursor test fails if the identity check is dropped; the split-traceback test loses the tail out of its block if the parser's carried state is dropped; the overlap test renders the delta twice without the supersession guard; the past-the-end cursor test receives an empty non-reset delta, and the Unicode-cursor test a 500, against the clamped and `isdigit()` code; the trailing-newline test finds a `line-height: 0.35` row; the pause test finds `0` written to storage.

**API, over HTTP against the running container:**
- `GET /api/core/logs/` → 200, listing the collector's files with sizes.
- `GET /api/core/logs/dispatcharr.log/` → 200, JSON with the tail, `reset: true` and a cursor.
- The same with `?cursor=` → 200, `reset: false`, only the bytes written since.
- Truncating the live file in place under the running collector, then polling with the old cursor → 200, `reset: true` with the new head; the next poll resumes from the new end.
- `GET /api/core/logs/collector.conf/` and `.../collector.pid/` and `.../passwd/` → **404**, confirming the family filter.
- Anonymous → **401**; a non-admin session → **403**.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

**ESLint and Prettier.** Verified as "this PR introduces no new problems": eslint reports the same counts on this branch as on stock `dev`, measured by extracting the committed frontend blobs and running the same binary against them. Prettier is clean on every file this PR adds and on every clean file it touches. `navigation.js`, `Sidebar.jsx` and `ConnectLogsSection.test.jsx` are not Prettier-clean on `dev` either and have been left that way rather than reformatted; their diffs are the intended lines only.
