### PR TITLE
feat(users): add sort and search to the Users table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Users table sort and search.** The Users page can sort by User Level, Username, Name, Email, Date Joined, and Last Login (header click cycles ascending, descending, unsorted, matching M3U/EPG), and filter with a debounced search over username, full name, email, and user level label. Empty values sort last in both directions; user level sorts by privilege rather than label. - Thanks [@brendongl](https://github.com/brendongl)
+
+### Changed
+
+- **Shared table sort header helpers moved out of `M3uTableUtils`.** `makeHeaderCellRenderer` and `makeSortingChangeHandler` now live in `frontend/src/components/tables/tableSortingUtils.jsx`, since M3U, EPG, and Users all reuse them. Imports updated accordingly.
+
 ## [0.30.0] - 2026-08-29
 
 ### Added

--- a/frontend/src/components/tables/EPGsTable.jsx
+++ b/frontend/src/components/tables/EPGsTable.jsx
@@ -49,7 +49,7 @@ import {
 import {
   makeHeaderCellRenderer,
   makeSortingChangeHandler,
-} from './M3uTableUtils.jsx';
+} from './tableSortingUtils.jsx';
 
 // Helper function to get status text color
 const getStatusColor = (status) => {

--- a/frontend/src/components/tables/M3UsTable.jsx
+++ b/frontend/src/components/tables/M3UsTable.jsx
@@ -60,7 +60,7 @@ import {
 import {
   makeHeaderCellRenderer,
   makeSortingChangeHandler,
-} from './M3uTableUtils.jsx';
+} from './tableSortingUtils.jsx';
 
 const ALL_ACCOUNT_TYPES = ['STD', 'XC'];
 

--- a/frontend/src/components/tables/M3uTableUtils.jsx
+++ b/frontend/src/components/tables/M3uTableUtils.jsx
@@ -14,7 +14,10 @@ export const makeHeaderCellRenderer = (sorting, onSortingChange) => (header) => 
   }
 
   return (
-    <Group>
+    // nowrap keeps the sort control on the header's line: with the default
+    // wrap, a column only a pixel or two too narrow drops the icon onto a
+    // second row and doubles the header height.
+    <Group gap="xs" wrap="nowrap">
       <Text size="sm" name={header.id}>
         {header.column.columnDef.header}
       </Text>
@@ -46,7 +49,9 @@ export const makeSortingChangeHandler =
     }
 
     setSorting(newSorting);
-    if (newSorting.length > 0) {
+    // Optional: tables that keep their rows in state re-sort them here. Tables
+    // that derive their rows from `sorting` don't pass a callback.
+    if (onDataSort && newSorting.length > 0) {
       onDataSort(newSorting[0].id, newSorting[0].desc);
     }
   };

--- a/frontend/src/components/tables/UsersTable.jsx
+++ b/frontend/src/components/tables/UsersTable.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useEffect, useState } from 'react';
+import React, { useMemo, useCallback, useState } from 'react';
 import API from '../../api';
 import UserForm from '../forms/User';
 import useUsersStore from '../../store/users';
@@ -34,10 +34,11 @@ import { CustomTable, useTable } from './CustomTable';
 import ConfirmationDialog from '../ConfirmationDialog';
 import useBrowserStorage from '../../hooks/useBrowserStorage';
 import { useDateTimeFormat, format } from '../../utils/dateTimeUtils.js';
+import { useDebounce } from '../../utils';
 import {
   makeHeaderCellRenderer,
   makeSortingChangeHandler,
-} from './M3uTableUtils';
+} from './tableSortingUtils';
 import {
   getFilteredUsers,
   getSortedUsers,
@@ -155,17 +156,9 @@ const UsersTable = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [search, setSearch] = useState('');
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-  // Empty array means "no column sorted" — the table falls back to its default
-  // id order. The third click on a header returns to this state.
+  // Empty query uses delay 0 so the clear button restores the list immediately.
+  const debouncedSearch = useDebounce(search, search.trim() === '' ? 0 : 300);
   const [sorting, setSorting] = useState([]);
-
-  // Debounce the search box so typing doesn't re-filter and re-sort the whole
-  // list on every keystroke.
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(timer);
-  }, [search]);
 
   const executeDeleteUser = useCallback(async (id) => {
     setIsLoading(true);
@@ -281,8 +274,6 @@ const UsersTable = () => {
       {
         header: 'Date Joined',
         accessorKey: 'date_joined',
-        // Wide enough for the header text plus the sort control; at the old
-        // 90px the two no longer fit on one line.
         size: 120,
         minSize: 110,
         sortable: true,
@@ -370,8 +361,6 @@ const UsersTable = () => {
     setUserModalOpen(false);
   };
 
-  // Rows actually rendered: search first (cheaper — it shrinks what has to be
-  // sorted), then sort. Copies the store array rather than sorting it in place.
   const data = useMemo(() => {
     const filtered = getFilteredUsers(users, debouncedSearch);
     const sortColumn = sorting[0];
@@ -394,8 +383,6 @@ const UsersTable = () => {
     enableRowVirtualization: false,
     renderTopToolbar: false,
     sorting,
-    // Rows arrive already sorted and filtered by `data` above, so the table
-    // must not reorder or re-filter them itself.
     manualSorting: true,
     manualFiltering: true,
     manualPagination: false,

--- a/frontend/src/components/tables/UsersTable.jsx
+++ b/frontend/src/components/tables/UsersTable.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useCallback, useEffect, useState } from 'react';
 import API from '../../api';
 import UserForm from '../forms/User';
 import useUsersStore from '../../store/users';
@@ -6,7 +6,15 @@ import useChannelsStore from '../../store/channels';
 import useAuthStore from '../../store/auth';
 import { USER_LEVELS, USER_LEVEL_LABELS } from '../../constants';
 import useWarningsStore from '../../store/warnings';
-import { SquarePlus, SquareMinus, SquarePen, Eye, EyeOff } from 'lucide-react';
+import {
+  SquarePlus,
+  SquareMinus,
+  SquarePen,
+  Eye,
+  EyeOff,
+  Search,
+  X,
+} from 'lucide-react';
 import {
   ActionIcon,
   Box,
@@ -19,12 +27,22 @@ import {
   LoadingOverlay,
   Stack,
   Badge,
+  TextInput,
   Tooltip,
 } from '@mantine/core';
 import { CustomTable, useTable } from './CustomTable';
 import ConfirmationDialog from '../ConfirmationDialog';
 import useBrowserStorage from '../../hooks/useBrowserStorage';
 import { useDateTimeFormat, format } from '../../utils/dateTimeUtils.js';
+import {
+  makeHeaderCellRenderer,
+  makeSortingChangeHandler,
+} from './M3uTableUtils';
+import {
+  getFilteredUsers,
+  getSortedUsers,
+  getUserFullName,
+} from '../../utils/tables/UsersTableUtils.js';
 
 const deleteUser = (id) => {
   return API.deleteUser(id);
@@ -136,6 +154,18 @@ const UsersTable = () => {
   const [userToDelete, setUserToDelete] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  // Empty array means "no column sorted" — the table falls back to its default
+  // id order. The third click on a header returns to this state.
+  const [sorting, setSorting] = useState([]);
+
+  // Debounce the search box so typing doesn't re-filter and re-sort the whole
+  // list on every keystroke.
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
 
   const executeDeleteUser = useCallback(async (id) => {
     setIsLoading(true);
@@ -188,6 +218,7 @@ const UsersTable = () => {
         accessorKey: 'user_level',
         size: 120,
         minSize: 80,
+        sortable: true,
         cell: ({ getValue }) => (
           <Text size="sm">{USER_LEVEL_LABELS[getValue()]}</Text>
         ),
@@ -197,6 +228,7 @@ const UsersTable = () => {
         accessorKey: 'username',
         size: 120,
         minSize: 75,
+        sortable: true,
         cell: ({ getValue }) => (
           <Box
             style={{
@@ -214,8 +246,8 @@ const UsersTable = () => {
         header: 'Name',
         size: 125,
         minSize: 50,
-        accessorFn: (row) =>
-          `${row.first_name || ''} ${row.last_name || ''}`.trim(),
+        sortable: true,
+        accessorFn: getUserFullName,
         cell: ({ getValue }) => (
           <Box
             style={{
@@ -233,6 +265,7 @@ const UsersTable = () => {
         accessorKey: 'email',
         size: 125,
         minSize: 50,
+        sortable: true,
         cell: ({ getValue }) => (
           <Box
             style={{
@@ -248,8 +281,11 @@ const UsersTable = () => {
       {
         header: 'Date Joined',
         accessorKey: 'date_joined',
-        size: 90,
-        minSize: 90,
+        // Wide enough for the header text plus the sort control; at the old
+        // 90px the two no longer fit on one line.
+        size: 120,
+        minSize: 110,
+        sortable: true,
         cell: ({ getValue }) => {
           const date = getValue();
           return (
@@ -262,6 +298,7 @@ const UsersTable = () => {
         accessorKey: 'last_login',
         size: 175,
         minSize: 85,
+        sortable: true,
         cell: ({ getValue }) => {
           const date = getValue();
           return (
@@ -333,17 +370,20 @@ const UsersTable = () => {
     setUserModalOpen(false);
   };
 
+  // Rows actually rendered: search first (cheaper — it shrinks what has to be
+  // sorted), then sort. Copies the store array rather than sorting it in place.
   const data = useMemo(() => {
-    return users.sort((a, b) => a.id - b.id);
-  }, [users]);
+    const filtered = getFilteredUsers(users, debouncedSearch);
+    const sortColumn = sorting[0];
 
-  const renderHeaderCell = (header) => {
-    return (
-      <Text size="sm" name={header.id}>
-        {header.column.columnDef.header}
-      </Text>
-    );
-  };
+    return sortColumn
+      ? getSortedUsers(filtered, sortColumn.id, sortColumn.desc)
+      : [...filtered].sort((a, b) => a.id - b.id);
+  }, [users, debouncedSearch, sorting]);
+
+  const onSortingChange = makeSortingChangeHandler(sorting, setSorting);
+
+  const renderHeaderCell = makeHeaderCellRenderer(sorting, onSortingChange);
 
   const table = useTable({
     columns,
@@ -353,8 +393,11 @@ const UsersTable = () => {
     enableRowSelection: false,
     enableRowVirtualization: false,
     renderTopToolbar: false,
-    manualSorting: false,
-    manualFiltering: false,
+    sorting,
+    // Rows arrive already sorted and filtered by `data` above, so the table
+    // must not reorder or re-filter them itself.
+    manualSorting: true,
+    manualFiltering: true,
     manualPagination: false,
     headerCellRenderFns: {
       actions: renderHeaderCell,
@@ -407,11 +450,35 @@ const UsersTable = () => {
             <Box
               style={{
                 display: 'flex',
-                justifyContent: 'flex-end',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: '16px',
                 padding: '16px',
                 borderBottom: '1px solid #3f3f46',
               }}
             >
+              <TextInput
+                placeholder="Search users..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                w={250}
+                size="xs"
+                leftSection={<Search size={16} />}
+                rightSection={
+                  search ? (
+                    <ActionIcon
+                      onClick={() => setSearch('')}
+                      variant="subtle"
+                      color="gray"
+                      size="sm"
+                      aria-label="Clear search"
+                    >
+                      <X size={14} />
+                    </ActionIcon>
+                  ) : null
+                }
+              />
+
               <Button
                 leftSection={<SquarePlus size={18} />}
                 variant="light"
@@ -441,7 +508,13 @@ const UsersTable = () => {
             >
               <div style={{ minWidth: '900px' }}>
                 <LoadingOverlay visible={isLoading} />
-                <CustomTable table={table} />
+                {data.length === 0 && users.length > 0 ? (
+                  <Text size="xl" c="dimmed" ta="center" py="xl">
+                    No users match this search.
+                  </Text>
+                ) : (
+                  <CustomTable table={table} />
+                )}
               </div>
             </Box>
           </Paper>

--- a/frontend/src/components/tables/__tests__/EPGsTable.test.jsx
+++ b/frontend/src/components/tables/__tests__/EPGsTable.test.jsx
@@ -36,7 +36,7 @@ vi.mock('../../../utils/tables/EPGsTableUtils.js', () => ({
   updateEpg: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../M3uTableUtils.jsx', () => ({
+vi.mock('../tableSortingUtils.jsx', () => ({
   makeHeaderCellRenderer: vi.fn(() => (header) => (
     <span data-testid={`header-${header.id}`}>
       {header.column.columnDef.header}
@@ -250,7 +250,7 @@ import { showNotification } from '../../../utils/notificationUtils.js';
 import * as EPGsTableUtils from '../../../utils/tables/EPGsTableUtils.js';
 import { useTable, CustomTable } from '../CustomTable';
 import useBrowserStorage from '../../../hooks/useBrowserStorage';
-import { makeSortingChangeHandler } from '../M3uTableUtils.jsx';
+import { makeSortingChangeHandler } from '../tableSortingUtils.jsx';
 
 // ── Factories ──────────────────────────────────────────────────────────────────
 const makeEpg = (overrides = {}) => ({

--- a/frontend/src/components/tables/__tests__/M3UsTable.test.jsx
+++ b/frontend/src/components/tables/__tests__/M3UsTable.test.jsx
@@ -44,7 +44,7 @@ vi.mock('../../../utils/tables/M3UsTableUtils.js', () => ({
   updatePlaylist: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../M3uTableUtils.jsx', () => ({
+vi.mock('../tableSortingUtils.jsx', () => ({
   makeHeaderCellRenderer: vi.fn(() => (header) => (
     <span data-testid={`header-${header.id}`}>
       {header.column.columnDef.header}

--- a/frontend/src/components/tables/__tests__/UsersTable.test.jsx
+++ b/frontend/src/components/tables/__tests__/UsersTable.test.jsx
@@ -42,7 +42,15 @@ vi.mock('../../forms/User', () => ({
 }));
 
 vi.mock('../../ConfirmationDialog', () => ({
-  default: ({ opened, onClose, onConfirm, title, loading, confirmLabel, cancelLabel }) =>
+  default: ({
+    opened,
+    onClose,
+    onConfirm,
+    title,
+    loading,
+    confirmLabel,
+    cancelLabel,
+  }) =>
     opened ? (
       <div data-testid="confirm-dialog">
         <span data-testid="confirm-title">{title}</span>
@@ -63,10 +71,17 @@ vi.mock('../CustomTable', () => ({
 
 // ── Mantine core ───────────────────────────────────────────────────────────────
 vi.mock('@mantine/core', () => ({
-  ActionIcon: ({ children, onClick, disabled, color }) => (
+  ActionIcon: ({
+    children,
+    onClick,
+    disabled,
+    color,
+    'aria-label': ariaLabel,
+  }) => (
     <button
       data-testid="action-icon"
       data-color={color}
+      aria-label={ariaLabel}
       onClick={onClick}
       disabled={disabled}
     >
@@ -79,27 +94,41 @@ vi.mock('@mantine/core', () => ({
     </span>
   ),
   Box: ({ children, style }) => <div style={style}>{children}</div>,
+  Center: ({ children }) => <div>{children}</div>,
   Button: ({ children, onClick, leftSection, disabled, loading }) => (
-    <button data-testid="button" onClick={onClick} disabled={disabled || loading}>
+    <button
+      data-testid="button"
+      onClick={onClick}
+      disabled={disabled || loading}
+    >
       {leftSection}
       {children}
     </button>
   ),
   Flex: ({ children, style }) => <div style={style}>{children}</div>,
-  Group: ({ children, style }) => (
-    <div style={style}>{children}</div>
-  ),
-  LoadingOverlay: ({ visible }) => visible ? <div data-testid="loading-overlay" /> : null,
+  Group: ({ children, style }) => <div style={style}>{children}</div>,
+  LoadingOverlay: ({ visible }) =>
+    visible ? <div data-testid="loading-overlay" /> : null,
   Paper: ({ children, style }) => <div style={style}>{children}</div>,
   Stack: ({ children, style }) => <div style={style}>{children}</div>,
+  TextInput: ({ placeholder, value, onChange, leftSection, rightSection }) => (
+    <div>
+      {leftSection}
+      <input
+        data-testid="search-input"
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      />
+      {rightSection}
+    </div>
+  ),
   Text: ({ children, style, name }) => (
     <span data-testid="text" data-name={name} style={style}>
       {children}
     </span>
   ),
-  Tooltip: ({ children, label }) => (
-    <div data-tooltip={label}>{children}</div>
-  ),
+  Tooltip: ({ children, label }) => <div data-tooltip={label}>{children}</div>,
   useMantineTheme: vi.fn(() => ({
     tailwind: {
       yellow: { 3: '#fde047' },
@@ -111,11 +140,22 @@ vi.mock('@mantine/core', () => ({
 
 // ── lucide-react ───────────────────────────────────────────────────────────────
 vi.mock('lucide-react', () => ({
+  ArrowDownWideNarrow: ({ onClick }) => (
+    <svg data-testid="icon-sort-desc" onClick={onClick} />
+  ),
+  ArrowUpDown: ({ onClick }) => (
+    <svg data-testid="icon-sort-none" onClick={onClick} />
+  ),
+  ArrowUpNarrowWide: ({ onClick }) => (
+    <svg data-testid="icon-sort-asc" onClick={onClick} />
+  ),
   Eye: () => <svg data-testid="icon-eye" />,
   EyeOff: () => <svg data-testid="icon-eye-off" />,
   SquareMinus: () => <svg data-testid="icon-square-minus" />,
   SquarePen: () => <svg data-testid="icon-square-pen" />,
   SquarePlus: () => <svg data-testid="icon-square-plus" />,
+  Search: () => <svg data-testid="icon-search" />,
+  X: () => <svg data-testid="icon-x" />,
 }));
 
 // ── Imports after mocks ────────────────────────────────────────────────────────
@@ -145,7 +185,12 @@ const makeUser = (overrides = {}) => ({
 });
 
 const makeAdminUser = (overrides = {}) =>
-  makeUser({ id: 99, username: 'admin', user_level: USER_LEVELS.ADMIN, ...overrides });
+  makeUser({
+    id: 99,
+    username: 'admin',
+    user_level: USER_LEVELS.ADMIN,
+    ...overrides,
+  });
 
 let capturedTableOptions = null;
 
@@ -156,17 +201,11 @@ const setupMocks = ({
   isWarningSuppressed = vi.fn(() => false),
   suppressWarning = vi.fn(),
 } = {}) => {
-  vi.mocked(useUsersStore).mockImplementation((sel) =>
-    sel({ users })
-  );
+  vi.mocked(useUsersStore).mockImplementation((sel) => sel({ users }));
 
-  vi.mocked(useChannelsStore).mockImplementation((sel) =>
-    sel({ profiles })
-  );
+  vi.mocked(useChannelsStore).mockImplementation((sel) => sel({ profiles }));
 
-  vi.mocked(useAuthStore).mockImplementation((sel) =>
-    sel({ user: authUser })
-  );
+  vi.mocked(useAuthStore).mockImplementation((sel) => sel({ user: authUser }));
 
   vi.mocked(useWarningsStore).mockImplementation((sel) =>
     sel({ isWarningSuppressed, suppressWarning })
@@ -326,7 +365,10 @@ describe('UsersTable', () => {
 
     it('edit button is disabled for non-admin auth user', () => {
       const user = makeUser({ id: 5 });
-      setupMocks({ users: [user], authUser: makeUser({ id: 99, user_level: USER_LEVELS.STANDARD }) });
+      setupMocks({
+        users: [user],
+        authUser: makeUser({ id: 99, user_level: USER_LEVELS.STANDARD }),
+      });
       render(<UsersTable />);
 
       const actionsCol = getActionsCell();
@@ -345,7 +387,9 @@ describe('UsersTable', () => {
       const { getByTestId } = render(
         actionsCol.cell({ row: { original: user } })
       );
-      expect(getByTestId('icon-square-pen').closest('button')).not.toBeDisabled();
+      expect(
+        getByTestId('icon-square-pen').closest('button')
+      ).not.toBeDisabled();
     });
   });
 
@@ -364,7 +408,9 @@ describe('UsersTable', () => {
       fireEvent.click(getByTestId('icon-square-minus').closest('button'));
 
       expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
-      expect(screen.getByTestId('confirm-title')).toHaveTextContent('Confirm User Deletion');
+      expect(screen.getByTestId('confirm-title')).toHaveTextContent(
+        'Confirm User Deletion'
+      );
     });
 
     it('calls API.deleteUser when confirmed via dialog', async () => {
@@ -379,9 +425,7 @@ describe('UsersTable', () => {
       fireEvent.click(getByTestId('icon-square-minus').closest('button'));
       fireEvent.click(screen.getByTestId('confirm-ok'));
 
-      await waitFor(() =>
-        expect(API.deleteUser).toHaveBeenCalledWith(5)
-      );
+      await waitFor(() => expect(API.deleteUser).toHaveBeenCalledWith(5));
     });
 
     it('closes the dialog after confirming delete', async () => {
@@ -427,15 +471,16 @@ describe('UsersTable', () => {
       );
       fireEvent.click(getByTestId('icon-square-minus').closest('button'));
 
-      await waitFor(() =>
-        expect(API.deleteUser).toHaveBeenCalledWith(7)
-      );
+      await waitFor(() => expect(API.deleteUser).toHaveBeenCalledWith(7));
       expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
     });
 
     it('delete button is disabled for non-admin auth user', () => {
       const user = makeUser({ id: 5 });
-      setupMocks({ users: [user], authUser: makeUser({ id: 99, user_level: USER_LEVELS.STANDARD }) });
+      setupMocks({
+        users: [user],
+        authUser: makeUser({ id: 99, user_level: USER_LEVELS.STANDARD }),
+      });
       render(<UsersTable />);
 
       const actionsCol = getActionsCell();
@@ -466,7 +511,9 @@ describe('UsersTable', () => {
       const { getByTestId } = render(
         actionsCol.cell({ row: { original: user } })
       );
-      expect(getByTestId('icon-square-minus').closest('button')).not.toBeDisabled();
+      expect(
+        getByTestId('icon-square-minus').closest('button')
+      ).not.toBeDisabled();
     });
   });
 
@@ -490,7 +537,9 @@ describe('UsersTable', () => {
       setupMocks();
       render(<UsersTable />);
 
-      const { getByText, getByTestId } = renderXCCell({ xc_password: 'mypassword' });
+      const { getByText, getByTestId } = renderXCCell({
+        xc_password: 'mypassword',
+      });
       fireEvent.click(getByTestId('icon-eye').closest('button'));
       expect(getByText('mypassword')).toBeInTheDocument();
     });
@@ -499,7 +548,9 @@ describe('UsersTable', () => {
       setupMocks();
       render(<UsersTable />);
 
-      const { getByText, getByTestId } = renderXCCell({ xc_password: 'mypassword' });
+      const { getByText, getByTestId } = renderXCCell({
+        xc_password: 'mypassword',
+      });
       const toggleBtn = getByTestId('icon-eye').closest('button');
       fireEvent.click(toggleBtn);
       fireEvent.click(getByTestId('icon-eye-off').closest('button'));
@@ -538,16 +589,24 @@ describe('UsersTable', () => {
       setupMocks();
       render(<UsersTable />);
       const col = getCol('user_level');
-      const { getByText } = render(col.cell({ getValue: () => USER_LEVELS.ADMIN }));
-      expect(getByText(USER_LEVEL_LABELS[USER_LEVELS.ADMIN])).toBeInTheDocument();
+      const { getByText } = render(
+        col.cell({ getValue: () => USER_LEVELS.ADMIN })
+      );
+      expect(
+        getByText(USER_LEVEL_LABELS[USER_LEVELS.ADMIN])
+      ).toBeInTheDocument();
     });
 
     it('renders the label for STANDARD level', () => {
       setupMocks();
       render(<UsersTable />);
       const col = getCol('user_level');
-      const { getByText } = render(col.cell({ getValue: () => USER_LEVELS.STANDARD }));
-      expect(getByText(USER_LEVEL_LABELS[USER_LEVELS.STANDARD])).toBeInTheDocument();
+      const { getByText } = render(
+        col.cell({ getValue: () => USER_LEVELS.STANDARD })
+      );
+      expect(
+        getByText(USER_LEVEL_LABELS[USER_LEVELS.STANDARD])
+      ).toBeInTheDocument();
     });
   });
 
@@ -590,8 +649,13 @@ describe('UsersTable', () => {
       setupMocks();
       render(<UsersTable />);
       const col = getCol('date_joined');
-      const { getByText } = render(col.cell({ getValue: () => '2024-01-15T10:00:00Z' }));
-      expect(vi.mocked(format)).toHaveBeenCalledWith('2024-01-15T10:00:00Z', 'MM/DD/YYYY');
+      const { getByText } = render(
+        col.cell({ getValue: () => '2024-01-15T10:00:00Z' })
+      );
+      expect(vi.mocked(format)).toHaveBeenCalledWith(
+        '2024-01-15T10:00:00Z',
+        'MM/DD/YYYY'
+      );
       expect(getByText('formatted:2024-01-15T10:00:00Z')).toBeInTheDocument();
     });
 
@@ -609,8 +673,13 @@ describe('UsersTable', () => {
       setupMocks();
       render(<UsersTable />);
       const col = getCol('last_login');
-      const { getByText } = render(col.cell({ getValue: () => '2024-06-01T12:00:00Z' }));
-      expect(vi.mocked(format)).toHaveBeenCalledWith('2024-06-01T12:00:00Z', 'MM/DD/YYYY HH:mm');
+      const { getByText } = render(
+        col.cell({ getValue: () => '2024-06-01T12:00:00Z' })
+      );
+      expect(vi.mocked(format)).toHaveBeenCalledWith(
+        '2024-06-01T12:00:00Z',
+        'MM/DD/YYYY HH:mm'
+      );
       expect(getByText('formatted:2024-06-01T12:00:00Z')).toBeInTheDocument();
     });
 
@@ -634,7 +703,10 @@ describe('UsersTable', () => {
 
     it('renders a badge for each assigned profile', () => {
       setupMocks({
-        profiles: { 10: { id: 10, name: 'HD Profile' }, 20: { id: 20, name: 'SD Profile' } },
+        profiles: {
+          10: { id: 10, name: 'HD Profile' },
+          20: { id: 20, name: 'SD Profile' },
+        },
       });
       render(<UsersTable />);
       const col = getCol('channel_profiles');
@@ -667,10 +739,220 @@ describe('UsersTable', () => {
       expect(capturedTableOptions.enableRowSelection).toBe(false);
     });
 
-    it('passes manualSorting: false', () => {
+    it('passes manualSorting: true so the table keeps the order it is given', () => {
       setupMocks();
       render(<UsersTable />);
-      expect(capturedTableOptions.manualSorting).toBe(false);
+      expect(capturedTableOptions.manualSorting).toBe(true);
+    });
+
+    it('passes manualFiltering: true so the table keeps the rows it is given', () => {
+      setupMocks();
+      render(<UsersTable />);
+      expect(capturedTableOptions.manualFiltering).toBe(true);
+    });
+  });
+
+  // ── Search ─────────────────────────────────────────────────────────────────
+
+  describe('search', () => {
+    const searchUsers = [
+      makeUser({ id: 1, username: 'alice', email: 'alice@example.com' }),
+      makeUser({ id: 2, username: 'bob', email: 'bob@example.com' }),
+    ];
+
+    const typeSearch = (value) =>
+      fireEvent.change(screen.getByTestId('search-input'), {
+        target: { value },
+      });
+
+    it('renders a search box', () => {
+      setupMocks();
+      render(<UsersTable />);
+      expect(screen.getByTestId('search-input')).toBeInTheDocument();
+    });
+
+    it('passes only matching users to the table', async () => {
+      setupMocks({ users: searchUsers });
+      render(<UsersTable />);
+      expect(capturedTableOptions.data).toHaveLength(2);
+
+      typeSearch('alice');
+
+      await waitFor(() =>
+        expect(capturedTableOptions.data.map((u) => u.username)).toEqual([
+          'alice',
+        ])
+      );
+    });
+
+    it('keeps allRowIds in step with the filtered rows', async () => {
+      setupMocks({ users: searchUsers });
+      render(<UsersTable />);
+
+      typeSearch('bob');
+
+      await waitFor(() => expect(capturedTableOptions.allRowIds).toEqual([2]));
+    });
+
+    it('does not filter until the debounce elapses', () => {
+      setupMocks({ users: searchUsers });
+      render(<UsersTable />);
+
+      typeSearch('alice');
+
+      // Synchronously after typing, the unfiltered list is still in place.
+      expect(capturedTableOptions.data).toHaveLength(2);
+    });
+
+    it('shows an empty-state message instead of the table when nothing matches', async () => {
+      setupMocks({ users: searchUsers });
+      render(<UsersTable />);
+      expect(screen.getByTestId('custom-table')).toBeInTheDocument();
+
+      typeSearch('nobody');
+
+      await waitFor(() =>
+        expect(
+          screen.getByText('No users match this search.')
+        ).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId('custom-table')).not.toBeInTheDocument();
+    });
+
+    it('does not show the empty-state message when there are no users at all', () => {
+      setupMocks({ users: [] });
+      render(<UsersTable />);
+      expect(
+        screen.queryByText('No users match this search.')
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('custom-table')).toBeInTheDocument();
+    });
+
+    it('restores every user when the clear button is pressed', async () => {
+      setupMocks({ users: searchUsers });
+      render(<UsersTable />);
+
+      typeSearch('alice');
+      await waitFor(() => expect(capturedTableOptions.data).toHaveLength(1));
+
+      fireEvent.click(screen.getByLabelText('Clear search'));
+
+      await waitFor(() => expect(capturedTableOptions.data).toHaveLength(2));
+    });
+  });
+
+  // ── Sorting ────────────────────────────────────────────────────────────────
+
+  describe('sorting', () => {
+    const sortUsers = [
+      makeUser({ id: 1, username: 'charlie' }),
+      makeUser({ id: 2, username: 'alice' }),
+      makeUser({ id: 3, username: 'bob' }),
+    ];
+
+    // The header cell renderers are handed to useTable, so drive them the way
+    // CustomTableHeader would.
+    const renderHeader = (columnId) => {
+      const element = capturedTableOptions.headerCellRenderFns[columnId]({
+        id: columnId,
+        column: { columnDef: getCol(columnId) },
+      });
+      return render(element);
+    };
+
+    const usernamesInTable = () =>
+      capturedTableOptions.data.map((u) => u.username);
+
+    it('defaults to id order with no column sorted', () => {
+      setupMocks({ users: sortUsers });
+      render(<UsersTable />);
+      expect(usernamesInTable()).toEqual(['charlie', 'alice', 'bob']);
+    });
+
+    it('marks the sortable columns and leaves the rest alone', () => {
+      setupMocks();
+      render(<UsersTable />);
+
+      [
+        'user_level',
+        'username',
+        'name',
+        'email',
+        'date_joined',
+        'last_login',
+      ].forEach((id) => expect(getCol(id).sortable).toBe(true));
+      ['custom_properties', 'channel_profiles', 'actions'].forEach((id) =>
+        expect(getCol(id).sortable).toBeUndefined()
+      );
+    });
+
+    it('cycles ascending → descending → unsorted on repeated clicks', () => {
+      setupMocks({ users: sortUsers });
+      render(<UsersTable />);
+
+      const { unmount } = renderHeader('username');
+      fireEvent.click(screen.getByTestId('icon-sort-none'));
+      expect(usernamesInTable()).toEqual(['alice', 'bob', 'charlie']);
+      unmount();
+
+      // Re-render the header so it picks up the new sorting state, which is
+      // what decides the icon.
+      const second = renderHeader('username');
+      fireEvent.click(screen.getByTestId('icon-sort-asc'));
+      expect(usernamesInTable()).toEqual(['charlie', 'bob', 'alice']);
+      second.unmount();
+
+      renderHeader('username');
+      fireEvent.click(screen.getByTestId('icon-sort-desc'));
+      expect(usernamesInTable()).toEqual(['charlie', 'alice', 'bob']);
+    });
+
+    it('replaces the sorted column rather than stacking sorts', () => {
+      setupMocks({
+        users: [
+          makeUser({ id: 1, username: 'charlie', email: 'a@example.com' }),
+          makeUser({ id: 2, username: 'alice', email: 'c@example.com' }),
+          makeUser({ id: 3, username: 'bob', email: 'b@example.com' }),
+        ],
+      });
+      render(<UsersTable />);
+
+      const { unmount } = renderHeader('username');
+      fireEvent.click(screen.getByTestId('icon-sort-none'));
+      expect(usernamesInTable()).toEqual(['alice', 'bob', 'charlie']);
+      unmount();
+
+      renderHeader('email');
+      fireEvent.click(screen.getByTestId('icon-sort-none'));
+      expect(usernamesInTable()).toEqual(['charlie', 'bob', 'alice']);
+    });
+
+    it('does not render a sort control for non-sortable columns', () => {
+      setupMocks();
+      render(<UsersTable />);
+
+      renderHeader('actions');
+      expect(screen.queryByTestId('icon-sort-none')).not.toBeInTheDocument();
+    });
+
+    it('sorts within the search results, not the whole list', async () => {
+      setupMocks({
+        users: [
+          makeUser({ id: 1, username: 'zeta-team' }),
+          makeUser({ id: 2, username: 'alpha-team' }),
+          makeUser({ id: 3, username: 'other' }),
+        ],
+      });
+      render(<UsersTable />);
+
+      fireEvent.change(screen.getByTestId('search-input'), {
+        target: { value: 'team' },
+      });
+      await waitFor(() => expect(capturedTableOptions.data).toHaveLength(2));
+
+      renderHeader('username');
+      fireEvent.click(screen.getByTestId('icon-sort-none'));
+      expect(usernamesInTable()).toEqual(['alpha-team', 'zeta-team']);
     });
   });
 });

--- a/frontend/src/components/tables/__tests__/tableSortingUtils.test.jsx
+++ b/frontend/src/components/tables/__tests__/tableSortingUtils.test.jsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   makeHeaderCellRenderer,
   makeSortingChangeHandler,
-} from '../M3uTableUtils';
+} from '../tableSortingUtils';
 
 vi.mock('@mantine/core', () => ({
   Center: ({ children }) => <div data-testid="center">{children}</div>,
@@ -224,6 +224,14 @@ describe('makeSortingChangeHandler', () => {
       const handler = makeSortingChangeHandler([], setSorting, onDataSort);
       handler('title');
       expect(setSorting).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('optional onDataSort', () => {
+    it('does not throw when onDataSort is omitted', () => {
+      const handler = makeSortingChangeHandler([], setSorting);
+      expect(() => handler('name')).not.toThrow();
+      expect(setSorting).toHaveBeenCalledWith([{ id: 'name', desc: false }]);
     });
   });
 });

--- a/frontend/src/components/tables/tableSortingUtils.jsx
+++ b/frontend/src/components/tables/tableSortingUtils.jsx
@@ -14,9 +14,8 @@ export const makeHeaderCellRenderer = (sorting, onSortingChange) => (header) => 
   }
 
   return (
-    // nowrap keeps the sort control on the header's line: with the default
-    // wrap, a column only a pixel or two too narrow drops the icon onto a
-    // second row and doubles the header height.
+    // nowrap: default wrap drops the sort icon onto a second row when the
+    // column is only a pixel or two too narrow, doubling the header height.
     <Group gap="xs" wrap="nowrap">
       <Text size="sm" name={header.id}>
         {header.column.columnDef.header}
@@ -43,16 +42,15 @@ export const makeSortingChangeHandler =
       if (sortDirection === false) {
         newSorting[0] = { id: column, desc: true };
       }
-      // third click → clear (empty array)
+      // third click clears sort
     } else {
       newSorting[0] = { id: column, desc: false };
     }
 
     setSorting(newSorting);
-    // Optional: tables that keep their rows in state re-sort them here. Tables
-    // that derive their rows from `sorting` don't pass a callback.
+    // Optional: tables that keep rows in state re-sort here. Tables that
+    // derive rows from `sorting` omit the callback.
     if (onDataSort && newSorting.length > 0) {
       onDataSort(newSorting[0].id, newSorting[0].desc);
     }
   };
-

--- a/frontend/src/utils/tables/UsersTableUtils.js
+++ b/frontend/src/utils/tables/UsersTableUtils.js
@@ -1,0 +1,71 @@
+import { USER_LEVEL_LABELS } from '../../constants';
+
+// The Name column has no backing model field — it is rendered from first_name
+// and last_name. Sorting and searching both go through this helper so the
+// column, the sort order, and the search all agree on what "name" means.
+export const getUserFullName = (user) =>
+  `${user.first_name || ''} ${user.last_name || ''}`.trim();
+
+// Value a column is compared on when sorting. Only the columns that need
+// something other than the raw field are listed; everything else falls through
+// to user[column].
+const getSortValue = (user, column) => {
+  switch (column) {
+    case 'name':
+      return getUserFullName(user);
+    // user_level is stored as a number (0 Streamer / 1 Standard / 10 Admin), so
+    // comparing the raw value orders by privilege rather than alphabetically by
+    // label, which is the ordering that is actually useful here.
+    default:
+      return user[column];
+  }
+};
+
+export const getSortedUsers = (users, compareColumn, compareDesc) => {
+  // Copy first: `users` is the array held in the Zustand store and sort()
+  // mutates in place.
+  return [...users].sort((a, b) => {
+    const aVal = getSortValue(a, compareColumn);
+    const bVal = getSortValue(b, compareColumn);
+
+    // Users with no value (never logged in, blank name) always sort last,
+    // whichever direction the column is sorted in.
+    const aEmpty = aVal == null || aVal === '';
+    const bEmpty = bVal == null || bVal === '';
+    if (aEmpty && bEmpty) return 0;
+    if (aEmpty) return 1;
+    if (bEmpty) return -1;
+
+    const comparison =
+      typeof aVal === 'string'
+        ? aVal.localeCompare(bVal, undefined, { sensitivity: 'base' })
+        : aVal < bVal
+          ? -1
+          : aVal > bVal
+            ? 1
+            : 0;
+
+    return compareDesc ? -comparison : comparison;
+  });
+};
+
+// Fields the search box matches against. The XC password is deliberately
+// excluded — it is masked in the table and matching it would let someone
+// confirm a password without revealing it.
+const getSearchableText = (user) =>
+  [
+    user.username,
+    getUserFullName(user),
+    user.email,
+    USER_LEVEL_LABELS[user.user_level],
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+export const getFilteredUsers = (users, search) => {
+  const query = (search || '').trim().toLowerCase();
+  if (!query) return users;
+
+  return users.filter((user) => getSearchableText(user).includes(query));
+};

--- a/frontend/src/utils/tables/UsersTableUtils.js
+++ b/frontend/src/utils/tables/UsersTableUtils.js
@@ -1,35 +1,27 @@
 import { USER_LEVEL_LABELS } from '../../constants';
 
-// The Name column has no backing model field — it is rendered from first_name
-// and last_name. Sorting and searching both go through this helper so the
-// column, the sort order, and the search all agree on what "name" means.
+// Shared by the Name cell, sort, and search so they cannot disagree on what
+// "name" means (there is no backing model field).
 export const getUserFullName = (user) =>
   `${user.first_name || ''} ${user.last_name || ''}`.trim();
 
-// Value a column is compared on when sorting. Only the columns that need
-// something other than the raw field are listed; everything else falls through
-// to user[column].
 const getSortValue = (user, column) => {
   switch (column) {
     case 'name':
       return getUserFullName(user);
-    // user_level is stored as a number (0 Streamer / 1 Standard / 10 Admin), so
-    // comparing the raw value orders by privilege rather than alphabetically by
-    // label, which is the ordering that is actually useful here.
     default:
+      // user_level stays numeric so sort order is by privilege, not label.
       return user[column];
   }
 };
 
 export const getSortedUsers = (users, compareColumn, compareDesc) => {
-  // Copy first: `users` is the array held in the Zustand store and sort()
-  // mutates in place.
+  // Copy first: `users` is the Zustand store array and sort() mutates in place.
   return [...users].sort((a, b) => {
     const aVal = getSortValue(a, compareColumn);
     const bVal = getSortValue(b, compareColumn);
 
-    // Users with no value (never logged in, blank name) always sort last,
-    // whichever direction the column is sorted in.
+    // Empty values (never logged in, blank name) sort last in both directions.
     const aEmpty = aVal == null || aVal === '';
     const bEmpty = bVal == null || bVal === '';
     if (aEmpty && bEmpty) return 0;
@@ -49,9 +41,8 @@ export const getSortedUsers = (users, compareColumn, compareDesc) => {
   });
 };
 
-// Fields the search box matches against. The XC password is deliberately
-// excluded — it is masked in the table and matching it would let someone
-// confirm a password without revealing it.
+// XC password deliberately omitted: the column masks it, and matching would
+// let someone confirm a password without revealing it.
 const getSearchableText = (user) =>
   [
     user.username,

--- a/frontend/src/utils/tables/__tests__/UsersTableUtils.test.js
+++ b/frontend/src/utils/tables/__tests__/UsersTableUtils.test.js
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getFilteredUsers,
+  getSortedUsers,
+  getUserFullName,
+} from '../UsersTableUtils';
+import { USER_LEVELS } from '../../../constants';
+
+// ── Factory ─────────────────────────────────────────────────────────────────
+const makeUser = (overrides = {}) => ({
+  id: 1,
+  username: 'testuser',
+  first_name: 'Test',
+  last_name: 'User',
+  email: 'test@example.com',
+  user_level: USER_LEVELS.STANDARD,
+  date_joined: '2024-01-15T10:00:00Z',
+  last_login: '2024-06-01T12:00:00Z',
+  ...overrides,
+});
+
+const usernames = (users) => users.map((u) => u.username);
+
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe('getUserFullName', () => {
+  it('joins first and last name', () => {
+    expect(
+      getUserFullName(makeUser({ first_name: 'Ada', last_name: 'Lovelace' }))
+    ).toBe('Ada Lovelace');
+  });
+
+  it('returns an empty string when both names are missing', () => {
+    expect(
+      getUserFullName(makeUser({ first_name: null, last_name: null }))
+    ).toBe('');
+  });
+
+  it('does not leave a stray space when only one name is set', () => {
+    expect(
+      getUserFullName(makeUser({ first_name: 'Ada', last_name: '' }))
+    ).toBe('Ada');
+    expect(
+      getUserFullName(makeUser({ first_name: '', last_name: 'Lovelace' }))
+    ).toBe('Lovelace');
+  });
+});
+
+describe('getSortedUsers', () => {
+  const users = [
+    makeUser({ id: 1, username: 'charlie' }),
+    makeUser({ id: 2, username: 'alice' }),
+    makeUser({ id: 3, username: 'bob' }),
+  ];
+
+  it('sorts strings ascending', () => {
+    expect(usernames(getSortedUsers(users, 'username', false))).toEqual([
+      'alice',
+      'bob',
+      'charlie',
+    ]);
+  });
+
+  it('sorts strings descending', () => {
+    expect(usernames(getSortedUsers(users, 'username', true))).toEqual([
+      'charlie',
+      'bob',
+      'alice',
+    ]);
+  });
+
+  it('does not mutate the array it is given', () => {
+    const input = [...users];
+    getSortedUsers(input, 'username', false);
+    expect(usernames(input)).toEqual(['charlie', 'alice', 'bob']);
+  });
+
+  it('sorts the virtual name column on the combined first and last name', () => {
+    const named = [
+      makeUser({ id: 1, username: 'a', first_name: 'Zoe', last_name: 'Adams' }),
+      makeUser({ id: 2, username: 'b', first_name: 'Ada', last_name: 'Zeta' }),
+    ];
+    expect(usernames(getSortedUsers(named, 'name', false))).toEqual(['b', 'a']);
+  });
+
+  it('compares case-insensitively', () => {
+    const mixed = [
+      makeUser({ id: 1, username: 'beta' }),
+      makeUser({ id: 2, username: 'Alpha' }),
+    ];
+    expect(usernames(getSortedUsers(mixed, 'username', false))).toEqual([
+      'Alpha',
+      'beta',
+    ]);
+  });
+
+  it('sorts user_level numerically by privilege, not by label', () => {
+    // Numeric order is Streamer (0) → Standard (1) → Admin (10). Sorting the
+    // labels alphabetically would give Admin → Standard User → Streamer.
+    const levels = [
+      makeUser({ id: 1, username: 'admin', user_level: USER_LEVELS.ADMIN }),
+      makeUser({
+        id: 2,
+        username: 'streamer',
+        user_level: USER_LEVELS.STREAMER,
+      }),
+      makeUser({
+        id: 3,
+        username: 'standard',
+        user_level: USER_LEVELS.STANDARD,
+      }),
+    ];
+    expect(usernames(getSortedUsers(levels, 'user_level', false))).toEqual([
+      'streamer',
+      'standard',
+      'admin',
+    ]);
+  });
+
+  it('sorts ISO date strings chronologically', () => {
+    const dated = [
+      makeUser({
+        id: 1,
+        username: 'newer',
+        last_login: '2024-06-01T12:00:00Z',
+      }),
+      makeUser({
+        id: 2,
+        username: 'older',
+        last_login: '2023-01-01T12:00:00Z',
+      }),
+    ];
+    expect(usernames(getSortedUsers(dated, 'last_login', false))).toEqual([
+      'older',
+      'newer',
+    ]);
+  });
+
+  it('puts users with no value last in both directions', () => {
+    const partial = [
+      makeUser({ id: 1, username: 'never', last_login: null }),
+      makeUser({
+        id: 2,
+        username: 'older',
+        last_login: '2023-01-01T12:00:00Z',
+      }),
+      makeUser({
+        id: 3,
+        username: 'newer',
+        last_login: '2024-06-01T12:00:00Z',
+      }),
+    ];
+    expect(usernames(getSortedUsers(partial, 'last_login', false))).toEqual([
+      'older',
+      'newer',
+      'never',
+    ]);
+    expect(usernames(getSortedUsers(partial, 'last_login', true))).toEqual([
+      'newer',
+      'older',
+      'never',
+    ]);
+  });
+
+  it('treats a blank name as no value', () => {
+    const partial = [
+      makeUser({ id: 1, username: 'blank', first_name: '', last_name: '' }),
+      makeUser({ id: 2, username: 'named', first_name: 'Ada', last_name: 'L' }),
+    ];
+    expect(usernames(getSortedUsers(partial, 'name', false))).toEqual([
+      'named',
+      'blank',
+    ]);
+  });
+});
+
+describe('getFilteredUsers', () => {
+  const users = [
+    makeUser({
+      id: 1,
+      username: 'alice',
+      first_name: 'Alice',
+      last_name: 'Smith',
+      email: 'alice@example.com',
+      user_level: USER_LEVELS.ADMIN,
+    }),
+    makeUser({
+      id: 2,
+      username: 'bob',
+      first_name: 'Bob',
+      last_name: 'Jones',
+      email: 'bob@other.org',
+      user_level: USER_LEVELS.STREAMER,
+    }),
+  ];
+
+  it('returns every user when the search is empty', () => {
+    expect(getFilteredUsers(users, '')).toHaveLength(2);
+    expect(getFilteredUsers(users, '   ')).toHaveLength(2);
+    expect(getFilteredUsers(users, null)).toHaveLength(2);
+  });
+
+  it('matches on username', () => {
+    expect(usernames(getFilteredUsers(users, 'ali'))).toEqual(['alice']);
+  });
+
+  it('matches on email', () => {
+    expect(usernames(getFilteredUsers(users, 'other.org'))).toEqual(['bob']);
+  });
+
+  it('matches on last name, which is not a column of its own', () => {
+    expect(usernames(getFilteredUsers(users, 'jones'))).toEqual(['bob']);
+  });
+
+  it('matches on the user level label shown in the table', () => {
+    expect(usernames(getFilteredUsers(users, 'streamer'))).toEqual(['bob']);
+  });
+
+  it('is case-insensitive and ignores surrounding whitespace', () => {
+    expect(usernames(getFilteredUsers(users, '  ALICE  '))).toEqual(['alice']);
+  });
+
+  it('never matches on the XC password, which the table masks', () => {
+    const withPassword = [
+      makeUser({
+        id: 1,
+        username: 'alice',
+        custom_properties: { xc_password: 'hunter2' },
+      }),
+    ];
+    expect(getFilteredUsers(withPassword, 'hunter2')).toEqual([]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(getFilteredUsers(users, 'nobody')).toEqual([]);
+  });
+
+  it('tolerates users with missing name and email fields', () => {
+    const sparse = [
+      makeUser({
+        id: 1,
+        username: 'ghost',
+        first_name: null,
+        last_name: null,
+        email: null,
+      }),
+    ];
+    expect(usernames(getFilteredUsers(sparse, 'ghost'))).toEqual(['ghost']);
+  });
+});

--- a/frontend/src/utils/tables/__tests__/UsersTableUtils.test.js
+++ b/frontend/src/utils/tables/__tests__/UsersTableUtils.test.js
@@ -95,8 +95,8 @@ describe('getSortedUsers', () => {
   });
 
   it('sorts user_level numerically by privilege, not by label', () => {
-    // Numeric order is Streamer (0) → Standard (1) → Admin (10). Sorting the
-    // labels alphabetically would give Admin → Standard User → Streamer.
+    // Numeric order is Streamer (0), Standard (1), Admin (10). Alphabetical
+    // by label would be Admin, Standard User, Streamer.
     const levels = [
       makeUser({ id: 1, username: 'admin', user_level: USER_LEVELS.ADMIN }),
       makeUser({


### PR DESCRIPTION
## Description

Adds client-side sorting and search to the Users page. Frontend only — no API, model or migration changes.

- **Sort** on User Level, Username, Name, Email, Date Joined and Last Login. Clicking a header cycles ascending → descending → unsorted, matching the M3U and EPG tables. XC Password, Channel Profiles and Actions are not sortable.
- **Search** — a debounced (300 ms) box in the existing toolbar matching username, full name, email and the user level label, case-insensitively. Sorting applies within the search results.
- Empty-state message when a search matches nothing.

The page previously rendered every account in fixed `id` order with no way to reorder or narrow it, which stops scaling at a few dozen users. Every other data-heavy table in the app already sorts and/or filters; Users was the outlier.

### How it works

**Sorting is done on the data, not by TanStack.** `useTable` registers only `getCoreRowModel`, and nothing in the frontend registers `getSortedRowModel` or `getFilteredRowModel` — so every table that sorts does it by sorting its own array and passing `manualSorting: true`. This follows that: rows are derived in one `useMemo` (filter first, since it shrinks what has to be sorted, then sort) and the table is told not to reorder or re-filter them.

Columns opt in with the existing custom `sortable` flag, and the header cells reuse `makeHeaderCellRenderer` / `makeSortingChangeHandler` from `M3uTableUtils` rather than reimplementing the click cycle.

Non-obvious decisions:

- **`getSortedUsers` copies before sorting.** The previous `data` memo called `users.sort(...)`, which sorts the Zustand store's own array in place. That was pre-existing, but the new code sorts far more often, so the copy matters.
- **`user_level` is compared on its raw numeric value** (0 / 1 / 10), so the order is by privilege. Sorting the labels alphabetically would give Admin → Standard User → Streamer.
- **The Name column has no model field** — it's `first_name + last_name`. The cell renderer, the sort and the search all go through `getUserFullName` so they can't drift apart.
- **Empty values sort last in both directions**, rather than leading in one. A blank name or a "Never" last-login isn't meaningfully smallest-or-largest, and 25 of the 84 accounts on my own install have no name set — having them swap between the top and bottom of the list on every direction toggle is noise.
- **Search deliberately excludes `custom_properties.xc_password`.** The column masks it behind `••••••••`; making it searchable would let someone confirm a password without ever revealing it.

### Changes outside `UsersTable.jsx`

Two, both in `M3uTableUtils.jsx`, both required by this feature rather than incidental cleanup — calling them out explicitly since they touch the M3U and EPG header rows:

1. `makeSortingChangeHandler`'s `onDataSort` callback is now optional. M3Us/EPGs keep their rows in state and re-sort them in that callback; this page derives rows from `sorting`, so it has nothing to pass. Making the argument optional was preferable to duplicating the three-click cycle logic. Existing callers are unaffected.
2. `makeHeaderCellRenderer`'s `Group` is now `wrap="nowrap"` with `gap="xs"`. With the default wrap and 16 px gap, the Date Joined header needed 105 px (75 label + 16 gap + 14 icon) in a 104 px column and dropped the sort icon onto a second row, doubling the header height. I checked the M3U and EPG header rows render correctly with the tighter grouping. Date Joined's own width also went 90 → 120 since it now carries a control.

If you'd rather these were not in this PR, I can inline a Users-specific header renderer instead — but that duplicates the cycle logic, so I went with the shared change.

## Related Issue

Closes #1626

## How was it tested?

**Automated**

- `npm run test` — **6305 tests pass across 207 files**, including the existing M3U and EPG table suites that share the changed renderer.
- New `frontend/src/utils/tables/__tests__/UsersTableUtils.test.js` (21 tests): sort direction, case-insensitive collation, that sorting does not mutate the input array, the virtual name column, numeric level ordering, null/blank-last in both directions, and that the XC password is not searchable.
- `frontend/src/components/tables/__tests__/UsersTable.test.jsx` extended 46 → 59 tests: search filtering, `allRowIds` staying in step with the filtered rows, the debounce, the empty state, the clear button, the sort cycle, sort replacing rather than stacking, non-sortable columns having no control, and sorting within search results.

**Manual, in a browser**

Ran a dev container built from this branch (`DISPATCHARR_ENV=dev`, vite + HMR) and drove the page with Playwright:

- Sort cycle asc → desc → off on all six sortable columns; verified the rendered row order each time.
- Search matching username, surname-only, email domain and user level label; verified case-insensitivity in both directions (a lowercase query matching a capitalised username and vice versa); verified `xc_password` values return no matches.
- Empty state, and the clear (×) button restoring the full list.
- Measured the header layout in-page to confirm the Date Joined sort icon no longer wraps to a second row (all header groups 20 px tall, previously 50 px for that one column).

Then loaded a **real 84-account user list** (25 with no name set, 82 never logged in) into the container to exercise the null/blank paths on non-synthetic data: blanks and "Never" trail correctly in both sort directions, level sorts Streamer → Standard User → Admin, and a re-sort of 84 rows takes ~30 ms measured click-to-paint.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

Two notes so those boxes aren't overstated:

- **Backend items are vacuous here** — no models and no endpoints were touched, so there is nothing to migrate or to appear in the OpenAPI schema.
- **On lint/format:** `npm run lint` reports 164 problems (108 errors, 56 warnings) on `dev`, and reports *exactly the same* 164 on this branch — this PR introduces none. My five touched files report a single warning, a `useMemo` dependency on `profileIdToName` in `UsersTable.jsx` that is pre-existing on `dev` and outside this change. There is no `format` script in `frontend/package.json` (the template and CONTRIBUTING both reference `npm run format`), so I verified formatting with `npx prettier --check` on the changed files instead; all new files are clean. Happy to add a `format` script in a separate PR if that would be useful.

---

*Disclosure: this PR was written with AI assistance (Claude). I have reviewed the diff and stand behind it — the reasoning behind each non-obvious decision is written up above, and I'm happy to talk through any line in review or rework anything you'd prefer done differently.*
