### PR TITLE
fix(epg): skip dummy sources in bulk set-from-EPG channel actions

### DIFF
--- a/apps/channels/tasks.py
+++ b/apps/channels/tasks.py
@@ -4022,8 +4022,12 @@ def set_channels_names_from_epg(self, channel_ids):
             batch_ids = channel_ids[i:i + batch_size]
             batch_updates = []
 
-            # Get channels and their EPG data
-            channels = Channel.objects.filter(id__in=batch_ids).select_related('epg_data')
+            # Get channels and their EPG data. A dummy source shares one placeholder
+            # EPGData row across all its channels, so copying from it would collapse
+            # every channel on that source onto the same value.
+            channels = Channel.objects.filter(id__in=batch_ids).select_related(
+                'epg_data'
+            ).exclude(epg_data__epg_source__source_type='dummy')
 
             for channel in channels:
                 try:
@@ -4285,8 +4289,12 @@ def set_channels_tvg_ids_from_epg(self, channel_ids):
             batch_ids = channel_ids[i:i + batch_size]
             batch_updates = []
 
-            # Get channels and their EPG data
-            channels = Channel.objects.filter(id__in=batch_ids).select_related('epg_data')
+            # Get channels and their EPG data. A dummy source shares one placeholder
+            # EPGData row across all its channels, so copying from it would collapse
+            # every channel on that source onto the same value.
+            channels = Channel.objects.filter(id__in=batch_ids).select_related(
+                'epg_data'
+            ).exclude(epg_data__epg_source__source_type='dummy')
 
             for channel in channels:
                 try:

--- a/apps/channels/tests/test_set_channels_from_epg.py
+++ b/apps/channels/tests/test_set_channels_from_epg.py
@@ -1,0 +1,108 @@
+"""Tests for the bulk "set channel TVG-IDs / names from EPG" tasks."""
+from django.test import TestCase
+
+from apps.channels.models import Channel
+from apps.channels.tasks import (
+    set_channels_names_from_epg,
+    set_channels_tvg_ids_from_epg,
+)
+from apps.epg.models import EPGData, EPGSource
+
+
+class SetChannelsFromEpgTests(TestCase):
+    def setUp(self):
+        self.source = EPGSource.objects.create(
+            name="XML EPG",
+            source_type="xmltv",
+            url="http://example.com/epg.xml",
+        )
+        # Creating a dummy source auto-creates a shared EPGData row
+        # (apps/epg/signals.py: create_dummy_epg_data) whose tvg_id and name
+        # describe the source, not any one channel.
+        dummy_source = EPGSource.objects.create(name="US Sports", source_type="dummy")
+        self.shared_epg_data = EPGData.objects.get(epg_source=dummy_source)
+
+    def test_copies_tvg_id_from_a_real_epg_source(self):
+        epg_data = EPGData.objects.create(
+            tvg_id="ch.one", name="Channel One", epg_source=self.source
+        )
+        channel = Channel.objects.create(
+            channel_number=1, name="Channel One", tvg_id="stale.id", epg_data=epg_data
+        )
+
+        result = set_channels_tvg_ids_from_epg([channel.id])
+
+        channel.refresh_from_db()
+        self.assertEqual(channel.tvg_id, "ch.one")
+        self.assertEqual(result["updated_count"], 1)
+        self.assertEqual(result["errors"], [])
+
+    def test_copies_tvg_id_when_epg_data_has_no_source(self):
+        epg_data = EPGData.objects.create(
+            tvg_id="orphan.id", name="Orphan", epg_source=None
+        )
+        channel = Channel.objects.create(
+            channel_number=2, name="Orphan", tvg_id="stale.id", epg_data=epg_data
+        )
+
+        result = set_channels_tvg_ids_from_epg([channel.id])
+
+        channel.refresh_from_db()
+        self.assertEqual(channel.tvg_id, "orphan.id")
+        self.assertEqual(result["updated_count"], 1)
+        self.assertEqual(result["errors"], [])
+
+    def test_leaves_dummy_epg_channels_tvg_ids_alone(self):
+        nba = Channel.objects.create(
+            channel_number=100,
+            name="NBA",
+            tvg_id="nba.us",
+            epg_data=self.shared_epg_data,
+        )
+        mlb = Channel.objects.create(
+            channel_number=101,
+            name="MLB",
+            tvg_id="mlb.us",
+            epg_data=self.shared_epg_data,
+        )
+
+        result = set_channels_tvg_ids_from_epg([nba.id, mlb.id])
+
+        nba.refresh_from_db()
+        mlb.refresh_from_db()
+        self.assertEqual(nba.tvg_id, "nba.us")
+        self.assertEqual(mlb.tvg_id, "mlb.us")
+        self.assertEqual(result["updated_count"], 0)
+        self.assertEqual(result["errors"], [])
+
+    def test_copies_name_from_a_real_epg_source(self):
+        epg_data = EPGData.objects.create(
+            tvg_id="ch.two", name="Channel Two", epg_source=self.source
+        )
+        channel = Channel.objects.create(
+            channel_number=3, name="Stale Name", epg_data=epg_data
+        )
+
+        result = set_channels_names_from_epg([channel.id])
+
+        channel.refresh_from_db()
+        self.assertEqual(channel.name, "Channel Two")
+        self.assertEqual(result["updated_count"], 1)
+        self.assertEqual(result["errors"], [])
+
+    def test_leaves_dummy_epg_channel_names_alone(self):
+        nba = Channel.objects.create(
+            channel_number=100, name="NBA", epg_data=self.shared_epg_data
+        )
+        mlb = Channel.objects.create(
+            channel_number=101, name="MLB", epg_data=self.shared_epg_data
+        )
+
+        result = set_channels_names_from_epg([nba.id, mlb.id])
+
+        nba.refresh_from_db()
+        mlb.refresh_from_db()
+        self.assertEqual(nba.name, "NBA")
+        self.assertEqual(mlb.name, "MLB")
+        self.assertEqual(result["updated_count"], 0)
+        self.assertEqual(result["errors"], [])


### PR DESCRIPTION
## Description

<!-- What does this PR do? Be specific. -->

Creating a dummy EPG source auto-creates a single `EPGData` row (`apps/epg/signals.py` → `create_dummy_epg_data`), and every channel assigned to that source points at that one row. Its `tvg_id` (`dummy_<source_name>`) and its `name` describe the *source*, not any individual channel.

Two bulk actions copy fields off `channel.epg_data` onto the channel:

- **Set TVG-IDs from EPG** (`set_channels_tvg_ids_from_epg`, `apps/channels/tasks.py`)
- **Set names from EPG** (`set_channels_names_from_epg`, same file)

Run either over a selection of dummy-assigned channels and they all get overwritten with the same shared placeholder. For tvg_id that is #970: with `tvg_id_source=tvg_id`, the XMLTV export then emits one `<channel id="dummy_us_sports">` for what used to be NBA, MLB, NCAAF and ESPN+, so every client shows identical listings across them. The name task has the same defect and renames every affected channel to the source's own name.

Both tasks now exclude dummy-source channels from the queryset:

```python
channels = Channel.objects.filter(id__in=batch_ids).select_related(
    'epg_data'
).exclude(epg_data__epg_source__source_type='dummy')
```

This mirrors `apps/epg/api_views.py`, which already partitions channels with `epg_data__epg_source__source_type='dummy'` and deliberately uses `str(channel.uuid)` rather than the shared dummy `tvg_id`. Doing it in the queryset rather than in the loop means dummy channels are never fetched or hydrated at all, which matters for exactly the workload in #970 (a large dummy-assigned selection).

`EPGData.epg_source` and `Channel.epg_data` are both nullable. Django keeps NULL rows across a negated nullable join (`NOT (source_type = 'dummy' AND source_type IS NOT NULL)` over LEFT OUTER JOINs), so channels with no EPG data and `EPGData` rows with no source still behave as before. There's a test pinning that.

Two things this deliberately does **not** do:

- It does not implement #970's proposed per-channel `EPGData` design. This closes the corruption path; the shared-row design is a bigger call and yours to make.
- It cannot repair installs that already ran the action. The original per-channel tvg_ids were overwritten in place and aren't recoverable from the DB.

One thing I'd fix in a follow-up if you want it: the confirmation dialog in `ChannelBatch.jsx` still says "This will replace the current TVG-IDs with the TVG-IDs from their assigned EPG data", which is now slightly inaccurate for dummy-assigned channels. I left the frontend out of a backend bugfix rather than guess at the wording.

Happy to drop the `set_channels_names_from_epg` half into its own PR if you'd rather keep this pinned to #970 literally. It's the identical defect two functions apart, so it seemed worse to leave it.

I used an AI assistant while working on this (finding the twin in the name task, and the suggestion to move the filter into the queryset). I've read and verified every line, and I can explain the NULL-join semantics, the `select_related` choice, and each test if you want to dig in.

## Related Issue

<!-- Non-trivial changes should have a linked issue. If this is a small/obvious fix, you may leave this blank. -->

Related to #970

## How was it tested?

<!-- What did you actually run to verify this works? Be specific — "it works" is not sufficient. -->

New file `apps/channels/tests/test_set_channels_from_epg.py`, 5 tests:

| test | pins |
| --- | --- |
| `test_copies_tvg_id_from_a_real_epg_source` | normal tvg_id copy still works |
| `test_copies_tvg_id_when_epg_data_has_no_source` | `EPGData.epg_source = None` rows survive the `exclude` |
| `test_leaves_dummy_epg_channels_tvg_ids_alone` | two dummy-assigned channels keep their own distinct tvg_ids (#970) |
| `test_copies_name_from_a_real_epg_source` | normal name copy still works |
| `test_leaves_dummy_epg_channel_names_alone` | two dummy-assigned channels keep their own names |

Reproduced first, on `dev` before touching anything: two channels on one dummy source "US Sports", run the task, both come back `dummy_us_sports`.

Every branch was mutation-tested rather than just run green:

- Revert `tasks.py` only → both dummy tests fail (`'dummy_us_sports' != 'nba.us'`), the other three pass. The bug tests are red for the right reason.
- Swap `.exclude(...)` for an in-loop `if epg_source and epg_source.source_type == 'dummy': continue`, then drop the `epg_source and` half → `test_copies_tvg_id_when_epg_data_has_no_source` fails. That test is load-bearing, not decoration.
- Printed the generated SQL to confirm both joins are LEFT OUTER and the `IS NOT NULL` term sits inside the negation.

Suite: `apps.channels.tests` (which is what `scripts/ci_backend_test_labels.py` selects for these two paths) — 499 tests, same 8 errors as clean `dev` at 494 tests, so no new failures. Those 8 are `test_logo_path_jail` / `test_recording_output_path` / `test_catchup_utils` failing on `/data` not existing outside the container; they're identical with and without this change.

Local caveat, for transparency: I ran on sqlite (`TEST_USE_SQLITE=1`) with migrations disabled, because several older migrations use Postgres-only raw SQL (`jsonb ~`, `ON CONFLICT`) that won't run on sqlite even against an empty DB. Tables were built from current model state. CI's Postgres run is the authoritative one. Nothing in this change is backend-specific.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed — no model changes
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema — no new endpoints
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`) — n/a, no frontend files touched
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

---
Used AI assistance on this; I reviewed and tested the change myself.