### PR TITLE
exec needs to be called interactively and with tty.

### DIFF
--- a/frontend/src/components/forms/LoginForm.jsx
+++ b/frontend/src/components/forms/LoginForm.jsx
@@ -298,7 +298,7 @@ const LoginForm = () => {
               If running with Docker:
             </Text>
             <Code block>
-              docker exec &lt;container_name&gt; python manage.py changepassword
+              docker exec -it &lt;container_name&gt; python manage.py changepassword
               &lt;username&gt;
             </Code>
           </div>


### PR DESCRIPTION
## Description

<!-- What does this PR do? Be specific. -->
docker exec needs to be called interactively and with tty.

just adding -it to the reset password instructions.

## Related Issue

<!-- Non-trivial changes should have a linked issue. If this is a small/obvious fix, you may leave this blank. -->

Closes #

## How was it tested?

<!-- What did you actually run to verify this works? Be specific — "it works" is not sufficient. -->

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
