### PR TITLE
docs(security): add vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+The latest stable release and current development builds of Dispatcharr receive security updates. Older releases do not receive security updates. For critical issues, maintainers may backport a fix at their discretion.
+
+## Reporting a Vulnerability
+
+Please do not report suspected vulnerabilities through public GitHub issues, discussions, or public Discord channels. Instead, use one of these reporting channels:
+
+| Method | How-To |
+| --- | --- |
+| GitHub | Use the repository's [**Report a vulnerability**](https://github.com/Dispatcharr/Dispatcharr/security/advisories/new) button |
+| Email | Send a report to [security@dispatcharr.tv](mailto:security@dispatcharr.tv) |
+
+### Include in Your Report
+
+Include as much of the following as possible:
+
+- The affected Dispatcharr version or development build.
+- Deployment details and relevant configuration.
+- Steps to reproduce, including a minimal proof of concept when available.
+- The potential impact and affected components or endpoints.
+- Relevant logs, request and response details, or screenshots. Do not include passwords, API keys, tokens, stream URLs, or other secrets.
+
+### Coordinated Disclosure
+
+Maintainers will review the report, assess its impact, and may contact you for additional information or to validate a fix.
+
+__Public disclosure is your choice.__ We ask that you give maintainers a reasonable opportunity to investigate and address the issue before sharing details publicly. We will work with reporters to coordinate disclosure after a fix or mitigation is available.


### PR DESCRIPTION
Adds a security policy with supported-version guidance and private vulnerability reporting channels.