### PR TITLE
test(epg): pin the grid dummy tests to a fixed request clock

### DIFF
--- a/apps/epg/tests/test_epg_grid_api.py
+++ b/apps/epg/tests/test_epg_grid_api.py
@@ -5,7 +5,8 @@ channels that have no EPG data (standard dummy) or a dummy EPG source (custom
 regex dummy).
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
+from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.db import connection
@@ -32,6 +33,9 @@ NHL_PROPS = {
     "program_duration": 180,
 }
 
+# Mid-day, so every evening fixture event is still ahead of the request clock.
+FIXED_NOW = datetime(2026, 1, 15, 12, 0, tzinfo=dt_timezone.utc)
+
 
 class EPGGridDummyProgramTests(TestCase):
     def setUp(self):
@@ -56,7 +60,8 @@ class EPGGridDummyProgramTests(TestCase):
         )
 
     def _get_grid(self):
-        response = self.client.get(GRID_URL)
+        with mock.patch.object(timezone, "now", return_value=FIXED_NOW):
+            response = self.client.get(GRID_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return response.data["data"]
 
@@ -173,15 +178,14 @@ class EPGGridDummyProgramTests(TestCase):
             epg_data=epg_data,
         )
 
-        now = timezone.now()
         programs = self._for_channel(self._get_grid(), channel)
 
         self.assertTrue(programs)
         for program in programs:
             start = timezone.datetime.fromisoformat(program["start_time"])
             end = timezone.datetime.fromisoformat(program["end_time"])
-            self.assertLess(start, now + timedelta(hours=24))
-            self.assertGreater(end, now - timedelta(hours=1, minutes=5))
+            self.assertLess(start, FIXED_NOW + timedelta(hours=24))
+            self.assertGreater(end, FIXED_NOW - timedelta(hours=1, minutes=5))
 
     def test_stream_name_source_resolves_by_channelstream_order(self):
         """stream_index must follow channelstream order, not Stream's own ordering.
@@ -276,11 +280,10 @@ class EPGGridDummyProgramTests(TestCase):
             channel_group=self.group,
             epg_data=epg_data,
         )
-        now = timezone.now()
         ProgramData.objects.create(
             epg=epg_data,
-            start_time=now - timedelta(minutes=30),
-            end_time=now + timedelta(minutes=30),
+            start_time=FIXED_NOW - timedelta(minutes=30),
+            end_time=FIXED_NOW + timedelta(minutes=30),
             title="Live Show",
             description="Airing now",
             tvg_id="real.channel",


### PR DESCRIPTION
## Description

Pins the EPG grid dummy-program tests to a fixed request clock, because today they only pass at some times of day.

The dummy timelines are generated relative to the request clock, and the class fixtures describe evening events in UTC (`"@ 07:00 PM"` through `"@ 11:00 PM"` with `"timezone": "UTC"`, 180-minute duration). Once such an event has ended — from 22:00 UTC onward for the 07:00 PM fixture — the recurring generator's overlap gate (`_generate_recurring_time_programs` in `apps/output/dummy_epg.py`) skips the whole event day, the grid comes back empty for that channel until midnight UTC, and `test_unmatched_stream_index_falls_back_to_stream_1` fails with `AssertionError: [] is not true`. Any CI run between 22:00 and 00:00 UTC hits it reliably; daytime runs never do, which is why it has looked like a flake.

The fix pins `timezone.now()` to a mid-day instant for the grid request (and uses the same instant for the two assertions and one fixture that previously read the real clock), so every fixture event is still ahead of the request clock regardless of when the suite runs.

One observation left deliberately out of scope: the same mechanism means a real dummy channel whose daily event has ended advertises an empty grid for the rest of its day — the ended-filler arm inside the day-0 branch is unreachable once the overlap gate `continue`s. Whether that filler should cover the post-event window is a generator behaviour question; happy to file it separately if you agree it's worth changing.

## Related Issue

Closes #

## How was it tested?

- Reproduced the failure on a clean `dev` checkout (`bb799a52`) at ~23:50 UTC in the CI-equivalent container: `apps.epg.tests.test_epg_grid_api` fails 11/12 with exactly the CI error, unmodified.
- With this change, `apps.epg.tests.test_epg_grid_api` passes 12/12, and the full `apps.epg.tests` suite passes 322/322 in the same container.
- Non-vacuity check: temporarily setting the pinned instant to 23:18 UTC (inside the failure window) reproduces the original failure deterministically at any wall-clock, confirming the pin controls the behaviour under test.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
