### PR TITLE
Prevent EPG edits from corrupting concurrent XMLTV exports

### DIFF
--- a/Plugins.md
+++ b/Plugins.md
@@ -528,3 +528,93 @@ class Plugin:
 - Model: `apps/plugins/models.py`
 - Frontend page: `frontend/src/pages/Plugins.jsx`
 - Sidebar entry: `frontend/src/components/Sidebar.jsx`
+
+## Updating EPG programme metadata
+
+Plugins running inside Dispatcharr can use `apps.epg.services.update_programmes`
+for bounded, transactional metadata updates. This is a Python service, not an
+HTTP endpoint. It does not grant additional permissions: plugins already execute
+with application privileges and must select the intended programmes themselves.
+
+```python
+from apps.epg.models import ProgramData
+from apps.epg.services import MISSING, ProgrammeUpdate, update_programmes
+
+programme = ProgramData.objects.get(pk=programme_id)
+if isinstance(programme.custom_properties, dict):
+    result = update_programmes([
+        ProgrammeUpdate(
+            programme_id=programme.pk,
+            expected={
+                "epg_id": programme.epg_id,
+                "start_time": programme.start_time,
+                "end_time": programme.end_time,
+                "title": programme.title,
+                "custom_properties": {
+                    "language": programme.custom_properties.get("language", MISSING),
+                },
+            },
+            values={"custom_properties": {"language": "en"}},
+        ),
+    ])
+    # result.changed, .unchanged, .conflicts, and .missing contain programme IDs.
+```
+
+The service accepts at most 500 updates with distinct positive integer IDs. It
+validates the entire batch before writing, then locks existing rows in ID order
+and compares each update's `expected` values with the current database row. A
+mismatch skips that programme and returns its ID in `conflicts`. A deleted or
+replaced row is returned in `missing`; the service never recreates it. Re-read
+conflicting or replaced programmes and reconsider the update rather than retrying
+with stale expectations. A source refresh can still replace metadata after a
+successful update; the API does not make plugin changes permanent overrides.
+
+Writable fields are `title`, `sub_title`, `description`, and `custom_properties`.
+Every writable scalar or property key included in `values` must also appear in
+`expected`. Additional expected conditions can include `epg_id`, `start_time`,
+`end_time`, `tvg_id`, and `program_id`. Timestamps must be timezone-aware Python
+`datetime` objects. Schedule times, source identity, and channel mappings cannot
+be changed through this service. Invalid requests raise Django `ValidationError`
+without applying any part of the batch.
+
+`custom_properties` is an explicit **top-level merge**. Unmentioned keys are
+preserved; a nested object supplied for a key replaces that key's whole value.
+Use `MISSING` in `expected` to require an absent key, and in `values` to delete a
+key. `None` means JSON null, which is distinct from absence. Property values must
+be JSON values with string object keys and finite numbers. Stored properties
+that are not an object cause a conflict when the update references properties;
+they are not silently converted or discarded.
+
+`preview=True` performs validation and conflict detection without changing data
+or the EPG revision. In previews, `changed` lists IDs that **would** change. No-op
+updates also leave the revision unchanged. Results classify IDs within this
+batch; they are not a durable audit log.
+
+A changed batch advances a durable database EPG revision once, in the same
+transaction as its metadata writes. If the caller wraps the operation in an
+outer `transaction.atomic()`, both the data and revision become visible on that
+outer commit, and both roll back together. Redis availability is not required
+for the update to commit. Plugins must not additionally delete XMLTV cache keys
+or call the output invalidation helper after this service.
+
+XMLTV requests select their cache generation using the committed revision.
+Previously started requests may finish with older data, while subsequent
+requests select the new generation. This protects cache and stream integrity;
+it does not provide a global database snapshot across multiple programme
+queries. Large jobs should use bounded batches and expect exports to observe
+intermediate committed batches. Built-in import and refresh paths continue to
+use their own ingestion logic with the host's revision invalidation mechanism.
+
+The cache never deletes an active build or reader's data when the revision
+changes. A cache-miss producer streams immediately; concurrent requests wait
+up to five seconds for a completed build before generating their own response.
+Only completed cache builds are replayed, with an exact byte `Content-Length`.
+Memory remains bounded to a chunk rather than a complete guide.
+
+Cached readers renew data retention on each chunk, independently of whether
+the generation remains available to new requests. A reader paused longer than
+that retention, or affected by Redis data loss, fails as an incomplete transfer
+instead of receiving a normally completed truncated document. Redis failure
+before headers falls back to uncached generation. If a producer loses its cache
+lease or Redis fails while it is writing chunks, it continues streaming its
+original source without publishing an incomplete cache. Failures are logged.

--- a/apps/epg/api_views.py
+++ b/apps/epg/api_views.py
@@ -1,9 +1,11 @@
+import json
 import logging
 import os
 from rest_framework import viewsets, status, serializers
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from rest_framework.exceptions import NotFound
 from rest_framework.views import APIView
 from apps.epg.sd_api import (
     SchedulesDirectPosterMixin,
@@ -12,11 +14,13 @@ from apps.epg.sd_api import (
 from rest_framework.decorators import action
 from drf_spectacular.utils import extend_schema, OpenApiParameter, inline_serializer
 from drf_spectacular.types import OpenApiTypes
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from .models import EPGSource, ProgramData, EPGData
+from .services import advance_epg_revision
 from .serializers import (
     ProgramDataSerializer,
     ProgramDetailSerializer,
@@ -137,6 +141,43 @@ class ProgramViewSet(SchedulesDirectPosterMixin, viewsets.ModelViewSet):
 
     queryset = ProgramData.objects.select_related("epg").all()
     serializer_class = ProgramDataSerializer
+
+    @transaction.atomic
+    def perform_create(self, serializer):
+        serializer.save()
+        advance_epg_revision()
+
+    @transaction.atomic
+    def perform_update(self, serializer):
+        # DRF looked up the instance before entering this transaction. Re-read
+        # under a row lock so save cannot resurrect a concurrently deleted row.
+        try:
+            instance = ProgramData.objects.select_for_update().get(pk=serializer.instance.pk)
+        except ProgramData.DoesNotExist as exc:
+            raise NotFound("Programme no longer exists.") from exc
+        serializer.instance = instance
+        changed = False
+        for name, value in serializer.validated_data.items():
+            current = getattr(instance, name)
+            if name == "custom_properties":
+                # Whole-field replacement keeps REST semantics; JSON booleans
+                # must not compare equal to numeric values (True == 1 in Python).
+                different = json.dumps(current, sort_keys=True) != json.dumps(value, sort_keys=True)
+            else:
+                different = current != value
+            changed = changed or different
+        if changed:
+            serializer.save()
+            advance_epg_revision()
+
+    @transaction.atomic
+    def perform_destroy(self, instance):
+        try:
+            instance = ProgramData.objects.select_for_update().get(pk=instance.pk)
+        except ProgramData.DoesNotExist as exc:
+            raise NotFound("Programme no longer exists.") from exc
+        instance.delete()
+        advance_epg_revision()
 
     # Short process-local cooldown for transient poster errors (auth/network).
     # Image download limits are persisted on the EPG source (shared across workers).

--- a/apps/epg/migrations/0028_epgrevision.py
+++ b/apps/epg/migrations/0028_epgrevision.py
@@ -1,0 +1,30 @@
+import uuid
+
+from django.db import migrations, models
+
+
+def initialize_revision(apps, schema_editor):
+    revision = apps.get_model("epg", "EPGRevision")
+    revision.objects.using(schema_editor.connection.alias).get_or_create(pk=1)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("epg", "0027_programdata_epg_start_end_index"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EPGRevision",
+            fields=[
+                ("id", models.PositiveSmallIntegerField(default=1, editable=False, primary_key=True, serialize=False)),
+                ("revision", models.UUIDField(default=uuid.uuid4, editable=False)),
+            ],
+            options={
+                "constraints": [
+                    models.CheckConstraint(condition=models.Q(id=1), name="epg_revision_singleton"),
+                ],
+            },
+        ),
+        migrations.RunPython(initialize_revision, migrations.RunPython.noop),
+    ]

--- a/apps/epg/models.py
+++ b/apps/epg/models.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from django_celery_beat.models import PeriodicTask
 from django.conf import settings
 import os
+import uuid
 
 class EPGSource(models.Model):
     SOURCE_TYPE_CHOICES = [
@@ -256,3 +257,15 @@ class SDProgramMD5(models.Model):
 
     def __str__(self):
         return f"SDProgramMD5: {self.program_id} ({self.epg_source.name})"
+
+
+class EPGRevision(models.Model):
+    """Durable cache namespace shared by EPG writers and XMLTV readers."""
+
+    id = models.PositiveSmallIntegerField(primary_key=True, default=1, editable=False)
+    revision = models.UUIDField(default=uuid.uuid4, editable=False)
+
+    class Meta:
+        constraints = [
+            models.CheckConstraint(condition=models.Q(id=1), name="epg_revision_singleton"),
+        ]

--- a/apps/epg/services.py
+++ b/apps/epg/services.py
@@ -1,0 +1,219 @@
+"""Commit-linked EPG revisions and bounded programme metadata updates."""
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import islice
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
+
+from .models import EPGRevision, ProgramData
+
+MISSING = object()
+MAX_PROGRAMME_UPDATES = 500
+_METADATA_FIELDS = {"title", "sub_title", "description", "custom_properties"}
+_EXPECTED_FIELDS = _METADATA_FIELDS | {
+    "epg_id", "start_time", "end_time", "tvg_id", "program_id",
+}
+
+
+@dataclass(frozen=True)
+class ProgrammeUpdate:
+    """Compare expected fields and merge values into one existing programme.
+
+    Property dictionaries compare/merge top-level keys. MISSING distinguishes
+    absent expected keys from JSON null, and deletes keys when used in values.
+    """
+
+    programme_id: int
+    expected: dict
+    values: dict
+
+
+@dataclass(frozen=True)
+class ProgrammeUpdateResult:
+    """Programme IDs classified by outcome; changed means would-change in preview."""
+
+    changed: tuple[int, ...]
+    unchanged: tuple[int, ...]
+    conflicts: tuple[int, ...]
+    missing: tuple[int, ...]
+
+
+def get_epg_revision() -> str:
+    """Read the committed cache namespace (or initialize it after a DB reset)."""
+    revision, _ = EPGRevision.objects.get_or_create(pk=1)
+    return str(revision.revision)
+
+
+@transaction.atomic
+def advance_epg_revision() -> str:
+    """Advance within the caller's transaction, without depending on Redis.
+
+    Call once after a changed EPG batch. An enclosing rollback also rolls back
+    this revision; a recreated row gets a new UUID rather than reusing old keys.
+    """
+    revision, _ = EPGRevision.objects.select_for_update().get_or_create(pk=1)
+    revision.revision = uuid.uuid4()
+    revision.save(update_fields=["revision"])
+    return str(revision.revision)
+
+
+def _json_value(value):
+    """Validate JSON without silently coercing tuples, object keys or NaN."""
+    try:
+        json.dumps(value, allow_nan=False)
+    except (TypeError, ValueError, OverflowError, RecursionError) as exc:
+        raise ValidationError("Properties must contain finite, serializable JSON values.") from exc
+    pending = [value]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, dict):
+            if any(not isinstance(key, str) for key in item):
+                raise ValidationError("Property object keys must be strings.")
+            pending.extend(item.values())
+        elif isinstance(item, list):
+            pending.extend(item)
+        elif item is not None and type(item) not in (str, int, float, bool):
+            raise ValidationError("Properties must contain JSON values.")
+
+
+def _validate_scalar(name, value, *, expected):
+    if name == "epg_id":
+        if type(value) is not int or value <= 0:
+            raise ValidationError("Expected epg_id must be a positive integer.")
+        ProgramData._meta.get_field("epg").target_field.run_validators(value)
+        return
+    if name in ("start_time", "end_time"):
+        if not isinstance(value, datetime) or timezone.is_naive(value):
+            raise ValidationError("Expected programme times must be timezone-aware datetimes.")
+        return
+    field = ProgramData._meta.get_field(name)
+    if value is not None and not isinstance(value, str):
+        raise ValidationError(f"{name} must be a string or an allowed null.")
+    # Comparisons may describe historical empty strings; new values must obey
+    # the model's blank/null rules and validators as well as its field type.
+    if expected:
+        if value is None and not field.null:
+            raise ValidationError(f"{name} does not allow null.")
+        field.run_validators(value)
+    else:
+        field.clean(value, None)
+
+
+def _validate_fields(fields, *, expected):
+    allowed = _EXPECTED_FIELDS if expected else _METADATA_FIELDS
+    if not isinstance(fields, dict) or fields.keys() - allowed:
+        raise ValidationError("Unsupported programme fields or invalid field mapping.")
+    for name, value in fields.items():
+        if name != "custom_properties":
+            _validate_scalar(name, value, expected=expected)
+            continue
+        if not isinstance(value, dict) or any(not isinstance(key, str) for key in value):
+            raise ValidationError("custom_properties must map string keys to expected or new values.")
+        for item in value.values():
+            if item is not MISSING:
+                _json_value(item)
+
+
+def _validate_updates(updates):
+    try:
+        updates = list(islice(iter(updates), MAX_PROGRAMME_UPDATES + 1))
+    except TypeError as exc:
+        raise ValidationError("updates must be an iterable of ProgrammeUpdate objects.") from exc
+    if len(updates) > MAX_PROGRAMME_UPDATES:
+        raise ValidationError(f"A batch may contain at most {MAX_PROGRAMME_UPDATES} programmes.")
+    ids = set()
+    for update in updates:
+        if not isinstance(update, ProgrammeUpdate):
+            raise ValidationError("Each update must be a ProgrammeUpdate.")
+        if type(update.programme_id) is not int or update.programme_id <= 0 or update.programme_id in ids:
+            raise ValidationError("Programme IDs must be distinct positive integers.")
+        ProgramData._meta.pk.run_validators(update.programme_id)
+        ids.add(update.programme_id)
+        _validate_fields(update.expected, expected=True)
+        _validate_fields(update.values, expected=False)
+        if update.values.keys() - update.expected.keys():
+            raise ValidationError("Every updated field requires an expected value.")
+        properties = update.values.get("custom_properties", {})
+        if properties.keys() - update.expected.get("custom_properties", {}).keys():
+            raise ValidationError("Every updated property key requires an expected value.")
+    return updates
+
+
+def _property_equal(actual, expected):
+    if actual is MISSING or expected is MISSING:
+        return actual is expected
+    # Python considers True == 1, including inside dictionaries. JSON compare
+    # retains that type distinction and ignores object-key ordering.
+    return json.dumps(actual, sort_keys=True) == json.dumps(expected, sort_keys=True)
+
+
+def _matches(programme, expected):
+    for name, value in expected.items():
+        actual = getattr(programme, name)
+        if name == "custom_properties":
+            if not isinstance(actual, dict):
+                return False
+            if any(not _property_equal(actual.get(key, MISSING), item) for key, item in value.items()):
+                return False
+        elif actual != value:
+            return False
+    return True
+
+
+def _changes(programme, values):
+    changes = {}
+    for name, value in values.items():
+        if name == "custom_properties":
+            properties = programme.custom_properties.copy()
+            for key, item in value.items():
+                if item is MISSING:
+                    properties.pop(key, None)
+                else:
+                    properties[key] = item
+            if not _property_equal(properties, programme.custom_properties):
+                changes[name] = properties
+        elif value != getattr(programme, name):
+            changes[name] = value
+    return changes
+
+
+def update_programmes(updates, *, preview=False) -> ProgrammeUpdateResult:
+    """Apply at most 500 metadata updates using row locks and expected values.
+
+    Validate the whole request before writes. Missing/conflicting programmes
+    are skipped; matching changes and one revision advance commit atomically.
+    Schedule/source fields are comparison-only. Preview and no-op batches do
+    not write. Errors propagate so callers cannot mistake a failed commit for
+    successful cache visibility. No Redis operation is required.
+    """
+    if type(preview) is not bool:
+        raise ValidationError("preview must be a boolean.")
+    updates = _validate_updates(updates)
+    changed, unchanged, conflicts, missing = [], [], [], []
+    with transaction.atomic():
+        rows = {
+            row.pk: row for row in ProgramData.objects.select_for_update()
+            .filter(pk__in=[update.programme_id for update in updates]).order_by("pk")
+        }
+        for update in updates:
+            programme = rows.get(update.programme_id)
+            if programme is None:
+                missing.append(update.programme_id)
+            elif not _matches(programme, update.expected):
+                conflicts.append(update.programme_id)
+            else:
+                changes = _changes(programme, update.values)
+                if changes:
+                    if not preview:
+                        ProgramData.objects.filter(pk=programme.pk).update(**changes)
+                    changed.append(programme.pk)
+                else:
+                    unchanged.append(programme.pk)
+        if changed and not preview:
+            advance_epg_revision()
+    return ProgrammeUpdateResult(tuple(changed), tuple(unchanged), tuple(conflicts), tuple(missing))

--- a/apps/epg/tests/test_programme_updates.py
+++ b/apps/epg/tests/test_programme_updates.py
@@ -1,0 +1,309 @@
+"""Public EPG updates preserve concurrent metadata and cache visibility."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.test import TestCase, TransactionTestCase
+from django.utils import timezone
+
+from apps.epg.models import EPGData, EPGRevision, ProgramData
+from apps.epg.services import (
+    MISSING,
+    ProgrammeUpdate,
+    advance_epg_revision,
+    get_epg_revision,
+    update_programmes,
+)
+
+
+class ProgrammeUpdateTests(TestCase):
+    def setUp(self):
+        self.epg = EPGData.objects.create(name="Metadata updates", tvg_id="test")
+        self.programme = ProgramData.objects.create(
+            epg=self.epg,
+            title="Original",
+            start_time=timezone.now(),
+            end_time=timezone.now() + timedelta(hours=1),
+            custom_properties={"category": "News", "rating": None},
+        )
+        self.revision = get_epg_revision()
+
+    def update(self, expected=None, values=None, **kwargs):
+        return update_programmes([
+            ProgrammeUpdate(
+                self.programme.pk,
+                expected if expected is not None else {"title": "Original"},
+                values if values is not None else {"title": "Updated"},
+            )
+        ], **kwargs)
+
+    def test_changed_batch_advances_once_and_preserves_identity(self):
+        original_identity = (
+            self.programme.epg_id, self.programme.start_time,
+            self.programme.end_time, self.programme.tvg_id,
+        )
+        with patch("apps.epg.services.advance_epg_revision", wraps=advance_epg_revision) as advance:
+            result = self.update()
+        self.programme.refresh_from_db()
+        self.assertEqual(result.changed, (self.programme.pk,))
+        self.assertEqual(self.programme.title, "Updated")
+        self.assertNotEqual(get_epg_revision(), self.revision)
+        advance.assert_called_once_with()
+        self.assertEqual(original_identity, (
+            self.programme.epg_id, self.programme.start_time,
+            self.programme.end_time, self.programme.tvg_id,
+        ))
+
+    def test_top_level_merge_keeps_unrelated_properties(self):
+        self.update(
+            {"custom_properties": {"language": MISSING}},
+            {"custom_properties": {"language": "en"}},
+        )
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.custom_properties, {
+            "category": "News", "rating": None, "language": "en",
+        })
+
+    def test_missing_null_and_delete_are_distinct(self):
+        result = self.update(
+            {"custom_properties": {"rating": MISSING}},
+            {"custom_properties": {"rating": "PG"}},
+        )
+        self.assertEqual(result.conflicts, (self.programme.pk,))
+        self.update(
+            {"custom_properties": {"rating": None, "language": MISSING}},
+            {"custom_properties": {"rating": MISSING, "language": None}},
+        )
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.custom_properties, {"category": "News", "language": None})
+
+    def test_stale_expected_value_does_not_overwrite_new_data(self):
+        ProgramData.objects.filter(pk=self.programme.pk).update(title="Concurrent edit")
+        result = self.update()
+        self.assertEqual(result.conflicts, (self.programme.pk,))
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.title, "Concurrent edit")
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_optional_identity_condition_prevents_wrong_programme_update(self):
+        result = self.update(
+            {"title": "Original", "start_time": self.programme.start_time + timedelta(days=1)},
+            {"title": "Updated"},
+        )
+        self.assertEqual(result.conflicts, (self.programme.pk,))
+
+    def test_deleted_row_is_missing_and_never_recreated(self):
+        programme_id = self.programme.pk
+        self.programme.delete()
+        result = update_programmes([ProgrammeUpdate(programme_id, {"title": "Original"}, {"title": "Updated"})])
+        self.assertEqual(result.missing, (programme_id,))
+        self.assertFalse(ProgramData.objects.filter(pk=programme_id).exists())
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_replacement_row_is_not_changed_by_stale_id(self):
+        old_id = self.programme.pk
+        self.programme.delete()
+        replacement = ProgramData.objects.create(
+            epg=self.epg, title="Original", start_time=timezone.now(), end_time=timezone.now(),
+        )
+        result = update_programmes([ProgrammeUpdate(old_id, {"title": "Original"}, {"title": "Updated"})])
+        self.assertEqual(result.missing, (old_id,))
+        replacement.refresh_from_db()
+        self.assertEqual(replacement.title, "Original")
+
+    def test_noop_and_empty_batch_leave_revision_unchanged(self):
+        result = self.update(values={"title": "Original"})
+        self.assertEqual(result.unchanged, (self.programme.pk,))
+        self.assertEqual(update_programmes([]).changed, ())
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_preview_reports_would_change_without_writes(self):
+        result = self.update(preview=True)
+        self.assertEqual(result.changed, (self.programme.pk,))
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.title, "Original")
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_outer_rollback_reverts_data_and_revision(self):
+        with self.assertRaises(RuntimeError):
+            with transaction.atomic():
+                self.update()
+                self.assertNotEqual(get_epg_revision(), self.revision)
+                raise RuntimeError("roll back caller transaction")
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.title, "Original")
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_malformed_stored_properties_are_conflicts(self):
+        for value in (None, [], "legacy", 5):
+            with self.subTest(value=value):
+                ProgramData.objects.filter(pk=self.programme.pk).update(custom_properties=value)
+                result = self.update(
+                    {"custom_properties": {"language": MISSING}},
+                    {"custom_properties": {"language": "en"}},
+                )
+                self.assertEqual(result.conflicts, (self.programme.pk,))
+                self.programme.refresh_from_db()
+                self.assertEqual(self.programme.custom_properties, value)
+
+    def test_boolean_and_number_expected_properties_are_not_equal(self):
+        ProgramData.objects.filter(pk=self.programme.pk).update(custom_properties={"nested": {"flag": True}})
+        result = self.update(
+            {"custom_properties": {"nested": {"flag": 1}}},
+            {"custom_properties": {"nested": {"flag": False}}},
+        )
+        self.assertEqual(result.conflicts, (self.programme.pk,))
+
+    def test_entire_batch_validated_before_any_write(self):
+        with self.assertRaises(ValidationError):
+            update_programmes([
+                ProgrammeUpdate(self.programme.pk, {"title": "Original"}, {"title": "Updated"}),
+                ProgrammeUpdate(self.programme.pk + 1, {"title": "Original"}, {"title": "x" * 256}),
+            ])
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.title, "Original")
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_invalid_fields_types_and_missing_preconditions_rejected(self):
+        cases = [
+            ({}, {"title": "Updated"}),
+            ({"title": "Original"}, {"title": 123}),
+            ({"title": "Original"}, {"title": None}),
+            ({"title": "Original"}, {"title": ""}),
+            ({"start_time": self.programme.start_time}, {"start_time": timezone.now()}),
+            ({"epg_id": self.epg.pk}, {"epg_id": self.epg.pk}),
+            ({"unknown": None}, {}),
+            ({"custom_properties": {}}, {"custom_properties": {"language": "en"}}),
+            ({"custom_properties": None}, {"custom_properties": {}}),
+            ({"custom_properties": {"key": MISSING}}, {"custom_properties": {"key": float("nan")}}),
+            ({"custom_properties": {"key": MISSING}}, {"custom_properties": {"key": {1: "bad key"}}}),
+            ({"custom_properties": {"key": MISSING}}, {"custom_properties": {"key": (1, 2)}}),
+            ({"custom_properties": {"key": MISSING}}, {"custom_properties": {"key": {"nested": MISSING}}}),
+        ]
+        for expected, values in cases:
+            with self.subTest(expected=expected, values=values):
+                with self.assertRaises(ValidationError):
+                    self.update(expected, values)
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_positive_unique_ids_and_limit_are_enforced(self):
+        for programme_id in (0, -1, True, "1"):
+            with self.subTest(programme_id=programme_id):
+                with self.assertRaises(ValidationError):
+                    update_programmes([ProgrammeUpdate(programme_id, {}, {})])
+        update = ProgrammeUpdate(self.programme.pk, {}, {})
+        with self.assertRaises(ValidationError):
+            update_programmes([update, update])
+        with self.assertRaises(ValidationError):
+            update_programmes(ProgrammeUpdate(i, {}, {}) for i in range(1, 502))
+
+    def test_revision_recreation_uses_new_namespace(self):
+        EPGRevision.objects.all().delete()
+        self.assertNotEqual(get_epg_revision(), self.revision)
+
+    def test_multiple_changes_share_one_revision_advance(self):
+        second = ProgramData.objects.create(
+            epg=self.epg, title="Second", start_time=timezone.now(), end_time=timezone.now(),
+        )
+        with patch("apps.epg.services.advance_epg_revision", wraps=advance_epg_revision) as advance:
+            result = update_programmes([
+                ProgrammeUpdate(second.pk, {"title": "Second"}, {"title": "Revised second"}),
+                ProgrammeUpdate(self.programme.pk, {"title": "Original"}, {"title": "Revised first"}),
+            ])
+        self.assertEqual(set(result.changed), {self.programme.pk, second.pk})
+        advance.assert_called_once_with()
+
+    def test_conflict_does_not_prevent_other_valid_updates(self):
+        second = ProgramData.objects.create(
+            epg=self.epg, title="Second", start_time=timezone.now(), end_time=timezone.now(),
+        )
+        result = update_programmes([
+            ProgrammeUpdate(self.programme.pk, {"title": "Stale"}, {"title": "Ignored"}),
+            ProgrammeUpdate(second.pk, {"title": "Second"}, {"title": "Updated"}),
+        ])
+        self.assertEqual(result.conflicts, (self.programme.pk,))
+        self.assertEqual(result.changed, (second.pk,))
+
+    def test_deleted_missing_property_is_unchanged(self):
+        result = self.update(
+            {"custom_properties": {"absent": MISSING}},
+            {"custom_properties": {"absent": MISSING}},
+        )
+        self.assertEqual(result.unchanged, (self.programme.pk,))
+        self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_nullable_text_fields_accept_null_and_empty_string(self):
+        result = self.update(
+            {"sub_title": None, "description": None},
+            {"sub_title": "", "description": "Details"},
+        )
+        self.assertEqual(result.changed, (self.programme.pk,))
+        self.update({"description": "Details"}, {"description": None})
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.sub_title, "")
+        self.assertIsNone(self.programme.description)
+
+    def test_revision_failure_rolls_back_programme_changes(self):
+        with patch("apps.epg.services.advance_epg_revision", side_effect=RuntimeError("database failure")):
+            with self.assertRaises(RuntimeError):
+                self.update()
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.title, "Original")
+        self.assertEqual(get_epg_revision(), self.revision)
+
+
+    def test_circular_properties_are_validation_errors(self):
+        circular = {}
+        circular["self"] = circular
+        with self.assertRaises(ValidationError):
+            self.update(
+                {"custom_properties": {"new": MISSING}},
+                {"custom_properties": {"new": circular}},
+            )
+
+    def test_out_of_range_ids_are_rejected_before_querying(self):
+        with self.assertRaises(ValidationError):
+            update_programmes([ProgrammeUpdate(2**100, {}, {})])
+
+    def test_preview_with_no_revision_row_does_not_initialize_it(self):
+        EPGRevision.objects.all().delete()
+        self.update(preview=True)
+        self.assertFalse(EPGRevision.objects.exists())
+
+
+class ConcurrentProgrammeUpdateTests(TransactionTestCase):
+    """Separate database connections exercise the row-lock/CAS boundary."""
+
+    def test_competing_writers_only_apply_one_expected_value(self):
+        from concurrent.futures import ThreadPoolExecutor
+        from threading import Barrier
+        from django.db import close_old_connections, connection
+
+        if not connection.features.has_select_for_update:
+            self.skipTest("Requires database row locks")
+        epg = EPGData.objects.create(name="Concurrent updates")
+        programme = ProgramData.objects.create(
+            epg=epg, title="Original", start_time=timezone.now(), end_time=timezone.now(),
+        )
+        get_epg_revision()
+        start = Barrier(2)
+
+        def write(title):
+            close_old_connections()
+            try:
+                start.wait(timeout=10)
+                return update_programmes([
+                    ProgrammeUpdate(programme.pk, {"title": "Original"}, {"title": title})
+                ])
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(write, title) for title in ("First", "Second")]
+            results = [future.result(timeout=15) for future in futures]
+        self.assertEqual(sum(len(result.changed) for result in results), 1)
+        self.assertEqual(sum(len(result.conflicts) for result in results), 1)
+        programme.refresh_from_db()
+        self.assertIn(programme.title, ("First", "Second"))

--- a/apps/output/epg.py
+++ b/apps/output/epg.py
@@ -17,6 +17,7 @@ from django.utils import timezone as django_timezone
 from apps.channels.models import Channel, ChannelProfile
 from apps.channels.utils import format_channel_number
 from apps.epg.models import ProgramData
+from apps.epg.services import get_epg_revision
 from apps.epg.utils import sd_poster_proxy_path
 from apps.output.dummy_epg import (
     build_channel_logo_url,
@@ -71,7 +72,7 @@ def generate_epg(request, profile_name=None, user=None, *, xc_catchup_prev_days=
         f":d={num_days}:p={prev_days}:logos={use_cached_logos}:tvgid={tvg_id_source}"
         f":origin={request_origin}"
     )
-    content_cache_key = f"epg_content:{cache_params}"
+    content_cache_key = f"epg_content:{get_epg_revision()}:{cache_params}"
 
     def epg_generator():
         """Generator function that yields EPG data with keep-alives during processing."""

--- a/apps/output/streaming_chunk_cache.py
+++ b/apps/output/streaming_chunk_cache.py
@@ -1,20 +1,61 @@
-"""Single-flight Redis chunk cache for large streaming HTTP responses."""
+"""Bounded streaming with immutable Redis builds and commit-linked EPG revisions."""
 
+import json
 import logging
 import time
+import uuid
 
 from django.http import StreamingHttpResponse
+from redis.exceptions import RedisError
 
 logger = logging.getLogger(__name__)
 
 STATUS_BUILDING = "building"
 STATUS_READY = "ready"
-STATUS_ERROR = "error"
-
 DEFAULT_CACHE_TTL = 300
 DEFAULT_LOCK_TTL = 120
 DEFAULT_POLL_INTERVAL = 0.05
-DEFAULT_MAX_FOLLOWER_WAIT = 600
+DEFAULT_MAX_FOLLOWER_WAIT = 5
+
+# Build UUIDs are never reused. A lost producer can finish its own source but
+# cannot append a suffix to expired data or publish/release a replacement build.
+_CLAIM = """
+if redis.call('exists', KEYS[1]) == 1 then return 0 end
+if not redis.call('set', KEYS[2], ARGV[1], 'NX', 'EX', ARGV[2]) then return 0 end
+redis.call('set', KEYS[3], 'building', 'EX', ARGV[2])
+return 1
+"""
+_APPEND = """
+if redis.call('get', KEYS[1]) ~= ARGV[1] or redis.call('get', KEYS[2]) ~= 'building' then return 0 end
+if redis.call('llen', KEYS[3]) ~= tonumber(ARGV[2]) then return 0 end
+redis.call('rpush', KEYS[3], ARGV[3])
+redis.call('expire', KEYS[1], ARGV[4])
+redis.call('expire', KEYS[2], ARGV[4])
+redis.call('expire', KEYS[3], ARGV[4])
+return 1
+"""
+_PUBLISH = """
+if redis.call('get', KEYS[1]) ~= ARGV[1] or redis.call('get', KEYS[2]) ~= 'building' then return 0 end
+if redis.call('llen', KEYS[3]) ~= tonumber(ARGV[2]) then return 0 end
+redis.call('set', KEYS[2], 'ready', 'EX', ARGV[5])
+redis.call('expire', KEYS[3], ARGV[5])
+redis.call('set', KEYS[4], ARGV[3], 'EX', ARGV[4])
+redis.call('del', KEYS[1])
+return 1
+"""
+_RELEASE = """
+if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) end
+return 0
+"""
+_READ = """
+if redis.call('get', KEYS[1]) ~= 'ready' then return {0} end
+if redis.call('llen', KEYS[2]) ~= tonumber(ARGV[2]) then return {0} end
+local chunk = redis.call('lindex', KEYS[2], ARGV[1])
+if not chunk then return {0} end
+redis.call('expire', KEYS[1], ARGV[3])
+redis.call('expire', KEYS[2], ARGV[3])
+return {1, chunk}
+"""
 
 
 def _chunks_key(base_key):
@@ -33,32 +74,19 @@ def _lock_key(base_key):
     return f"{base_key}:lock"
 
 
-def _decode_chunk(chunk):
-    if chunk is None:
-        return None
-    if isinstance(chunk, bytes):
-        return chunk.decode("utf-8")
-    return chunk
-
-
 def _encode_chunk(chunk):
-    if isinstance(chunk, bytes):
-        return chunk
-    return chunk.encode("utf-8")
+    return chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")
 
 
 def _poll_wait(interval):
-    try:
-        from core.utils import _is_gevent_monkey_patched
+    from core.utils import _is_gevent_monkey_patched
 
-        if _is_gevent_monkey_patched():
-            import gevent
+    if _is_gevent_monkey_patched():
+        import gevent
 
-            gevent.sleep(interval)
-            return
-    except ImportError:
-        pass
-    time.sleep(interval)
+        gevent.sleep(interval)
+    else:
+        time.sleep(interval)
 
 
 def _get_redis():
@@ -67,126 +95,144 @@ def _get_redis():
     return get_redis_connection("default")
 
 
-def _get_status(redis, base_key):
-    raw = redis.get(_status_key(base_key))
+class _Build:
+    """Owned iterator whose close releases its lease even before first iteration."""
+
+    def __init__(self, redis, base_key, source, *, cache_ttl, lock_ttl):
+        self.redis = redis
+        self.base = base_key
+        self.owner = uuid.uuid4().hex
+        self.key = f"{base_key}:build:{self.owner}"
+        self.cache_ttl = cache_ttl
+        self.lock_ttl = lock_ttl
+        self.source = source
+        self.iterator = self._stream()
+
+    def claim(self):
+        return bool(self.redis.eval(_CLAIM, 3, _ready_key(self.base), _lock_key(self.base),
+                                    _status_key(self.key), self.owner, self.lock_ttl))
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self.iterator)
+
+    def close(self):
+        try:
+            self.iterator.close()
+        finally:
+            self._release()
+
+    def _release(self):
+        try:
+            self.redis.eval(_RELEASE, 1, _lock_key(self.base), self.owner)
+        except RedisError:
+            logger.warning("Could not release XMLTV cache build lease", exc_info=True)
+
+    def _append(self, offset, chunk):
+        return self.redis.eval(_APPEND, 3, _lock_key(self.base), _status_key(self.key), _chunks_key(self.key),
+                               self.owner, offset, chunk, self.lock_ttl)
+
+    def _publish(self, count, byte_length):
+        manifest = json.dumps({"id": self.owner, "count": count, "bytes": byte_length})
+        return self.redis.eval(_PUBLISH, 4, _lock_key(self.base), _status_key(self.key), _chunks_key(self.key),
+                               _ready_key(self.base), self.owner, count, manifest, self.cache_ttl,
+                               max(self.cache_ttl, DEFAULT_LOCK_TTL))
+
+    def _stream(self):
+        iterator = None
+        count, byte_length, caching = 0, 0, True
+        try:
+            iterator = iter(self.source())
+            for chunk in iterator:
+                chunk = _encode_chunk(chunk)
+                if caching:
+                    caching = self._cache_chunk(count, chunk)
+                count += 1
+                byte_length += len(chunk)
+                yield chunk
+            if caching:
+                self._finish(count, byte_length)
+        finally:
+            try:
+                close = getattr(iterator, "close", None)
+                if close:
+                    close()
+            finally:
+                self._release()
+
+    def _cache_chunk(self, offset, chunk):
+        try:
+            if self._append(offset, chunk):
+                return True
+            logger.warning("XMLTV cache build lost ownership or chunks; continuing source uncached")
+        except RedisError:
+            logger.warning("XMLTV cache write failed; continuing source uncached", exc_info=True)
+        self._release()
+        return False
+
+    def _finish(self, count, byte_length):
+        try:
+            if not self._publish(count, byte_length):
+                logger.warning("XMLTV cache build no longer eligible for publication")
+        except RedisError:
+            logger.warning("XMLTV cache publication failed", exc_info=True)
+
+
+def _read_chunk(redis, build_key, manifest, offset, retention):
+    result = redis.eval(_READ, 2, _status_key(build_key), _chunks_key(build_key), offset, manifest["count"], retention)
+    if not result[0]:
+        raise RuntimeError("XMLTV cache snapshot expired or lost chunks during transfer")
+    return _encode_chunk(result[1])
+
+
+def _stream_ready(redis, build_key, manifest, first, retention):
+    # The exact byte count is sent in Content-Length. Backend loss after headers
+    # must abort an incomplete transfer, never masquerade as normal end-of-file.
+    if first is not None:
+        yield first
+    for offset in range(1, manifest["count"]):
+        yield _read_chunk(redis, build_key, manifest, offset, retention)
+
+
+def _manifest(raw):
+    value = json.loads(raw)
+    valid = (isinstance(value, dict) and isinstance(value.get("id"), str)
+             and len(value["id"]) == 32 and all(c in "0123456789abcdef" for c in value["id"])
+             and type(value.get("count")) is int and value["count"] >= 0
+             and type(value.get("bytes")) is int and value["bytes"] >= 0)
+    if not valid:
+        raise ValueError("Invalid XMLTV cache manifest")
+    return value
+
+
+def _select_ready(redis, base_key, retention):
+    raw = redis.get(_ready_key(base_key))
     if raw is None:
         return None
-    return _decode_chunk(raw)
-
-
-def _clear_build_keys(redis, base_key):
-    redis.delete(
-        _chunks_key(base_key),
-        _status_key(base_key),
-        _ready_key(base_key),
-        _lock_key(base_key),
-    )
-
-
-def _try_acquire_lock(redis, base_key, lock_ttl):
-    return bool(redis.set(_lock_key(base_key), "1", nx=True, ex=lock_ttl))
-
-
-def _refresh_build_ttl(redis, base_key, lock_ttl):
-    redis.expire(_lock_key(base_key), lock_ttl)
-    redis.expire(_status_key(base_key), lock_ttl)
-    redis.expire(_chunks_key(base_key), lock_ttl)
-
-
-def _stream_ready(redis, base_key):
-    offset = 0
-    chunks_key = _chunks_key(base_key)
-    while True:
-        chunk = redis.lindex(chunks_key, offset)
-        if chunk is None:
-            break
-        yield _decode_chunk(chunk)
-        offset += 1
-
-
-def _stream_build(redis, base_key, source, cache_ttl, lock_ttl):
-    """Leader: stream to client and append each chunk to Redis."""
-    chunks_key = _chunks_key(base_key)
-    status_key = _status_key(base_key)
     try:
-        from django.core.cache import cache as django_cache
-
-        django_cache.delete(base_key)  # clear any non-chunked entry under this key
-        redis.delete(chunks_key, _ready_key(base_key))
-        redis.set(status_key, STATUS_BUILDING, ex=lock_ttl)
-        refresh_interval = max(1, lock_ttl // 4)
-        last_refresh = 0.0
-        from core.utils import _cooperative_yield
-
-        for chunk in source():
-            redis.rpush(chunks_key, _encode_chunk(chunk))
-            now = time.monotonic()
-            if now - last_refresh >= refresh_interval:
-                _refresh_build_ttl(redis, base_key, lock_ttl)
-                last_refresh = now
-            _cooperative_yield()
-            yield chunk
-        redis.set(status_key, STATUS_READY)
-        redis.set(_ready_key(base_key), "1")
-        redis.expire(chunks_key, cache_ttl)
-        redis.expire(status_key, cache_ttl)
-        redis.expire(_ready_key(base_key), cache_ttl)
-        logger.debug("Cached response in %s chunks", redis.llen(chunks_key))
-    except Exception:
-        logger.exception("Chunk cache build failed for %s", base_key)
-        redis.delete(chunks_key)
-        redis.set(status_key, STATUS_ERROR, ex=60)
-        raise
-    finally:
-        redis.delete(_lock_key(base_key))
+        manifest = _manifest(raw)
+        build_key = f"{base_key}:build:{manifest['id']}"
+        first = _read_chunk(redis, build_key, manifest, 0, retention) if manifest["count"] else None
+    except (ValueError, TypeError, RuntimeError):
+        redis.eval(_RELEASE, 1, _ready_key(base_key), raw)
+        return None
+    return _stream_ready(redis, build_key, manifest, first, retention), manifest["bytes"]
 
 
-def _stream_follow(redis, base_key, source, cache_ttl, lock_ttl, poll_interval, max_follower_wait):
-    """Follower: read chunks as the leader writes them."""
-    offset = 0
+def _select_stream(redis, base_key, source, *, cache_ttl, lock_ttl, poll_interval, max_follower_wait):
     deadline = time.monotonic() + max_follower_wait
-    idle_polls = 0
-    chunks_key = _chunks_key(base_key)
-    lock_key = _lock_key(base_key)
-
+    build = _Build(redis, base_key, source, cache_ttl=cache_ttl, lock_ttl=lock_ttl)
     while True:
-        chunk = redis.lindex(chunks_key, offset)
-        if chunk is not None:
-            idle_polls = 0
-            yield _decode_chunk(chunk)
-            offset += 1
-            continue
-
-        status = _get_status(redis, base_key)
-        if status == STATUS_READY:
-            break
-
-        if status == STATUS_ERROR:
-            _clear_build_keys(redis, base_key)
-            if offset == 0 and _try_acquire_lock(redis, base_key, lock_ttl):
-                yield from _stream_build(redis, base_key, source, cache_ttl, lock_ttl)
-                return
-            raise RuntimeError("Chunk cache build failed")
-
+        ready = _select_ready(redis, base_key, max(cache_ttl, DEFAULT_LOCK_TTL))
+        if ready is not None:
+            return ready
+        if build.claim():
+            return build, None
         if time.monotonic() >= deadline:
-            if offset == 0 and _try_acquire_lock(redis, base_key, lock_ttl):
-                logger.warning("Chunk cache follower timed out; rebuilding %s", base_key)
-                yield from _stream_build(redis, base_key, source, cache_ttl, lock_ttl)
-                return
-            logger.warning("Chunk cache follower timed out after partial read for %s", base_key)
-            break
-
-        lock_active = bool(redis.exists(lock_key))
-        if status != STATUS_BUILDING and not lock_active:
-            idle_polls += 1
-            if offset == 0 and idle_polls >= max(1, int(1.0 / poll_interval)):
-                if _try_acquire_lock(redis, base_key, lock_ttl):
-                    logger.warning("Chunk cache leader lost; rebuilding %s", base_key)
-                    yield from _stream_build(redis, base_key, source, cache_ttl, lock_ttl)
-                    return
-        else:
-            idle_polls = 0
-
+            logger.debug("XMLTV cache producer still busy; streaming independent source")
+            return source(), None
         _poll_wait(poll_interval)
 
 
@@ -202,40 +248,24 @@ def stream_cached_response(
     max_follower_wait=DEFAULT_MAX_FOLLOWER_WAIT,
     redis=None,
 ):
+    """Stream a source or replay one complete, immutable cache build.
+
+    The leader streams immediately. Followers wait before headers for a ready
+    build (up to max_follower_wait), then use an independent source if needed.
+    Ready readers retain data per chunk and send an exact Content-Length, so
+    even a reader stalled beyond retention fails detectably instead of ending
+    with a successful truncated body. Memory remains bounded to one chunk.
     """
-    Stream a large response with single-flight Redis chunk caching.
-
-    ``source`` must be a callable returning a chunk iterator. Only the leader
-    invokes it; concurrent followers replay chunks already written to Redis, so
-    the expensive ``source`` runs at most once per ``cache_key``.
-    """
-    if redis is None:
-        redis = _get_redis()
-
-    if redis.get(_ready_key(cache_key)):
-        logger.debug("Serving response from chunk cache")
-        stream = _stream_ready(redis, cache_key)
-    else:
-        status = _get_status(redis, cache_key)
-        if status == STATUS_ERROR:
-            _clear_build_keys(redis, cache_key)
-
-        if _try_acquire_lock(redis, cache_key, lock_ttl):
-            logger.debug("Building response (cache leader)")
-            stream = _stream_build(redis, cache_key, source, cache_ttl, lock_ttl)
-        else:
-            logger.debug("Following in-flight cache build")
-            stream = _stream_follow(
-                redis,
-                cache_key,
-                source,
-                cache_ttl,
-                lock_ttl,
-                poll_interval,
-                max_follower_wait,
-            )
-
+    try:
+        redis = redis if redis is not None else _get_redis()
+        stream, length = _select_stream(redis, cache_key, source, cache_ttl=cache_ttl, lock_ttl=lock_ttl,
+                                        poll_interval=poll_interval, max_follower_wait=max_follower_wait)
+    except RedisError:
+        logger.warning("XMLTV cache unavailable; streaming source uncached", exc_info=True)
+        stream, length = source(), None
     response = StreamingHttpResponse(stream, content_type=content_type)
+    if length is not None:
+        response["Content-Length"] = str(length)
     if filename:
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
     response["Cache-Control"] = "no-cache"
@@ -243,26 +273,20 @@ def stream_cached_response(
 
 
 def invalidate_epg_chunk_cache():
-    """
-    Drop all XMLTV /output/epg chunk-cache entries.
+    """Retire EPG selections without deleting data used by active exports.
 
-    EPG assignment changes (channel or override), programme imports, and
-    finished EPG refreshes (XMLTV and Schedules Direct) do not change the
-    cache key, so without this the next /output/epg can keep serving stale
-    programmes for up to DEFAULT_CACHE_TTL while the in-app guide (uncached)
-    is already correct. M3U refreshes that rewrite channels also call this so
-    channel names, numbers, and logos in the XMLTV channel list stay current.
+    The database revision follows the caller's transaction and does not depend
+    on Redis. New requests use the new namespace; old builds expire naturally.
+    Return False and log if the revision could not be advanced.
     """
+    from apps.epg.services import advance_epg_revision
+
     try:
-        redis = _get_redis()
-        deleted = 0
-        for key in redis.scan_iter(match="epg_content:*", count=200):
-            redis.delete(key)
-            deleted += 1
-        if deleted:
-            logger.debug("Invalidated %s epg_content cache key(s)", deleted)
+        advance_epg_revision()
+        return True
     except Exception:
-        logger.warning("Failed to invalidate EPG chunk cache", exc_info=True)
+        logger.warning("Failed to advance EPG export revision", exc_info=True)
+        return False
 
 
 def invalidate_m3u_content_cache():

--- a/apps/output/tests/test_cache_integrity.py
+++ b/apps/output/tests/test_cache_integrity.py
@@ -1,0 +1,184 @@
+"""Regressions against real Redis, including invalidation during consumption."""
+import json
+import threading
+import time
+import uuid
+from unittest.mock import patch
+
+import redis as redis_library
+from django.conf import settings
+from django.test import TransactionTestCase
+
+from apps.epg.services import get_epg_revision
+from apps.output import streaming_chunk_cache as cache
+
+
+def consume(response):
+    try:
+        return b"".join(response.streaming_content)
+    finally:
+        response.close()
+
+
+class CacheIntegrityTests(TransactionTestCase):
+    def setUp(self):
+        self.redis = redis_library.Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=14)
+        self.prefix = f"epg_content:test-{uuid.uuid4().hex}"
+        self.chunks = ["<tv>", "<programme><title>Épisode</title></programme>", "</tv>"]
+
+    def tearDown(self):
+        keys = list(self.redis.scan_iter(match=self.prefix + "*"))
+        if keys:
+            self.redis.delete(*keys)
+
+    def response(self, source=None, *, key=None, **kwargs):
+        return cache.stream_cached_response(key or self.prefix, source or (lambda: iter(self.chunks)), redis=self.redis, **kwargs)
+
+    def test_invalidation_does_not_delete_an_active_cached_reader(self):
+        key = self.prefix + ":" + get_epg_revision()
+        expected = consume(self.response(key=key))
+        response = self.response(key=key)
+        stream = iter(response.streaming_content)
+        first = next(stream)
+        with patch.object(cache, "_get_redis", return_value=self.redis):
+            cache.invalidate_epg_chunk_cache()
+        self.assertEqual(first + b"".join(stream), expected)
+        response.close()
+
+    def test_invalidated_producer_cannot_republish_into_new_revision(self):
+        previous_revision = get_epg_revision()
+        key = self.prefix + ":" + previous_revision
+        response = self.response(key=key)
+        stream = iter(response.streaming_content)
+        first = next(stream)
+        with patch.object(cache, "_get_redis", return_value=self.redis):
+            cache.invalidate_epg_chunk_cache()
+        revision = get_epg_revision()
+        self.assertNotEqual(revision, previous_revision)
+        replacement = b"<tv><programme><title>New</title></programme></tv>"
+        new_key = self.prefix + ":" + revision
+        self.assertEqual(consume(self.response(lambda: iter([replacement]), key=new_key)), replacement)
+        self.assertEqual(first + b"".join(stream), "".join(self.chunks).encode())
+        response.close()
+        self.assertEqual(consume(self.response(key=new_key)), replacement)
+
+    def test_ready_response_has_exact_byte_length(self):
+        expected = consume(self.response())
+        response = self.response()
+        self.assertEqual(int(response["Content-Length"]), len(expected))
+        self.assertEqual(consume(response), expected)
+
+    def test_redis_unavailable_before_headers_uses_original_source(self):
+        with patch.object(self.redis, "get", side_effect=redis_library.ConnectionError("offline")):
+            self.assertEqual(consume(self.response()), "".join(self.chunks).encode())
+
+    def test_redis_append_failure_does_not_interrupt_original_producer(self):
+        response = self.response()
+        stream = iter(response.streaming_content)
+        first = next(stream)
+        with patch.object(self.redis, "eval", side_effect=redis_library.ConnectionError("offline")), \
+                patch.object(self.redis, "rpush", side_effect=redis_library.ConnectionError("offline")):
+            self.assertEqual(first + b"".join(stream), "".join(self.chunks).encode())
+        response.close()
+        self.assertFalse(self.redis.exists(cache._ready_key(self.prefix)))
+
+    def test_expired_lease_does_not_allow_old_owner_to_release_replacement(self):
+        original = self.response()
+        stream = iter(original.streaming_content)
+        first = next(stream)
+        self.redis.delete(cache._lock_key(self.prefix))
+        replacement = self.response(lambda: iter(["<tv>", "new", "</tv>"]))
+        replacement_owner = self.redis.get(cache._lock_key(self.prefix))
+        self.assertEqual(first + b"".join(stream), "".join(self.chunks).encode())
+        original.close()
+        self.assertEqual(self.redis.get(cache._lock_key(self.prefix)), replacement_owner)
+        self.assertEqual(consume(replacement), b"<tv>new</tv>")
+
+    def test_close_before_first_iteration_releases_build(self):
+        response = self.response()
+        self.assertTrue(self.redis.exists(cache._lock_key(self.prefix)))
+        response.close()
+        self.assertFalse(self.redis.exists(cache._lock_key(self.prefix)))
+
+    def test_source_factory_exception_releases_claim_immediately(self):
+        def broken_source():
+            raise ValueError("source failed before yielding")
+        response = self.response(broken_source)
+        with self.assertRaises(ValueError):
+            next(iter(response.streaming_content))
+        self.assertFalse(self.redis.exists(cache._lock_key(self.prefix)))
+        response.close()
+
+    def test_ready_selection_expiry_does_not_expire_active_reader_data(self):
+        expected = consume(self.response(cache_ttl=1))
+        response = self.response(cache_ttl=1)
+        stream = iter(response.streaming_content)
+        first = next(stream)
+        deadline = time.monotonic() + 3
+        while self.redis.exists(cache._ready_key(self.prefix)) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertFalse(self.redis.exists(cache._ready_key(self.prefix)))
+        self.assertEqual(first + b"".join(stream), expected)
+        response.close()
+
+    def test_expired_build_cannot_recreate_a_suffix_cache(self):
+        response = self.response(lock_ttl=1)
+        stream = iter(response.streaming_content)
+        first = next(stream)
+        deadline = time.monotonic() + 3
+        while self.redis.exists(cache._lock_key(self.prefix)) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertFalse(self.redis.exists(cache._lock_key(self.prefix)))
+        self.assertEqual(first + b"".join(stream), "".join(self.chunks).encode())
+        self.assertFalse(self.redis.exists(cache._ready_key(self.prefix)))
+        response.close()
+
+    def test_publication_error_does_not_interrupt_source(self):
+        response = self.response()
+        with patch.object(cache._Build, "_publish", side_effect=redis_library.ConnectionError("offline")):
+            self.assertEqual(consume(response), "".join(self.chunks).encode())
+        self.assertFalse(self.redis.exists(cache._ready_key(self.prefix)))
+
+    def test_follower_timeout_uses_an_independent_source_before_headers(self):
+        leader = self.response()
+        fallback = self.response(lambda: iter(["<tv>fallback</tv>"]), max_follower_wait=0.01, poll_interval=0.005)
+        self.assertEqual(consume(fallback), b"<tv>fallback</tv>")
+        self.assertNotIn("Content-Length", fallback)
+        leader.close()
+
+    def test_deleted_chunk_data_never_means_successful_eof(self):
+        consume(self.response())
+        response = self.response()
+        self.assertIn("Content-Length", response)
+        stream = iter(response.streaming_content)
+        next(stream)
+        manifest = json.loads(self.redis.get(cache._ready_key(self.prefix)))
+        self.redis.delete(cache._chunks_key(self.prefix + ":build:" + manifest["id"]))
+        with self.assertRaises(RuntimeError):
+            b"".join(stream)
+        response.close()
+
+    def test_follower_waits_for_complete_build_before_getting_length(self):
+        started, release = threading.Event(), threading.Event()
+        errors, responses = [], []
+        def source():
+            yield "<tv>"
+            started.set()
+            if not release.wait(3):
+                raise RuntimeError("test barrier expired")
+            yield "</tv>"
+        def producer():
+            try:
+                responses.append(consume(self.response(source)))
+            except Exception as exc:
+                errors.append(exc)
+        thread = threading.Thread(target=producer)
+        thread.start()
+        self.assertTrue(started.wait(3))
+        release.set()
+        follower = self.response(lambda: self.fail("follower unexpectedly rebuilt"))
+        self.assertIn("Content-Length", follower)
+        self.assertEqual(consume(follower), b"<tv></tv>")
+        thread.join(3)
+        self.assertEqual(errors, [])
+        self.assertEqual(responses, [b"<tv></tv>"])

--- a/apps/output/tests/test_epg_cache_http.py
+++ b/apps/output/tests/test_epg_cache_http.py
@@ -1,0 +1,365 @@
+"""Real HTTP XMLTV exports retain integrity across committed EPG updates."""
+
+import threading
+import time
+import uuid
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from datetime import timedelta
+from unittest.mock import patch
+
+import requests
+from django.db import connection, transaction
+from django.test import LiveServerTestCase, TestCase
+from django.utils import timezone
+from django_redis import get_redis_connection
+
+from apps.accounts.models import User
+from apps.channels.models import (
+    Channel, ChannelGroup, ChannelOverride, ChannelProfile, ChannelProfileMembership,
+)
+from apps.epg.models import EPGData, ProgramData
+from apps.epg.services import ProgrammeUpdate, get_epg_revision, update_programmes
+from apps.output import streaming_chunk_cache as chunk_cache
+
+
+class EPGCacheHTTPTests(LiveServerTestCase):
+    """Exercise Django's WSGI server, PostgreSQL, and the configured real Redis."""
+
+    def setUp(self):
+        super().setUp()
+        if connection.vendor != "postgresql":
+            self.skipTest("HTTP concurrency requires separate PostgreSQL connections")
+        self.redis = get_redis_connection("default")
+        self.redis.ping()
+        self.prefix = uuid.uuid4().hex
+        self.profile = ChannelProfile.objects.create(name=f"http-{self.prefix}")
+        group = ChannelGroup.objects.create(name=f"HTTP {self.prefix}")
+        self.epg = EPGData.objects.create(name="Override programme data")
+        base_epg = EPGData.objects.create(name="Provider programme data")
+        channels = {}
+        for number, (name, extra) in enumerate([
+            ("visible", {}),
+            ("hidden", {"hidden_from_output": True}),
+            ("restricted", {"user_level": 10}),
+            ("adult", {"is_adult": True}),
+            ("outside", {}),
+        ], 1):
+            channels[name] = Channel.objects.create(
+                name=name, tvg_id=name, channel_number=number,
+                channel_group=group, epg_data=base_epg, **extra,
+            )
+        # Profile/channel creation signals may auto-add memberships.
+        ChannelProfileMembership.objects.filter(channel_profile=self.profile).delete()
+        ChannelProfileMembership.objects.bulk_create([
+            ChannelProfileMembership(channel_profile=self.profile, channel=channel, enabled=True)
+            for name, channel in channels.items() if name != "outside"
+        ])
+        ChannelOverride.objects.create(
+            channel=channels["visible"], name="Override display name",
+            tvg_id="visible.override", channel_number=101, epg_data=self.epg,
+        )
+        now = timezone.now() + timedelta(minutes=1)
+        programmes = ProgramData.objects.bulk_create([
+            ProgramData(
+                epg=self.epg, title=f"Programme {number}",
+                start_time=now + timedelta(minutes=number),
+                end_time=now + timedelta(minutes=number + 1),
+            )
+            for number in range(1001)
+        ])
+        self.programme = programmes[0]
+        ProgramData.objects.create(
+            epg=base_epg, title="Restricted schedule", start_time=now, end_time=now + timedelta(hours=1),
+        )
+        self.admin_key = uuid.uuid4().hex
+        User.objects.create_user(username=f"admin-{self.prefix}", user_level=10, api_key=self.admin_key)
+        self.xc_password = uuid.uuid4().hex
+        self.viewer = User.objects.create_user(
+            username=f"viewer-{self.prefix}", user_level=0,
+            custom_properties={"xc_password": self.xc_password, "hide_adult_content": True},
+        )
+        self.viewer.channel_profiles.add(self.profile)
+        self.revision = get_epg_revision()
+
+    def tearDown(self):
+        # Live server origin is unique to this class; never flush a shared Redis DB.
+        if hasattr(self, "redis"):
+            keys = [key for key in self.redis.scan_iter(match="epg_content:*")
+                    if self.live_server_url.encode() in key]
+            if keys:
+                self.redis.delete(*keys)
+        super().tearDown()
+
+    def _get(self, endpoint):
+        params = {"tvg_id_source": "tvg_id", "days": 0, "prev_days": 0}
+        if endpoint == "xc":
+            path = "/xmltv.php"
+            params.update(username=self.viewer.username, password=self.xc_password)
+        else:
+            path = f"/output/epg/{self.profile.name}"
+        return requests.get(
+            self.live_server_url + path, params=params,
+            headers={"Accept-Encoding": "identity", "Connection": "close"}, timeout=(3, 15),
+        )
+
+    def _assert_feed(self, response, endpoint, title="Programme 0"):
+        self.assertEqual(response.status_code, 200, response.content[:200])
+        root = ET.fromstring(response.content)
+        self.assertEqual(root.tag, "tv")
+        channels = {element.get("id"): element for element in root.findall("channel")}
+        expected_channels = {"visible.override"} if endpoint == "xc" else {"visible.override", "restricted", "adult"}
+        self.assertEqual(set(channels), expected_channels)
+        self.assertEqual(channels["visible.override"].findtext("display-name"), "Override display name")
+        programmes = root.findall("programme")
+        self.assertEqual(len(programmes), 1001 if endpoint == "xc" else 1003)
+        selected = [item for item in programmes if item.get("channel") == "visible.override"]
+        self.assertEqual(len(selected), 1001)
+        self.assertEqual(selected[0].findtext("title"), title)
+        self.assertEqual(selected[-1].findtext("title"), "Programme 1000")
+        if "Content-Length" in response.headers:
+            self.assertEqual(int(response.headers["Content-Length"]), len(response.content))
+        return response.content
+
+    def _warm(self, endpoint):
+        expected = self._assert_feed(self._get(endpoint), endpoint)
+        cached = self._get(endpoint)
+        self.assertIn("Content-Length", cached.headers)
+        self.assertEqual(self._assert_feed(cached, endpoint), expected)
+        return expected
+
+    def _service_update(self, title="Updated", **kwargs):
+        return update_programmes([
+            ProgrammeUpdate(self.programme.pk, {"title": "Programme 0"}, {"title": title})
+        ], **kwargs)
+
+    @contextmanager
+    def _pause(self, target, *, producer=False):
+        """Pause real cache work, retaining original bytes and Redis operations."""
+        entered, release = threading.Event(), threading.Event()
+        claimed = threading.Lock()
+        build_keys = []
+        original = getattr(chunk_cache._Build if producer else chunk_cache, target)
+        revision = get_epg_revision()
+
+        def barrier(build_key):
+            if revision not in build_key or entered.is_set():
+                return
+            with claimed:
+                if entered.is_set():
+                    return
+                build_keys.append(build_key)
+                entered.set()
+            if not release.wait(10):
+                raise RuntimeError("HTTP cache test barrier timed out")
+
+        if producer:
+            def wrapped(build, offset, chunk):
+                result = original(build, offset, chunk)
+                if b"<programme " in chunk:
+                    barrier(build.key)
+                return result
+            owner = chunk_cache._Build
+        else:
+            def wrapped(redis, build_key, manifest, offset, retention):
+                if offset == 1:
+                    barrier(build_key)
+                return original(redis, build_key, manifest, offset, retention)
+            owner = chunk_cache
+        with patch.object(owner, target, wrapped):
+            try:
+                yield entered, release, build_keys
+            finally:
+                release.set()
+
+    def test_admin_http_update_refreshes_both_endpoints_and_preserves_visibility(self):
+        for endpoint in ("standard", "xc"):
+            self._warm(endpoint)
+        response = requests.patch(
+            f"{self.live_server_url}/api/epg/programs/{self.programme.pk}/",
+            json={"title": "Updated & <title>"},
+            headers={"X-API-Key": self.admin_key}, timeout=(3, 15),
+        )
+        self.assertEqual(response.status_code, 200, response.content[:200])
+        self.assertNotEqual(get_epg_revision(), self.revision)
+        for endpoint in ("standard", "xc"):
+            self._assert_feed(self._get(endpoint), endpoint, title="Updated & <title>")
+
+    def test_admin_http_noop_does_not_advance_revision(self):
+        expected = self._warm("xc")
+        response = requests.patch(
+            f"{self.live_server_url}/api/epg/programs/{self.programme.pk}/",
+            json={"title": "Programme 0"}, headers={"X-API-Key": self.admin_key}, timeout=(3, 15),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(get_epg_revision(), self.revision)
+        self.assertEqual(self._assert_feed(self._get("xc"), "xc"), expected)
+
+    def test_admin_http_delete_retires_cached_programme(self):
+        self._warm("xc")
+        response = requests.delete(
+            f"{self.live_server_url}/api/epg/programs/{self.programme.pk}/",
+            headers={"X-API-Key": self.admin_key}, timeout=(3, 15),
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertNotEqual(get_epg_revision(), self.revision)
+        feed = self._get("xc")
+        self.assertEqual(feed.status_code, 200)
+        programmes = ET.fromstring(feed.content).findall("programme")
+        self.assertEqual(len(programmes), 1000)
+        self.assertEqual(programmes[0].findtext("title"), "Programme 1")
+
+    def test_admin_http_update_does_not_resurrect_row_deleted_after_lookup(self):
+        from apps.epg.api_views import ProgramViewSet
+
+        original = ProgramViewSet.perform_update
+        programme_id = self.programme.pk
+
+        def delete_before_write(view, serializer):
+            ProgramData.objects.filter(pk=programme_id).delete()
+            return original(view, serializer)
+
+        with patch.object(ProgramViewSet, "perform_update", delete_before_write):
+            response = requests.patch(
+                f"{self.live_server_url}/api/epg/programs/{programme_id}/",
+                json={"title": "Stale edit"}, headers={"X-API-Key": self.admin_key}, timeout=(3, 15),
+            )
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(ProgramData.objects.filter(pk=programme_id).exists())
+
+    def test_preview_noop_and_rollback_retain_warmed_feeds(self):
+        baseline = {endpoint: self._warm(endpoint) for endpoint in ("standard", "xc")}
+        self._service_update(preview=True)
+        self._service_update(title="Programme 0")
+        with self.assertRaises(RuntimeError):
+            with transaction.atomic():
+                self._service_update()
+                raise RuntimeError("Caller rolls back")
+        self.assertEqual(get_epg_revision(), self.revision)
+        for endpoint, expected in baseline.items():
+            response = self._get(endpoint)
+            self.assertIn("Content-Length", response.headers)
+            self.assertEqual(self._assert_feed(response, endpoint), expected)
+
+    def test_active_producer_survives_update_and_new_generation(self):
+        with self._pause("_cache_chunk", producer=True) as (entered, release, build_keys):
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                old = pool.submit(self._get, "standard")
+                try:
+                    self.assertTrue(entered.wait(5))
+                    self._service_update()
+                    self._assert_feed(self._get("standard"), "standard", title="Updated")
+                    self._assert_feed(self._get("xc"), "xc", title="Updated")
+                finally:
+                    release.set()
+                self._assert_feed(old.result(timeout=15), "standard")
+        self.assertTrue(self.redis.exists(chunk_cache._chunks_key(build_keys[0])))
+        self._assert_feed(self._get("standard"), "standard", title="Updated")
+
+    def test_active_ready_reader_survives_update_and_new_generation(self):
+        expected = self._warm("xc")
+        with self._pause("_read_chunk") as (entered, release, build_keys):
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                old = pool.submit(self._get, "xc")
+                try:
+                    self.assertTrue(entered.wait(5))
+                    self._service_update()
+                    self._assert_feed(self._get("xc"), "xc", title="Updated")
+                    self._assert_feed(self._get("standard"), "standard", title="Updated")
+                finally:
+                    release.set()
+                self.assertEqual(self._assert_feed(old.result(timeout=15), "xc"), expected)
+        self.assertTrue(self.redis.exists(chunk_cache._chunks_key(build_keys[0])))
+
+    def test_cached_data_loss_aborts_http_transfer_instead_of_returning_truncated_xml(self):
+        for expire in (False, True):
+            with self.subTest(expire=expire):
+                self._warm("standard")
+                with self._pause("_read_chunk") as (entered, release, build_keys):
+                    with ThreadPoolExecutor(max_workers=1) as pool:
+                        response = pool.submit(self._get, "standard")
+                        try:
+                            self.assertTrue(entered.wait(5))
+                            chunks_key = chunk_cache._chunks_key(build_keys[0])
+                            if expire:
+                                self.redis.pexpire(chunks_key, 1)
+                                deadline = time.monotonic() + 2
+                                while self.redis.exists(chunks_key) and time.monotonic() < deadline:
+                                    time.sleep(0.01)
+                                self.assertFalse(self.redis.exists(chunks_key))
+                            else:
+                                self.redis.delete(chunks_key)
+                        finally:
+                            release.set()
+                        with self.assertRaises(requests.exceptions.ChunkedEncodingError):
+                            response.result(timeout=15)
+                # A later HTTP request rebuilds a complete feed, without waiting for TTL.
+                self._assert_feed(self._get("standard"), "standard")
+
+
+class ProgrammeViewMutationTests(TestCase):
+    """Verify transaction guarantees of the existing DRF persistence hooks."""
+
+    def setUp(self):
+        from apps.epg.api_views import ProgramViewSet
+        from apps.epg.serializers import ProgramDataSerializer
+
+        self.view = ProgramViewSet()
+        self.serializer_class = ProgramDataSerializer
+        self.epg = EPGData.objects.create(name="Mutation hook test")
+        self.now = timezone.now()
+        self.programme = ProgramData.objects.create(
+            epg=self.epg, title="Original", start_time=self.now, end_time=self.now + timedelta(hours=1),
+            custom_properties={"flag": True, "unrelated": "existing"},
+        )
+        self.revision = get_epg_revision()
+
+    def _creation_serializer(self):
+        serializer = self.serializer_class(data={
+            "title": "New programme", "start_time": self.now, "end_time": self.now + timedelta(hours=1),
+        })
+        serializer.is_valid(raise_exception=True)
+        # The existing HTTP serializer does not expose epg. Supply it here to
+        # exercise the persistence hook without widening that public schema.
+        serializer.validated_data["epg"] = self.epg
+        return serializer
+
+    def test_create_advances_revision_in_same_transaction(self):
+        serializer = self._creation_serializer()
+        self.view.perform_create(serializer)
+        self.assertTrue(ProgramData.objects.filter(pk=serializer.instance.pk).exists())
+        self.assertNotEqual(get_epg_revision(), self.revision)
+
+    def test_revision_failure_rolls_back_create_update_and_delete(self):
+        update = self.serializer_class(self.programme, data={"title": "Changed"}, partial=True)
+        update.is_valid(raise_exception=True)
+        operations = [
+            lambda: self.view.perform_create(self._creation_serializer()),
+            lambda: self.view.perform_update(update),
+            lambda: self.view.perform_destroy(self.programme),
+        ]
+        for operation in operations:
+            with self.subTest(operation=operation):
+                with patch("apps.epg.api_views.advance_epg_revision", side_effect=RuntimeError("revision failed")):
+                    with self.assertRaises(RuntimeError):
+                        operation()
+                self.programme.refresh_from_db()
+                self.assertEqual(self.programme.title, "Original")
+                self.assertEqual(ProgramData.objects.count(), 1)
+                self.assertEqual(get_epg_revision(), self.revision)
+
+    def test_json_replacement_distinguishes_numbers_from_booleans(self):
+        class PropertySerializer(self.serializer_class):
+            class Meta(self.serializer_class.Meta):
+                fields = [*self.serializer_class.Meta.fields, "custom_properties"]
+
+        serializer = PropertySerializer(
+            self.programme, data={"custom_properties": {"flag": 1}}, partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        self.view.perform_update(serializer)
+        self.programme.refresh_from_db()
+        self.assertEqual(self.programme.custom_properties, {"flag": 1})
+        self.assertIs(type(self.programme.custom_properties["flag"]), int)
+        self.assertNotEqual(get_epg_revision(), self.revision)

--- a/apps/output/tests/test_streaming_chunk_cache.py
+++ b/apps/output/tests/test_streaming_chunk_cache.py
@@ -1,6 +1,11 @@
+import json
 import threading
 import time
-from unittest import TestCase
+import uuid
+
+import redis as redis_library
+from django.conf import settings
+from django.test import TransactionTestCase
 
 from apps.output.streaming_chunk_cache import (
     STATUS_BUILDING,
@@ -13,84 +18,22 @@ from apps.output.streaming_chunk_cache import (
 )
 
 
-class FakeRedis:
-    """Minimal Redis stand-in for chunk-cache unit tests."""
-
-    def __init__(self):
-        self._strings = {}
-        self._lists = {}
-        self._expires_at = {}
-
-    def _purge_expired(self):
-        now = time.monotonic()
-        expired = [key for key, deadline in self._expires_at.items() if deadline <= now]
-        for key in expired:
-            self._strings.pop(key, None)
-            self._lists.pop(key, None)
-            self._expires_at.pop(key, None)
-
-    def get(self, key):
-        self._purge_expired()
-        return self._strings.get(key)
-
-    def set(self, key, value, nx=False, ex=None):
-        self._purge_expired()
-        if nx and key in self._strings:
-            return None
-        self._strings[key] = value
-        if ex is not None:
-            self._expires_at[key] = time.monotonic() + ex
-        return True
-
-    def delete(self, *keys):
-        for key in keys:
-            self._strings.pop(key, None)
-            self._lists.pop(key, None)
-            self._expires_at.pop(key, None)
-
-    def exists(self, key):
-        self._purge_expired()
-        return key in self._strings or key in self._lists
-
-    def expire(self, key, ttl):
-        if key in self._strings or key in self._lists:
-            self._expires_at[key] = time.monotonic() + ttl
-        return True
-
-    def rpush(self, key, value):
-        self._lists.setdefault(key, []).append(value)
-
-    def lindex(self, key, offset):
-        items = self._lists.get(key, [])
-        if offset < len(items):
-            return items[offset]
-        return None
-
-    def llen(self, key):
-        return len(self._lists.get(key, []))
-
-    def scan_iter(self, match=None, count=None):  # noqa: ARG002
-        self._purge_expired()
-        import fnmatch
-
-        keys = list(self._strings) + list(self._lists)
-        if match:
-            # Redis glob: * matches anything
-            pattern = match
-            for key in keys:
-                if fnmatch.fnmatch(key, pattern):
-                    yield key
-        else:
-            yield from keys
-
-
 def _consume(response):
     return b"".join(response.streaming_content).decode("utf-8")
 
 
-class StreamingChunkCacheTests(TestCase):
+class StreamingChunkCacheTests(TransactionTestCase):
+    def setUp(self):
+        self.redis = redis_library.Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=15)
+        self.key = f"epg_content:unit-{uuid.uuid4().hex}"
+
+    def tearDown(self):
+        keys = list(self.redis.scan_iter(match=self.key + "*"))
+        if keys:
+            self.redis.delete(*keys)
+
     def test_leader_caches_chunks_and_sets_ready(self):
-        redis = FakeRedis()
+        redis = self.redis
         calls = []
 
         def source():
@@ -98,17 +41,19 @@ class StreamingChunkCacheTests(TestCase):
             yield "<tv>"
             yield "</tv>"
 
-        body = _consume(stream_cached_response("cache:test", source, redis=redis))
+        body = _consume(stream_cached_response(self.key, source, redis=redis))
 
         self.assertEqual(body, "<tv></tv>")
         self.assertEqual(calls, [1])
-        self.assertEqual(redis.get(_ready_key("cache:test")), "1")
-        self.assertEqual(redis.get(_status_key("cache:test")), STATUS_READY)
-        self.assertEqual(redis.llen(_chunks_key("cache:test")), 2)
-        self.assertFalse(redis.exists(_lock_key("cache:test")))
+        manifest = json.loads(redis.get(_ready_key(self.key)))
+        build_key = f"{self.key}:build:{manifest['id']}"
+        self.assertEqual(redis.get(_status_key(build_key)), STATUS_READY.encode())
+        self.assertEqual(manifest["count"], 2)
+        self.assertEqual(redis.llen(_chunks_key(build_key)), 2)
+        self.assertFalse(redis.exists(_lock_key(self.key)))
 
     def test_cache_hit_skips_source(self):
-        redis = FakeRedis()
+        redis = self.redis
         calls = []
 
         def source():
@@ -116,16 +61,16 @@ class StreamingChunkCacheTests(TestCase):
             yield "<tv>"
             yield "</tv>"
 
-        _consume(stream_cached_response("cache:test", source, redis=redis))
+        _consume(stream_cached_response(self.key, source, redis=redis))
         calls.clear()
-        body = _consume(stream_cached_response("cache:test", source, redis=redis))
+        body = _consume(stream_cached_response(self.key, source, redis=redis))
 
         self.assertEqual(body, "<tv></tv>")
         self.assertEqual(calls, [])
 
     def test_follower_reads_leader_chunks_without_rebuilding(self):
-        redis = FakeRedis()
-        base = "cache:follow"
+        redis = self.redis
+        base = self.key
         leader_started = threading.Event()
         rebuild_calls = []
 
@@ -167,7 +112,7 @@ class StreamingChunkCacheTests(TestCase):
         self.assertEqual(rebuild_calls, [1])
 
     def test_only_one_leader_when_two_clients_start_together(self):
-        redis = FakeRedis()
+        redis = self.redis
         build_calls = []
         barrier = threading.Barrier(2)
         results = {}
@@ -180,7 +125,7 @@ class StreamingChunkCacheTests(TestCase):
             barrier.wait()
             results[threading.current_thread().name] = _consume(
                 stream_cached_response(
-                    "cache:race",
+                    self.key,
                     source,
                     redis=redis,
                     poll_interval=0.01,
@@ -200,25 +145,17 @@ class StreamingChunkCacheTests(TestCase):
         self.assertEqual(results["t2"], "x")
         self.assertEqual(len(build_calls), 1)
 
-    def test_invalidate_epg_chunk_cache_deletes_epg_content_keys(self):
-        from unittest.mock import patch
-
+    def test_invalidation_advances_revision_without_deleting_old_chunks(self):
+        from apps.epg.services import get_epg_revision
         from apps.output.streaming_chunk_cache import invalidate_epg_chunk_cache
 
-        redis = FakeRedis()
-        redis.set("epg_content:all:anonymous:d=0:ready", "1")
-        redis.rpush("epg_content:all:anonymous:d=0:chunks", b"<tv/>")
-        redis.set("unrelated:key", "keep")
-
-        with patch(
-            "apps.output.streaming_chunk_cache._get_redis",
-            return_value=redis,
-        ):
-            invalidate_epg_chunk_cache()
-
-        self.assertFalse(redis.exists("epg_content:all:anonymous:d=0:ready"))
-        self.assertFalse(redis.exists("epg_content:all:anonymous:d=0:chunks"))
-        self.assertTrue(redis.exists("unrelated:key"))
+        revision = get_epg_revision()
+        self.redis.set(self.key + ":ready", "retained")
+        self.redis.rpush(self.key + ":chunks", b"<tv/>")
+        self.assertTrue(invalidate_epg_chunk_cache())
+        self.assertNotEqual(get_epg_revision(), revision)
+        self.assertTrue(self.redis.exists(self.key + ":ready"))
+        self.assertTrue(self.redis.exists(self.key + ":chunks"))
 
     def test_invalidate_m3u_content_cache_uses_django_delete_pattern(self):
         from unittest.mock import MagicMock, patch

--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -307,13 +307,13 @@ class OutputEPGXMLEscapingTest(OutputEndpointTestMixin, TestCase):
 
     def test_override_epg_change_invalidates_xmltv_chunk_cache(self):
         """
-        XC reads live ProgramData; XMLTV is chunk-cached. Changing the
-        effective EPG via ChannelOverride must drop that cache so the next
-        /output/epg emits the new station's programmes, not the previous ones.
+        Changing the effective EPG retires the cache generation so new
+        requests use the new station without deleting active readers' data.
         """
         from django.utils import timezone
         from apps.channels.models import ChannelOverride
         from apps.epg.models import ProgramData
+        from apps.epg.services import get_epg_revision
         from django_redis import get_redis_connection
 
         # This mixin normally bypasses Redis chunk caching; use the real path here.
@@ -358,17 +358,14 @@ class OutputEPGXMLEscapingTest(OutputEndpointTestMixin, TestCase):
             self.assertNotIn('<title>NEW PROGRAMME</title>', before)
 
             redis = get_redis_connection("default")
-            cached_before = list(redis.scan_iter(match="epg_content:*", count=200))
+            previous_revision = get_epg_revision()
+            cached_before = list(redis.scan_iter(match=f"epg_content:{previous_revision}:*", count=200))
             self.assertGreater(len(cached_before), 0, "XMLTV chunk cache should be warm")
 
             ChannelOverride.objects.create(channel=channel, epg_data=epg_new)
 
-            cached_after = list(redis.scan_iter(match="epg_content:*", count=200))
-            self.assertEqual(
-                len(cached_after),
-                0,
-                "Override EPG change must invalidate XMLTV chunk cache",
-            )
+            self.assertNotEqual(get_epg_revision(), previous_revision)
+            self.assertTrue(all(redis.exists(key) for key in cached_before), "Active readers retain their old cache data")
 
             after = _response_text(self.client.get(url))
             self.assertIn('<title>NEW PROGRAMME</title>', after)
@@ -1423,6 +1420,9 @@ class GenerateEpgPrevDaysTests(SimpleTestCase):
 
     def setUp(self):
         self.factory = RequestFactory()
+        revision = patch("apps.output.epg.get_epg_revision", return_value="test-revision")
+        revision.start()
+        self.addCleanup(revision.stop)
 
     @patch("apps.output.epg.stream_cached_response")
     @patch("apps.output.epg.Channel.objects")


### PR DESCRIPTION
## Description

Prevent committed EPG edits from corrupting concurrent XMLTV exports. Export selection now includes a durable database revision, and each Redis build has a unique identity with atomic ownership, chunk-count and publication checks. Invalidation retires a revision without deleting data used by active readers or producers.

Cache-miss producers still stream immediately. Concurrent followers wait up to five seconds for a completed build, then generate their own response if needed. Completed cache replays carry an exact Content-Length, so expired or missing data causes a detectable incomplete transfer rather than a normally completed truncated XML document. Memory remains bounded to one chunk.

Also adds a documented Python service for up to 500 expected-value programme metadata updates per batch, preserving unrelated properties and reporting conflicts/missing rows. Metadata changes and their revision commit together. Existing programme API writes advance the same revision atomically; stale PATCH requests cannot recreate rows deleted by an EPG refresh.

No new dependencies, HTTP endpoints, or frontend changes. The migration creates the EPG revision row. The implementation and tests were AI-assisted. Author has manually reviewed and tested these changes, ready for review. 

## Related Issue

resolves #1650

## How was it tested?

- `python manage.py test apps.output.tests apps.epg.tests apps.channels.tests apps.m3u.tests --keepdb -v1`: **1,230 tests passed** on PostgreSQL 17 and real Redis using the project CI bootstrap in a disposable container.
- Added failing regressions before the cache and API fixes. Real HTTP tests exercise both standard and XC XMLTV, active producers/readers during mutation, preview/no-op/rollback, API freshness, missing-row conflicts, and preservation of profile/user/hidden-channel/override behavior.
- Real Redis expiry/deletion tests verify incomplete cached transfers are detected. HTTP fault tests use Django's WSGI LiveServer with `Connection: close`; this is not a claim of production nginx/uWSGI deployment testing.
- `python manage.py makemigrations epg --check --dry-run`: no EPG migration drift. Python compilation and `git diff --check` passed. Independent review found no remaining high-severity correctness or security findings.

Existing requests do not become global database snapshots. Retired generations expire naturally; readers paused beyond retention can fail detectably. Followers may regenerate after the bounded wait.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema (not applicable: no new endpoints)
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`) (not applicable: no frontend changes)
- [x] Tests are included for new functionality
- [x] Existing tests still pass (the four affected/backend caller suites above)
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
