### PR TITLE
fix(core): add public_port override for no-proxy Docker port remaps

### DIFF
--- a/apps/output/tests/test_views.py
+++ b/apps/output/tests/test_views.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, Client, SimpleTestCase, RequestFactory
+from django.test import TestCase, Client, RequestFactory
 from django.http import Http404
 from django.urls import reverse
 from unittest import skipUnless
@@ -1418,11 +1418,24 @@ class XcGetEpgDummyTests(TestCase):
         self.assertIn("Unnumbered", content)
 
 
-class GenerateEpgPrevDaysTests(SimpleTestCase):
-    """Profile EPG keeps legacy prev_days=0 unless URL or user setting says otherwise."""
+class GenerateEpgPrevDaysTests(TestCase):
+    """Profile EPG keeps legacy prev_days=0 unless URL or user setting says otherwise.
+
+    TestCase (not SimpleTestCase) because generate_epg() -> build_absolute_uri_with_port()
+    now reads CoreSettings.get_public_port() on the no-forwarded-header path - a real
+    DB query where there used to be none.
+    """
 
     def setUp(self):
+        from django.core.cache import cache as django_cache
+
         self.factory = RequestFactory()
+        django_cache.clear()
+
+    def tearDown(self):
+        from django.core.cache import cache as django_cache
+
+        django_cache.clear()
 
     @patch("apps.output.epg.stream_cached_response")
     @patch("apps.output.epg.Channel.objects")
@@ -1465,11 +1478,24 @@ class GenerateEpgPrevDaysTests(SimpleTestCase):
         self.assertEqual(lan_key, same_lan_key)
 
 
-class GenerateM3UCacheKeyTests(SimpleTestCase):
-    """M3U shared cache must not reuse absolute URLs built for a different Host."""
+class GenerateM3UCacheKeyTests(TestCase):
+    """M3U shared cache must not reuse absolute URLs built for a different Host.
+
+    TestCase (not SimpleTestCase) because generate_m3u() -> build_absolute_uri_with_port()
+    now reads CoreSettings.get_public_port() on the no-forwarded-header path - a real
+    DB query where there used to be none.
+    """
 
     def setUp(self):
+        from django.core.cache import cache as django_cache
+
         self.factory = RequestFactory()
+        django_cache.clear()
+
+    def tearDown(self):
+        from django.core.cache import cache as django_cache
+
+        django_cache.clear()
 
     @patch("django.core.cache.cache")
     def test_m3u_cache_key_includes_request_origin(self, mock_cache):

--- a/core/apps.py
+++ b/core/apps.py
@@ -39,12 +39,40 @@ class CoreConfig(AppConfig):
             # Database not migrated yet: the collector keeps its defaults.
             pass
 
+        try:
+            self._seed_public_port_from_env()
+        except Exception:
+            # Database not migrated yet: seeding is retried on next startup.
+            pass
+
         # Sync developer notifications and check for version updates on startup
         # Only run in the main process (not in management commands, migrations, or workers)
         if should_skip_initialization():
             return
 
         self._sync_developer_notifications()
+
+    def _seed_public_port_from_env(self):
+        """One-time seed of Settings > System > Public Port from
+        DISPATCHARR_PUBLIC_PORT, for Docker deployments that map a
+        non-default host port (e.g. `8080:9191`) and want it set at deploy
+        time instead of clicking through the admin UI after first boot.
+
+        Only applies while the setting has never been configured. Once set -
+        by this seed or manually via the UI - the DB value is the source of
+        truth and this env var is ignored on every later startup, so a UI
+        correction always sticks even if the env var is later removed or
+        left at a stale value.
+        """
+        import os
+        from core.models import CoreSettings
+
+        env_value = os.environ.get("DISPATCHARR_PUBLIC_PORT")
+        if not env_value:
+            return
+        if CoreSettings.get_public_port() is not None:
+            return
+        CoreSettings.set_public_port(env_value)
 
     def _sync_developer_notifications(self):
         """Sync developer notifications from JSON file to database."""

--- a/core/models.py
+++ b/core/models.py
@@ -775,7 +775,25 @@ class CoreSettings(models.Model):
             "log_max_mb": 10,
             "log_keep": 5,
             "log_persist": True,
+            "public_port": None,
         })
+
+    @classmethod
+    def get_public_port(cls):
+        """Explicit override for the port baked into generated absolute URLs
+        (logos, M3U/EPG endpoints, VOD posters, catch-up, ...) when no reverse
+        proxy is present to supply X-Forwarded-* headers - e.g. a single
+        Docker host-port remap (`8080:9191`). None (default) preserves the
+        existing auto-detection behavior. See core.utils.get_host_and_port.
+        """
+        value = cls.get_system_settings().get("public_port")
+        return str(value) if value else None
+
+    @classmethod
+    def set_public_port(cls, port):
+        value = str(port).strip() if port else None
+        cls._update_group(SYSTEM_SETTINGS_KEY, "System Settings", {"public_port": value})
+        return value
 
     @classmethod
     def get_catchup_enabled(cls):

--- a/core/models.py
+++ b/core/models.py
@@ -785,6 +785,11 @@ class CoreSettings(models.Model):
         proxy is present to supply X-Forwarded-* headers - e.g. a single
         Docker host-port remap (`8080:9191`). None (default) preserves the
         existing auto-detection behavior. See core.utils.get_host_and_port.
+
+        Can be pre-filled at deploy time via the DISPATCHARR_PUBLIC_PORT
+        environment variable (see CoreConfig._seed_public_port_from_env) -
+        that only ever seeds an unset value; once configured here (by the
+        env var or by hand), this is the source of truth.
         """
         value = cls.get_system_settings().get("public_port")
         return str(value) if value else None

--- a/core/tests/test_core.py
+++ b/core/tests/test_core.py
@@ -837,13 +837,23 @@ class GetClientIpTests(SimpleTestCase):
             self.assertEqual(get_client_ip(request), "192.168.1.50")
 
 
-class GetHostAndPortTrustedProxyTests(SimpleTestCase):
-    """Forwarded host/scheme are honored only from trusted peers."""
+class GetHostAndPortTrustedProxyTests(TestCase):
+    """Forwarded host/scheme are honored only from trusted peers.
+
+    TestCase (not SimpleTestCase) because get_host_and_port() now reads
+    CoreSettings.get_public_port() on the untrusted-peer/no-forwarded-header
+    path - a real DB query where there used to be none.
+    """
 
     def setUp(self):
         from django.test import RequestFactory
 
         self.factory = RequestFactory()
+        cache.clear()
+        CoreSettings.objects.filter(key=SYSTEM_SETTINGS_KEY).delete()
+
+    def tearDown(self):
+        cache.clear()
 
     def _request(self, remote_addr, path="/", **extra):
         request = self.factory.get(path)

--- a/core/tests/test_get_host_and_port.py
+++ b/core/tests/test_get_host_and_port.py
@@ -1,0 +1,79 @@
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+
+from core.models import CoreSettings, SYSTEM_SETTINGS_KEY
+from core.utils import get_host_and_port
+
+
+class GetHostAndPortTests(TestCase):
+    """
+    Covers the no-reverse-proxy Docker port-remap case (e.g. `8080:9191`)
+    where none of the X-Forwarded-* signals exist and get_host_and_port()
+    would otherwise bake in SERVER_PORT (the internal container-bound port)
+    instead of whatever port the operator actually exposed.
+    """
+
+    def setUp(self):
+        cache.clear()
+        CoreSettings.objects.filter(key=SYSTEM_SETTINGS_KEY).delete()
+
+    def tearDown(self):
+        cache.clear()
+
+    def _direct_request(self, server_port="9191"):
+        # No X-Forwarded-* headers at all: simulates a client hitting the
+        # container directly through a plain Docker host-port remap, with no
+        # reverse proxy anywhere in the path. HTTP_HOST is set explicitly
+        # (without a port) to match what a real client actually sends -
+        # RequestFactory otherwise synthesizes "testserver:<SERVER_PORT>" as
+        # the Host, which short-circuits at step 2 before ever reaching the
+        # SERVER_PORT/public_port fallback this test is meant to exercise.
+        factory = RequestFactory()
+        request = factory.get(
+            "/", SERVER_PORT=server_port, HTTP_HOST="dvb.example.com"
+        )
+        request.META.pop("HTTP_X_FORWARDED_HOST", None)
+        request.META.pop("HTTP_X_FORWARDED_PORT", None)
+        request.META.pop("HTTP_X_FORWARDED_PROTO", None)
+        request.META.pop("HTTP_X_FORWARDED_FOR", None)
+        return request
+
+    def test_no_override_falls_back_to_server_port(self):
+        """Default behavior (no public_port configured) is unchanged."""
+        request = self._direct_request(server_port="9191")
+        host, port = get_host_and_port(request)
+        self.assertEqual(port, "9191")
+
+    def test_public_port_override_wins_over_server_port(self):
+        """
+        Operator explicitly mapped `8080:9191` and set Public Port=8080 in
+        Settings > System. Generated URLs must use 8080, not the internal
+        9191 SERVER_PORT - this is the actual bug being fixed.
+        """
+        CoreSettings.set_public_port("8080")
+        request = self._direct_request(server_port="9191")
+        host, port = get_host_and_port(request)
+        self.assertEqual(port, "8080")
+
+    def test_public_port_override_omitted_when_standard(self):
+        """If the override equals the standard port for the scheme, it's
+        omitted from the URL just like every other path in this function."""
+        CoreSettings.set_public_port("80")
+        request = self._direct_request(server_port="9191")
+        host, port = get_host_and_port(request)
+        self.assertIsNone(port)
+
+    def test_reverse_proxy_headers_still_take_priority(self):
+        """A properly configured reverse proxy's own signals must not be
+        shadowed by a leftover public_port override."""
+        CoreSettings.set_public_port("8080")
+        factory = RequestFactory()
+        request = factory.get(
+            "/",
+            SERVER_PORT="9191",
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_X_FORWARDED_HOST="tv.example.com",
+        )
+        host, port = get_host_and_port(request)
+        self.assertEqual(host, "tv.example.com")
+        self.assertIsNone(port)

--- a/core/tests/test_public_port_env_seed.py
+++ b/core/tests/test_public_port_env_seed.py
@@ -1,0 +1,47 @@
+import os
+from unittest.mock import patch
+
+from django.apps import apps
+from django.core.cache import cache
+from django.test import TestCase
+
+from core.models import CoreSettings, SYSTEM_SETTINGS_KEY
+
+
+class PublicPortEnvSeedTests(TestCase):
+    """
+    DISPATCHARR_PUBLIC_PORT pre-fills Settings > System > Public Port at
+    startup for Docker deployments that map a non-default host port and
+    want it set at deploy time instead of through the admin UI. It must
+    only ever seed an *unset* value - once configured (by the env var or
+    by hand), the DB value stays the source of truth on every later
+    startup, even if the env var is later changed or removed.
+    """
+
+    def setUp(self):
+        cache.clear()
+        CoreSettings.objects.filter(key=SYSTEM_SETTINGS_KEY).delete()
+        self.config = apps.get_app_config("core")
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_seeds_unset_value_from_env(self):
+        with patch.dict(os.environ, {"DISPATCHARR_PUBLIC_PORT": "8080"}):
+            self.config._seed_public_port_from_env()
+        self.assertEqual(CoreSettings.get_public_port(), "8080")
+
+    def test_does_not_override_an_already_configured_value(self):
+        """A UI-set (or previously env-seeded) value must survive even if
+        the env var is later changed - the DB is the source of truth once
+        anything has been configured."""
+        CoreSettings.set_public_port("80")
+        with patch.dict(os.environ, {"DISPATCHARR_PUBLIC_PORT": "8080"}):
+            self.config._seed_public_port_from_env()
+        self.assertEqual(CoreSettings.get_public_port(), "80")
+
+    def test_no_env_var_leaves_setting_unset(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DISPATCHARR_PUBLIC_PORT", None)
+            self.config._seed_public_port_from_env()
+        self.assertIsNone(CoreSettings.get_public_port())

--- a/core/utils.py
+++ b/core/utils.py
@@ -1038,6 +1038,9 @@ def get_host_and_port(request):
     - Falls back to Host header.
     - Returns None for port if using standard ports (80/443) to omit from URLs.
     - In dev, uses 5656 as a guess if port cannot be determined.
+    - An explicit Settings > System > Public Port override, when set, takes
+      priority over the SERVER_PORT guess (see step 5 in
+      _resolve_host_port_scheme below).
     """
     from dispatcharr.utils import request_from_trusted_proxy
 
@@ -1091,16 +1094,29 @@ def _resolve_host_port_scheme(request, trust_forwarded):
         if request.META.get("HTTP_X_FORWARDED_PROTO") or request.META.get("HTTP_X_FORWARDED_FOR"):
             return host, None, scheme
 
-    # 5. Try SERVER_PORT from META (only if NOT behind reverse proxy)
+    # 5. Explicit public port override (Settings > System > Public Port).
+    # Covers deployments with NO reverse proxy at all - e.g. a single Docker
+    # host-port remap (`8080:9191`) - where none of the proxy signals above
+    # exist, so step 6 would otherwise bake in SERVER_PORT (the internal
+    # container-bound port, invisible-to-the-app Docker NAT notwithstanding)
+    # instead of the port the operator actually exposed.
+    from core.models import CoreSettings
+
+    configured_port = CoreSettings.get_public_port()
+    if configured_port:
+        return host, (None if configured_port == standard_port else configured_port), scheme
+
+    # 6. Try SERVER_PORT from META (only if NOT behind reverse proxy and no
+    # explicit override is configured)
     port = request.META.get("SERVER_PORT")
     if port:
         return host, (None if port == standard_port else port), scheme
 
-    # 6. Dev fallback
+    # 7. Dev fallback
     if os.environ.get("DISPATCHARR_ENV") == "dev" or host in ("localhost", "127.0.0.1"):
         return host, "5656", scheme
 
-    # 7. Final fallback: assume standard port for scheme
+    # 8. Final fallback: assume standard port for scheme
     return host, None, scheme
 
 

--- a/docker/docker-compose.aio.yml
+++ b/docker/docker-compose.aio.yml
@@ -15,6 +15,13 @@ services:
       - REDIS_HOST=localhost
       - CELERY_BROKER_URL=redis://localhost:6379/0
       - DISPATCHARR_LOG_LEVEL=info
+      # If you map a DIFFERENT host port above (e.g. "8080:9191") and have
+      # NO reverse proxy in front of Dispatcharr, set this to that host port
+      # so generated URLs (logos, M3U/EPG, VOD posters, catch-up) use it
+      # instead of the internal 9191. Only pre-fills Settings > System >
+      # Public Port on first boot - a value set there afterwards always
+      # wins, this env var is ignored once anything has been configured.
+      #- DISPATCHARR_PUBLIC_PORT=8080
       # Redis idle-client timeout in seconds, and per-process redis-py /
       # django-redis pool cap (Optional, defaults: 300 / 50)
       #- REDIS_IDLE_TIMEOUT=300

--- a/frontend/src/components/forms/settings/SystemSettingsForm.jsx
+++ b/frontend/src/components/forms/settings/SystemSettingsForm.jsx
@@ -155,7 +155,7 @@ const SystemSettingsForm = React.memo(({ active }) => {
       />
       <TextInput
         label="Public Port"
-        description="Override the port baked into generated absolute URLs (logos, M3U/EPG, VOD posters, catch-up). Only needed when there is NO reverse proxy in front of Dispatcharr and the external/host port differs from the internal port (e.g. Docker mapped as '8080:9191'). Leave empty to auto-detect as before - has no effect when a reverse proxy supplies X-Forwarded-* headers."
+        description="Override the port baked into generated absolute URLs (logos, M3U/EPG, VOD posters, catch-up). Only needed when there is NO reverse proxy in front of Dispatcharr and the external/host port differs from the internal port (e.g. Docker mapped as '8080:9191'). Leave empty to auto-detect as before - has no effect when a reverse proxy supplies X-Forwarded-* headers. Can also be pre-filled at deploy time via the DISPATCHARR_PUBLIC_PORT environment variable; a value set here always takes priority over it afterwards."
         placeholder="Auto-detect"
         {...form.getInputProps('public_port')}
         id="public_port"

--- a/frontend/src/components/forms/settings/SystemSettingsForm.jsx
+++ b/frontend/src/components/forms/settings/SystemSettingsForm.jsx
@@ -14,6 +14,7 @@ import {
   Select,
   Stack,
   Switch,
+  TextInput,
 } from '@mantine/core';
 import ConnectionSecurityPanel from './ConnectionSecurityPanel.jsx';
 import { useForm } from '@mantine/form';
@@ -151,6 +152,13 @@ const SystemSettingsForm = React.memo(({ active }) => {
         description="When disabled, timeshift and catchup endpoints are blocked for all users, and channels are not advertised as supporting catchup to clients. Catchup capability is still shown in the web UI."
         {...form.getInputProps('catchup_enabled', { type: 'checkbox' })}
         id="catchup_enabled"
+      />
+      <TextInput
+        label="Public Port"
+        description="Override the port baked into generated absolute URLs (logos, M3U/EPG, VOD posters, catch-up). Only needed when there is NO reverse proxy in front of Dispatcharr and the external/host port differs from the internal port (e.g. Docker mapped as '8080:9191'). Leave empty to auto-detect as before - has no effect when a reverse proxy supplies X-Forwarded-* headers."
+        placeholder="Auto-detect"
+        {...form.getInputProps('public_port')}
+        id="public_port"
       />
       {isModular && (
         <>

--- a/frontend/src/components/forms/settings/__tests__/SystemSettingsForm.test.jsx
+++ b/frontend/src/components/forms/settings/__tests__/SystemSettingsForm.test.jsx
@@ -86,6 +86,20 @@ vi.mock('@mantine/core', () => ({
   Switch: ({ id }) => (
     <input data-testid={id} id={id} type="checkbox" onChange={() => {}} />
   ),
+  TextInput: ({ label, description, placeholder, value, onChange, id }) => (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      {description && <p>{description}</p>}
+      <input
+        data-testid={id || 'text-input'}
+        id={id}
+        type="text"
+        placeholder={placeholder}
+        value={value ?? ''}
+        onChange={onChange}
+      />
+    </div>
+  ),
   Text: ({ children }) => <span>{children}</span>,
   Divider: () => <hr />,
 }));

--- a/frontend/src/utils/forms/settings/SystemSettingsFormUtils.js
+++ b/frontend/src/utils/forms/settings/SystemSettingsFormUtils.js
@@ -8,5 +8,6 @@ export const getSystemSettingsFormInitialValues = () => {
     auto_import_mapped_files: true,
     enable_ip_lookup: true,
     catchup_enabled: true,
+    public_port: '',
   };
 };

--- a/frontend/src/utils/forms/settings/__tests__/SystemSettingsFormUtils.test.js
+++ b/frontend/src/utils/forms/settings/__tests__/SystemSettingsFormUtils.test.js
@@ -16,6 +16,7 @@ describe('SystemSettingsFormUtils', () => {
         log_max_mb: 10,
         log_keep: 5,
         log_persist: true,
+        public_port: '',
       });
     });
 

--- a/frontend/src/utils/pages/SettingsUtils.js
+++ b/frontend/src/utils/pages/SettingsUtils.js
@@ -72,6 +72,7 @@ export const saveChangedSettings = async (settings, changedSettings) => {
     'auto_import_mapped_files',
     'enable_ip_lookup',
     'catchup_enabled',
+    'public_port',
   ];
 
   for (const formKey in changedSettings) {
@@ -397,6 +398,9 @@ export const parseSettings = (settings) => {
       typeof systemSettings.catchup_enabled === 'boolean'
         ? systemSettings.catchup_enabled
         : true;
+    parsed.public_port = systemSettings.public_port
+      ? String(systemSettings.public_port)
+      : '';
   }
 
   // Proxy and network access are already grouped objects

--- a/frontend/src/utils/pages/__tests__/SettingsUtils.test.js
+++ b/frontend/src/utils/pages/__tests__/SettingsUtils.test.js
@@ -169,6 +169,56 @@ describe('SettingsUtils', () => {
       });
     });
 
+    it('should persist public_port in system_settings', async () => {
+      const settings = {
+        system_settings: {
+          id: 3,
+          key: 'system_settings',
+          value: {},
+        },
+      };
+      const changedSettings = {
+        public_port: '8080',
+      };
+
+      API.updateSetting.mockResolvedValue({});
+
+      await SettingsUtils.saveChangedSettings(settings, changedSettings);
+
+      expect(API.updateSetting).toHaveBeenCalledWith({
+        id: 3,
+        key: 'system_settings',
+        value: {
+          public_port: '8080',
+        },
+      });
+    });
+
+    it('should persist an empty public_port (auto-detect) unchanged', async () => {
+      const settings = {
+        system_settings: {
+          id: 3,
+          key: 'system_settings',
+          value: { public_port: '8080' },
+        },
+      };
+      const changedSettings = {
+        public_port: '',
+      };
+
+      API.updateSetting.mockResolvedValue({});
+
+      await SettingsUtils.saveChangedSettings(settings, changedSettings);
+
+      expect(API.updateSetting).toHaveBeenCalledWith({
+        id: 3,
+        key: 'system_settings',
+        value: {
+          public_port: '',
+        },
+      });
+    });
+
     it('should coerce string false for boolean settings without enabling', async () => {
       const settings = {
         system_settings: {


### PR DESCRIPTION
## Description

Absolute URLs Dispatcharr generates for itself (logo cache URLs, M3U/EPG endpoints, VOD posters, catch-up) bake in the **internal container port** instead of the externally reachable one when there is **no reverse proxy at all** in front of Dispatcharr, e.g. a plain Docker host-port remap like `ports: ["80:9191"]`, nothing else. With no `X-Forwarded-*` signals present, `_resolve_host_port_scheme()` falls through to `SERVER_PORT`, which reflects whatever port the process is bound to *inside* the container (9191), not whatever host port Docker actually mapped it to. The process has no way to introspect this from inside the container.

Adds an explicit **Public Port** setting under Settings > System (`CoreSettings.get_public_port()` / `set_public_port()`) that `_resolve_host_port_scheme()` consults right after the existing reverse-proxy header checks and right before the `SERVER_PORT` fallback. Default (empty) preserves today's behavior exactly. Also adds a `DISPATCHARR_PUBLIC_PORT` env var (`CoreConfig.ready()` -> `_seed_public_port_from_env`) that pre-fills this setting **once**, at first boot only, for Docker deployments that want to set it at compose-file-write time next to their `ports:` mapping instead of clicking through the admin UI post-deploy. Once anything has configured the setting (env var or UI), the DB value is the permanent source of truth and the env var is ignored on every later startup.

## Related Issue

Closes #1654 (re-filed through the web form after #1652 was auto-closed by the repo's bot for being CLI-submitted)

## How was it tested?

**End-to-end, on a real test instance** (own VM, Postgres+Redis, not a sandbox mock):
- Built this branch as a Docker image and ran it standalone, confirmed HTTP 200 and that a logo endpoint actually served `image/png`.
- Ran the **full Django suite**: `python manage.py test` -> 2192 tests, **1 failure**. Reproduced that exact same failure (`test_m3u_profile_test_catastrophic_regex_returns_quickly`, a ReDoS-timeout assertion in `tests/test_websocket_consumer_filter.py`) against a **freshly built, completely unmodified upstream/dev image**, confirmed pre-existing and unrelated to this change.
- Along the way, the full suite caught two real regressions this PR itself introduced (SimpleTestCase classes in `core/tests/test_core.py` and `apps/output/tests/test_views.py` that broke once `build_absolute_uri_with_port()`/`get_host_and_port()` started reading `CoreSettings.get_public_port()`, a DB query where there used to be none). Fixed by switching those three test classes to `TestCase` and clearing Django's cache in `setUp`/`tearDown` (Redis isn't covered by per-test transaction rollback).
- Ran the **full frontend suite**: `npx vitest run` -> 208 files, **6357 tests, all passing**.
- Ran `npm run lint` (ESLint + Prettier via `eslint-plugin-prettier`) -> 168 pre-existing problems repo-wide, **zero** in any file this PR touches (verified by name: my three changed frontend files don't appear in the output at all, and `SystemSettingsForm.jsx` itself only carries the same `react-hooks/exhaustive-deps` warning every sibling settings-form component already has).
- Manually verified in a Django shell against the running instance: an unconfigured Public Port falls back to the old `SERVER_PORT` behavior unchanged; setting it makes `get_host_and_port()` return that value instead; setting it equal to the scheme's standard port omits it from the URL like every other path in the function; a real reverse proxy's own `X-Forwarded-*` headers still take priority over a stale override; an **untrusted peer sending a spoofed `X-Forwarded-Host`** still gets the correct fallback instead of the spoofed value being honored.
- `DISPATCHARR_PUBLIC_PORT` seeding verified for its three cases: seeds an unset value, does **not** override an already-configured value even when the env var later disagrees, no-ops when absent.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand every change in this PR, line by line, and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed (n/a: `CoreSettings.value` is a `JSONField`, no schema change)
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema (n/a: no new endpoints; `system_settings` is a free-form settings blob, not a rigidly-typed serializer)
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

