### PR TITLE
fix(vod): strict-client XC payloads, session cleanup race, self-termination and capacity races around VOD playback

### DIFF
--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -689,7 +689,7 @@ class XcVodSeriesRegressionTests(TestCase):
         self.assertEqual(stream["stream_type"], "movie")
         self.assertEqual(stream["stream_id"], movie.id)
         self.assertEqual(stream["rating_5based"], 5.0)
-        self.assertEqual(stream["custom_sid"], None)
+        self.assertEqual(stream["custom_sid"], "")
         self.assertEqual(stream["direct_source"], "")
 
     def test_vod_streams_null_optional_fields(self):
@@ -704,7 +704,8 @@ class XcVodSeriesRegressionTests(TestCase):
 
         stream = xc_get_vod_streams(self.request, self.user)[0]
 
-        self.assertIsNone(stream["stream_icon"])
+        # Strict XC clients reject JSON null where a string is expected.
+        self.assertEqual(stream["stream_icon"], "")
         self.assertEqual(stream["category_id"], "0")
         self.assertEqual(stream["category_ids"], [])
         self.assertEqual(stream["container_extension"], "mp4")
@@ -993,7 +994,8 @@ class XcVodSeriesRegressionTests(TestCase):
 
         row = xc_get_series(self.request, self.user)[0]
 
-        self.assertIsNone(row["cover"])
+        # Strict XC clients reject JSON null where a string is expected.
+        self.assertEqual(row["cover"], "")
         self.assertEqual(row["category_id"], "0")
         self.assertEqual(row["category_ids"], [])
         self.assertEqual(row["release_date"], "")

--- a/apps/output/tests/test_xc_series_info.py
+++ b/apps/output/tests/test_xc_series_info.py
@@ -107,6 +107,30 @@ class XCGetSeriesInfoTests(TestCase):
         info = self._info(self.relation_a.id)
         self.assertEqual(info['episodes'][1][0]['container_extension'], 'mp4')
 
+    def test_episode_payload_has_no_nulls_and_string_ids(self):
+        # Strict XC clients (e.g. iPlayTV on Apple TV) reject JSON null where
+        # a string is expected and reject numeric episode ids; real panels
+        # emit strings and empty strings for absent values.
+        info = self._info(self.relation_a.id)
+
+        def assert_no_null(node, path):
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    assert_no_null(value, f"{path}.{key}")
+            elif isinstance(node, list):
+                for index, value in enumerate(node):
+                    assert_no_null(value, f"{path}[{index}]")
+            else:
+                self.assertIsNotNone(node, f"null value at {path}")
+
+        self.assertTrue(info['episodes'])
+        for season, episodes in info['episodes'].items():
+            for episode in episodes:
+                assert_no_null(episode, f"episodes[{season}]")
+                self.assertIsInstance(episode['id'], str)
+                self.assertIsInstance(episode['info']['id'], str)
+                self.assertEqual(episode['custom_sid'], "")
+
     def test_episode_artwork_prefers_higher_priority_relation(self):
         self.s1e1.custom_properties = {
             'movie_image': 'https://cdn.example.com/stale.jpg',

--- a/apps/output/views.py
+++ b/apps/output/views.py
@@ -1335,7 +1335,7 @@ def xc_get_vod_streams(request, user, category_id=None):
                 logo_id=row['movie__logo_id'],
                 logo_url_parts=_logo_url_parts,
                 url_parts=_movie_image_parts,
-            ),
+            ) or "",
             "rating": rating or "0",
             "rating_5based": round(float(rating or 0) / 2, 2) if rating else 0,
             "added": str(int(row['movie__created_at'].timestamp())),
@@ -1352,7 +1352,7 @@ def xc_get_vod_streams(request, user, category_id=None):
             "category_id": category_id_str,
             "category_ids": category_id_list,
             "container_extension": row['container_extension'] or "mp4",
-            "custom_sid": None,
+            "custom_sid": "",
             "direct_source": "",
         })
 
@@ -1429,7 +1429,7 @@ def xc_get_series(request, user, category_id=None):
                 logo_id=row['series__logo_id'],
                 logo_url_parts=_logo_url_parts,
                 url_parts=_series_image_parts,
-            ),
+            ) or "",
             "plot": row['series__description'] or "",
             "cast": custom_props.get('cast', ''),
             "director": custom_props.get('director', ''),
@@ -1569,16 +1569,18 @@ def xc_get_series_info(request, user, series_id):
         )
 
         seasons[season_num].append({
-            "id": episode.id,
+            # Real XC panels emit episode ids as strings; strict clients
+            # (e.g. iPlayTV) reject JSON numbers where they expect strings.
+            "id": str(episode.id),
             "season": season_num,
             "episode_num": episode.episode_number or 0,
             "title": episode.name,
             "container_extension": container_extension,
             "added": added_timestamp,
-            "custom_sid": None,
+            "custom_sid": "",
             "direct_source": "",
             "info": {
-                "id": int(episode.id),
+                "id": str(episode.id),
                 "name": episode.name,
                 "overview": episode.description or "",
                 "crew": str(episode.custom_properties.get('crew', "") if episode.custom_properties else ""),
@@ -1882,7 +1884,7 @@ def xc_get_vod_info(request, user, vod_id):
             "category_id": str(movie_relation.category.id) if movie_relation.category else "0",
             "category_ids": [int(movie_relation.category.id)] if movie_relation.category else [],
             "container_extension": movie_relation.container_extension or "mp4",
-            "custom_sid": None,
+            "custom_sid": "",
             "direct_source": "",
         }
     }

--- a/apps/proxy/tests/test_stream_limits.py
+++ b/apps/proxy/tests/test_stream_limits.py
@@ -283,3 +283,70 @@ class TimeshiftAdminStopTests(TestCase):
         programme_stop = RedisKeys.client_stop(self.programme_vid, self.client_id)
         self.assertEqual(self.redis.store.get(programme_stop), _STOP_REASON_ADMIN)
         self.assertIn(self.programme_vid, result["stop_channel_ids"])
+
+
+class VodSiblingLimitExemptionTests(TestCase):
+    """A user's own VOD connection to the media they are requesting must not
+    count against their stream limit nor be terminated to serve its own
+    continuation (range/probe/seek requests from the same viewing session)."""
+
+    class _User:
+        id = 5
+        username = "viewer"
+        stream_limit = 1
+
+    def _limits_settings(self):
+        return {
+            "terminate_oldest": True,
+            "prioritize_single_client_channels": True,
+            "ignore_same_channel_connections": False,
+        }
+
+    def _run(self, connections, media_id, terminate_result=True):
+        with patch(
+            "apps.proxy.utils.get_user_active_connections",
+            return_value=connections,
+        ), patch(
+            "apps.proxy.utils.CoreSettings.get_user_limits_settings",
+            return_value=self._limits_settings(),
+        ), patch(
+            "apps.proxy.utils.attempt_stream_termination",
+            return_value=terminate_result,
+        ) as terminate:
+            allowed = check_user_stream_limits(
+                self._User(), "newsession", media_id=media_id
+            )
+        return allowed, terminate
+
+    def test_same_content_vod_sibling_allowed_without_termination(self):
+        connections = [{
+            "media_id": "content-uuid-1",
+            "client_id": "vod_existing",
+            "connected_at": 1000.0,
+            "type": "vod",
+        }]
+        allowed, terminate = self._run(connections, media_id="content-uuid-1")
+        self.assertTrue(allowed)
+        terminate.assert_not_called()
+
+    def test_different_content_still_enforces_limit(self):
+        connections = [{
+            "media_id": "content-uuid-1",
+            "client_id": "vod_existing",
+            "connected_at": 1000.0,
+            "type": "vod",
+        }]
+        allowed, terminate = self._run(connections, media_id="content-uuid-2")
+        self.assertTrue(allowed)
+        terminate.assert_called_once()
+
+    def test_live_connection_does_not_trigger_vod_exemption(self):
+        connections = [{
+            "media_id": "7",
+            "client_id": "live_existing",
+            "connected_at": 1000.0,
+            "type": "live",
+        }]
+        allowed, terminate = self._run(connections, media_id="7")
+        self.assertTrue(allowed)
+        terminate.assert_called_once()

--- a/apps/proxy/utils.py
+++ b/apps/proxy/utils.py
@@ -354,6 +354,21 @@ def check_user_stream_limits(user, client_id, media_id=None):
                         )
                         return True
 
+        # VOD sibling range/probe requests for the same content share one
+        # viewing session (idle-session reuse) - never count the user's own
+        # connection to the media they are requesting against their limit,
+        # and never terminate it to make room for its own continuation
+        # (mirrors the live same-channel and timeshift sibling exemptions).
+        if media_id and any(
+            conn.get('type') not in ('live', 'timeshift')
+            and str(conn.get('media_id') or '') == str(media_id)
+            for conn in active_connections
+        ):
+            logger.debug(
+                f"[stream limits][{client_id}] Same-content VOD sibling for {media_id} allowed"
+            )
+            return True
+
         if user_stream_count >= user.stream_limit:
             if user_limit_settings.get("terminate_on_limit_exceeded", True) == False:
                 return False

--- a/apps/proxy/vod_proxy/multi_worker_connection_manager.py
+++ b/apps/proxy/vod_proxy/multi_worker_connection_manager.py
@@ -773,6 +773,23 @@ class RedisBackedVODConnection:
                 logger.info(f"[{self.session_id}] Active streams present ({state.active_streams}) but owned by worker {state.worker_id} - local cleanup only")
             return
 
+        # Grace period: clients that chain rapid range requests (VLC-based
+        # players probing MKV containers) can be mid-flight between profile
+        # slot reserve and stream INCR on this same session; deleting the
+        # state here orphans that request and leaks its reserved profile
+        # slot. Skip the delete while the session saw activity recently -
+        # the key TTL still reaps abandoned sessions.
+        try:
+            _idle_for = time.time() - float(state.last_activity or 0)
+        except (TypeError, ValueError):
+            _idle_for = float('inf')
+        if _idle_for < 20:
+            logger.debug(
+                f"[{self.session_id}] Cleanup deferred - session active "
+                f"{_idle_for:.1f}s ago"
+            )
+            return
+
         # No active streams: atomically delete only if still idle (Lua).
         # Avoids racing a reconnect INCR between HGET and DEL without holding
         # the metadata lock across the whole check.

--- a/apps/proxy/vod_proxy/tests/test_vod_lock_contention.py
+++ b/apps/proxy/vod_proxy/tests/test_vod_lock_contention.py
@@ -223,6 +223,14 @@ def _seed_session(redis, session_id, active_streams=1, profile_id=7):
     return conn
 
 
+def _age_session(redis, conn, seconds=30):
+    """Push last_activity beyond the idle-cleanup activity grace period."""
+    redis.hset(
+        conn.connection_key,
+        mapping={"last_activity": str(time.time() - seconds)},
+    )
+
+
 class TestAtomicActiveStreams(SimpleTestCase):
     def test_incr_decr_round_trip(self):
         RedisBackedVODConnection, _ = _import_vod()
@@ -335,13 +343,24 @@ class TestAtomicActiveStreams(SimpleTestCase):
     def test_cleanup_deletes_when_idle(self):
         redis = LockAwareFakeRedis()
         conn = _seed_session(redis, "vod_clean_idle", active_streams=0)
+        _age_session(redis, conn)
         conn.cleanup()
         self.assertIsNone(conn._get_connection_state())
+
+    def test_cleanup_defers_while_recently_active(self):
+        """A session with recent activity must survive idle cleanup - a
+        reusing request may be mid-flight between profile-slot reserve and
+        stream INCR on this same session (the key TTL reaps it later)."""
+        redis = LockAwareFakeRedis()
+        conn = _seed_session(redis, "vod_clean_grace", active_streams=0)
+        conn.cleanup()
+        self.assertIsNotNone(conn._get_connection_state())
 
     def test_cleanup_does_not_delete_metadata_lock(self):
         """Idle cleanup must not steal the metadata lock from a holder."""
         redis = LockAwareFakeRedis()
         holder = _seed_session(redis, "vod_lock_keep", active_streams=0)
+        _age_session(redis, holder)
         self.assertTrue(holder._acquire_lock())
         try:
             holder.cleanup()
@@ -358,6 +377,7 @@ class TestAtomicActiveStreams(SimpleTestCase):
         redis = LockAwareFakeRedis()
         holder = _seed_session(redis, "vod_zombie_raw", active_streams=0)
         stale = holder._get_connection_state()
+        _age_session(redis, holder)
         self.assertTrue(holder._acquire_lock())
         try:
             holder.cleanup()
@@ -382,6 +402,7 @@ class TestAtomicActiveStreams(SimpleTestCase):
         stale = holder._get_connection_state()
         stale.worker_id = "worker-late"
         stale.last_activity = time.time()
+        _age_session(redis, holder)
 
         self.assertTrue(holder._acquire_lock())
         try:
@@ -531,6 +552,7 @@ class TestVodActiveStreamsRealRedis(SimpleTestCase):
         holder = self._seed(active_streams=0)
         stale = holder._get_connection_state()
         stale.worker_id = "late-writer"
+        _age_session(self.redis, holder)
 
         self.assertTrue(holder._acquire_lock())
         try:

--- a/apps/proxy/vod_proxy/views.py
+++ b/apps/proxy/vod_proxy/views.py
@@ -24,7 +24,7 @@ from apps.accounts.models import User
 from apps.accounts.permissions import IsAdmin
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from apps.accounts.authentication import ApiKeyAuthentication, QueryParamJWTAuthentication
-from apps.proxy.utils import check_user_stream_limits
+from apps.proxy.utils import check_user_stream_limits, get_user_active_connections
 from dispatcharr.utils import network_access_allowed
 from core.utils import dispatcharr_user_agent
 
@@ -678,6 +678,40 @@ def _vod_playback_allowed(content_type, user):
     return True
 
 
+def _displace_own_vod_stream(user, content_id, requesting_session_id):
+    """Same-user same-content takeover: when a seek/reopen cannot get a
+    provider slot because the viewer's own stream still holds it, signal
+    that stream to stop so the new request can take over (mirrors the
+    timeshift scrub preemption). Returns the displaced client ids."""
+    displaced = []
+    try:
+        connections = get_user_active_connections(user.id)
+    except Exception as e:
+        logger.warning(f"[VOD-TAKEOVER] Could not list connections: {e}")
+        return displaced
+    redis_client = MultiWorkerVODConnectionManager.get_instance().redis_client
+    if not redis_client:
+        return displaced
+    for conn in connections:
+        if conn.get('type') in ('live', 'timeshift'):
+            continue
+        if str(conn.get('media_id') or '') != str(content_id):
+            continue
+        cid = conn.get('client_id')
+        if not cid:
+            continue
+        try:
+            redis_client.setex(get_vod_client_stop_key(cid), 60, "true")
+            displaced.append(cid)
+            logger.info(
+                f"[VOD-TAKEOVER] Displacing own stream {cid} on media {content_id} "
+                f"for seek/reopen by session {requesting_session_id}"
+            )
+        except Exception as e:
+            logger.warning(f"[VOD-TAKEOVER] Failed to signal {cid}: {e}")
+    return displaced
+
+
 @api_view(["GET"])
 @authentication_classes([JWTAuthentication, ApiKeyAuthentication, QueryParamJWTAuthentication])
 @permission_classes([AllowAny])
@@ -867,6 +901,35 @@ def stream_vod(request, content_type, content_id, session_id=None, profile_id=No
             profile_id,
             session_id,
         )
+        if not selected and user:
+            # Displace the viewer's own same-content stream if one holds the
+            # slot (seek/reopen), then retry regardless: players open several
+            # parallel probe connections at start-up which hold the slot for
+            # well under a second, so a brief bounded wait beats an instant
+            # 503 that makes the client abort playback entirely.
+            displaced = _displace_own_vod_stream(user, content_id, session_id)
+            for _ in range(10):
+                time.sleep(0.3)
+                selected = _select_vod_stream(
+                    content_type,
+                    content_id,
+                    preferred_m3u_account_id,
+                    preferred_stream_id,
+                    profile_id,
+                    session_id,
+                )
+                if selected:
+                    break
+            # Consume our own displacement signals so the new stream
+            # (possibly reusing the same session id) never reads a stale
+            # kill order meant for its predecessor.
+            _rc = MultiWorkerVODConnectionManager.get_instance().redis_client
+            for _cid in displaced:
+                try:
+                    if _rc:
+                        _rc.delete(get_vod_client_stop_key(_cid))
+                except Exception:
+                    pass
         if not selected:
             logger.error(
                 "[VOD-ERROR] No available provider with capacity for %s %s",


### PR DESCRIPTION
## Description

Five stacked fixes around XC VOD/series playback, found while debugging why iPlayTV (Apple TV) could not play series episodes. They compound: strict clients first fail on the JSON payload; once past that, rapid range/probe request patterns (VLC-based players, and TiviMate/Emby-style players at start-up) trip races and the user's own stream-limit enforcement, producing black screens, `profile_connections` slot leaks, and provider request storms.

1. **`custom_sid: null` in XC VOD/series payloads** (`apps/output/views.py`) — strict XC clients (iPlayTV) reject JSON `null` where a string is expected; real panels emit `""`. The live-channel path already sends `""`; the three VOD paths (`xc_get_vod_streams`, `xc_get_series_info`, `xc_get_vod_info`) still sent `null`. Also guarded `stream_icon`/`cover` (`_xc_cover_or_logo` returns `None` when a movie/series has no artwork and no logo).
2. **Episode ids emitted as JSON numbers** (`apps/output/views.py`) — real XC panels emit episode ids as strings; iPlayTV's decoder rejects numbers there and never even requests the stream. Now `str(episode.id)` for `id` and `info.id` in `get_series_info`.
3. **Delayed-cleanup race destroys session state under a live request** (`multi_worker_connection_manager.py`) — the 1s-delayed cleanup after each completed range request hard-deletes the shared session state. A client chaining rapid ranges can be mid-flight between profile-slot reserve and stream INCR on that same session when it fires: the in-flight request dies (`INCR-AS failed: no state`) and its reserved profile slot is never decremented — a permanent `profile_connections` ghost that blocks the whole account until Redis is reset. Fix: skip the hard delete while the session saw activity in the last 20s; the existing key TTL still reaps abandoned sessions.
4. **User stream-limit enforcement terminates the user's own playback** (`apps/proxy/utils.py`) — `check_user_stream_limits` has a same-channel exemption for live and a sibling exemption for timeshift (a9087207), but nothing for VOD. With `stream_limit=1`, the viewer's own parked same-content session counts against their next range request, so enforcement terminates their own stream every ~800KB (the stop-key poll interval), forcing an endless reconnect loop that also hammers the provider (we observed provider-side 429 rate limiting as a direct consequence). Fix: same-content VOD sibling exemption, mirroring the existing live/timeshift precedents.
5. **Seek/start-up burst gets an instant 503 while the viewer's own stream holds the slot** (`apps/proxy/vod_proxy/views.py`) — FF/RW opens a new connection before the old one tears down; players also open several parallel probe connections at start-up which hold the slot for well under a second. With `max_streams=1`, selection failed instantly → 503 → players abort playback entirely. Fix: on capacity failure, signal the viewer's own same-content stream to stop (timeshift-scrub-style takeover), then retry selection for up to 3s before giving up; displacement signals are consumed afterwards so a reused session id never reads a stale kill order.

No behavior change for other clients: fixes 1–2 align the payload with what real panels emit (every client already handles that), and fixes 3–5 only act on paths that were already failures (instant 503 / killed stream / leaked slot). Three existing assertions in `apps/output/tests/test_views.py` that locked in the `null` payload values were updated to the new `""` values.

Happy to split this into separate PRs if you prefer — the five changes are in distinct code paths but were found and validated together.

## Related Issue

Related: #1256 — fix 3 is the mechanism behind the stuck `profile_connections` counters reported there (reproduced live: reserve at capacity → delayed cleanup deletes session state under the in-flight request → its slot is never decremented). Not marking it as closed since that issue was already closed, but this removes the leak path we could reproduce.

## How was it tested?

- Built a fresh AIO image from this branch (`docker build -f docker/Dockerfile` succeeds) and ran the backend suites in a disposable container with its own database:
  `python -m django test apps.timeshift.tests.test_helpers apps.timeshift.tests.test_sessions apps.timeshift.tests.test_stats apps.timeshift.tests.test_views apps.output.tests.test_xc_vod_info apps.output.tests.test_views apps.output.tests.test_xc_series_info apps.proxy.tests.test_stream_limits` → **424 tests, OK**.
- 4 new regression tests included: strict-client series payload (walks the whole episodes payload asserting no `null` anywhere, string `id`/`info.id`, `custom_sid == ""`) and `VodSiblingLimitExemptionTests` (same-content VOD sibling allowed without termination; different content still enforced; live connections unaffected).
- Live-validated the equivalent patches on a production 0.30.0 setup with two XC provider accounts (`max_streams=1` each):
  - iPlayTV/Apple TV: series episode now starts (previously the app crashed parsing the payload and never requested the stream), and 4 consecutive FF jumps (21.9MB → 677.8MB → 1.59GB → 2.03GB byte offsets) were each served at the exact requested position in ~0.6s on the reused session.
  - TiviMate/Android: series start-up burst (3-4 parallel probe connections) no longer gets an instant 503; playback starts and runs on a single long-lived provider request.
  - Verified the `profile_connections` leak no longer reproduces under rapid range churn (counter returns to 0 after playback, no ghost slots, no stale stop keys), where before we could reproduce a stuck counter within seconds.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed (no model changes)
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema (no new endpoints)
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`) (no frontend changes)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
