### PR TITLE
feat(auth): optional reverse proxy header authentication

### DIFF
--- a/apps/accounts/api_urls.py
+++ b/apps/accounts/api_urls.py
@@ -23,12 +23,15 @@ router.register(r"api-keys", APIKeyViewSet, basename="api-key")
 # 🔹 Custom Authentication Endpoints
 auth_view = AuthViewSet.as_view({"post": "login"})
 
+proxy_login_view = AuthViewSet.as_view({"post": "proxy_login"})
+
 logout_view = AuthViewSet.as_view({"post": "logout"})
 
 # 🔹 Define API URL patterns
 urlpatterns = [
     # Authentication
     path("auth/login/", auth_view, name="user-login"),
+    path("auth/proxy-login/", proxy_login_view, name="user-proxy-login"),
     path("auth/logout/", logout_view, name="user-logout"),
     # Superuser API
     path("initialize-superuser/", initialize_superuser, name="initialize_superuser"),

--- a/apps/accounts/api_views.py
+++ b/apps/accounts/api_views.py
@@ -16,11 +16,18 @@ from dispatcharr.utils import (
     SETUP_ALLOWED_IP_ENV,
     get_client_ip,
     network_access_allowed,
+    proxy_auth_identity,
     setup_ip_allowed,
 )
 
 from .models import User
-from .serializers import UserSerializer, GroupSerializer, PermissionSerializer
+from .serializers import (
+    UserSerializer,
+    GroupSerializer,
+    PermissionSerializer,
+    ProxyLoginResponseSerializer,
+)
+from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 logger = logging.getLogger(__name__)
@@ -51,6 +58,20 @@ def _setup_forbidden_response(client_ip):
         },
         status=403,
     )
+
+
+def _resolve_proxy_auth_user(identity):
+    """Match a proxy-asserted identity by username, then by unambiguous email."""
+    user = User.objects.filter(username__iexact=identity).first()
+    if user is not None:
+        return user
+
+    if "@" in identity:
+        matches = list(User.objects.filter(email__iexact=identity)[:2])
+        if len(matches) == 1:
+            return matches[0]
+
+    return None
 
 
 class TokenObtainPairView(TokenObtainPairView):
@@ -214,6 +235,82 @@ class AuthViewSet(viewsets.ViewSet):
         network access checks are handled there."""
         view = TokenObtainPairView.as_view()
         return view(request._request)
+
+    @extend_schema(
+        description=(
+            "Exchange a reverse-proxy-asserted identity for JWT tokens. "
+            "Returns 401 unless reverse proxy auth is enabled, the request "
+            "carries the configured header, and the connecting peer is a "
+            "trusted proxy. Takes no request body."
+        ),
+        request=None,
+        responses={200: ProxyLoginResponseSerializer},
+    )
+    def proxy_login(self, request):
+        """Sign in the user named by the trusted proxy's header."""
+        from core.utils import log_system_event
+
+        client_ip = get_client_ip(request) or "unknown"
+        user_agent = request.META.get("HTTP_USER_AGENT", "unknown")
+
+        if not network_access_allowed(request, "UI"):
+            logger.info(f"Proxy login blocked by network policy: ip={client_ip}")
+            log_system_event(
+                event_type="login_failed",
+                user="proxy_auth",
+                client_ip=client_ip,
+                user_agent=user_agent,
+                reason="Network access denied",
+            )
+            return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        identity = proxy_auth_identity(request)
+        if not identity:
+            return Response(
+                {"detail": "Reverse proxy authentication unavailable."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        user = _resolve_proxy_auth_user(identity)
+        if user is None or not user.is_active:
+            reason = (
+                "No matching account"
+                if user is None
+                else "Account inactive"
+            )
+            logger.info(
+                f"Proxy login rejected: identity={identity} ip={client_ip} ({reason})"
+            )
+            log_system_event(
+                event_type="login_failed",
+                user=identity,
+                client_ip=client_ip,
+                user_agent=user_agent,
+                reason=f"Reverse proxy auth: {reason.lower()}",
+            )
+            return Response(
+                {"detail": "No account matches the authenticated identity."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        from django.utils import timezone
+
+        refresh = RefreshToken.for_user(user)
+        user.last_login = timezone.now()
+        user.save(update_fields=["last_login"])
+
+        log_system_event(
+            event_type="login_success",
+            user=user.username,
+            client_ip=client_ip,
+            user_agent=user_agent,
+        )
+        logger.info(f"Proxy login success: user={user.username} ip={client_ip}")
+
+        serializer = ProxyLoginResponseSerializer(
+            {"access": str(refresh.access_token), "refresh": str(refresh)}
+        )
+        return Response(serializer.data)
 
     @extend_schema(
         description="Log out the current user",

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -175,3 +175,10 @@ class UserSerializer(serializers.ModelSerializer):
             instance.channel_profiles.set(channel_profiles)
 
         return instance
+
+
+class ProxyLoginResponseSerializer(serializers.Serializer):
+    """JWT pair returned by the reverse proxy sign-in endpoint."""
+
+    access = serializers.CharField()
+    refresh = serializers.CharField()

--- a/apps/accounts/tests/test_reverse_proxy_auth.py
+++ b/apps/accounts/tests/test_reverse_proxy_auth.py
@@ -1,0 +1,137 @@
+"""Reverse proxy header auth: off by default, and only trusted peers count.
+
+The configured header is client-suppliable, so security rests on two checks:
+an admin must enable the setting, and REMOTE_ADDR must be a trusted proxy. If
+either regresses, anyone who can reach the port can sign in as any user.
+"""
+
+import os
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from core.models import CoreSettings, REVERSE_PROXY_AUTH_KEY
+
+User = get_user_model()
+
+PROXY_LOGIN_URL = "/api/accounts/auth/proxy-login/"
+HEADER = "X-Forwarded-User"
+UNTRUSTED_PEER = "203.0.113.7"
+
+
+# Pinned so the suite does not depend on the ambient DISPATCHARR_TRUSTED_PROXIES
+# of whatever host runs it; the test client's REMOTE_ADDR is 127.0.0.1.
+@mock.patch.dict(
+    os.environ, {"DISPATCHARR_TRUSTED_PROXIES": "127.0.0.0/8"}, clear=False
+)
+class ReverseProxyAuthTests(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.api = APIClient()
+        self.user = User.objects.create_user(
+            username="proxyuser",
+            password="unused-password",
+            email="proxy.user@example.com",
+            user_level=10,
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def _configure(self, *, enabled=True, header=HEADER):
+        CoreSettings.objects.update_or_create(
+            key=REVERSE_PROXY_AUTH_KEY,
+            defaults={
+                "name": "Reverse Proxy Auth",
+                "value": {"enabled": enabled, "header": header},
+            },
+        )
+        cache.clear()
+
+    def _post(self, **extra):
+        return self.api.post(PROXY_LOGIN_URL, **extra)
+
+    def test_disabled_by_default_even_with_the_header_present(self):
+        response = self._post(**{"HTTP_X_FORWARDED_USER": "proxyuser"})
+        self.assertEqual(response.status_code, 401)
+
+    def test_enabled_trusted_peer_returns_tokens(self):
+        self._configure()
+        response = self._post(**{"HTTP_X_FORWARDED_USER": "proxyuser"})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("access", response.json())
+        self.assertIn("refresh", response.json())
+
+    def test_header_from_untrusted_peer_is_ignored(self):
+        self._configure()
+        response = self._post(
+            REMOTE_ADDR=UNTRUSTED_PEER, **{"HTTP_X_FORWARDED_USER": "proxyuser"}
+        )
+        self.assertEqual(response.status_code, 401)
+
+    @mock.patch.dict(
+        os.environ, {"DISPATCHARR_TRUSTED_PROXIES": UNTRUSTED_PEER}, clear=False
+    )
+    def test_explicitly_trusted_peer_is_honored(self):
+        self._configure()
+        response = self._post(
+            REMOTE_ADDR=UNTRUSTED_PEER, **{"HTTP_X_FORWARDED_USER": "proxyuser"}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_missing_header_does_not_sign_anyone_in(self):
+        self._configure()
+        self.assertEqual(self._post().status_code, 401)
+
+    def test_unknown_identity_is_rejected(self):
+        self._configure()
+        response = self._post(**{"HTTP_X_FORWARDED_USER": "nobody"})
+        self.assertEqual(response.status_code, 401)
+
+    def test_inactive_user_is_rejected(self):
+        self._configure()
+        self.user.is_active = False
+        self.user.save(update_fields=["is_active"])
+        response = self._post(**{"HTTP_X_FORWARDED_USER": "proxyuser"})
+        self.assertEqual(response.status_code, 401)
+
+    def test_identity_matches_email_for_proxies_that_assert_one(self):
+        self._configure()
+        response = self._post(
+            **{"HTTP_X_FORWARDED_USER": "Proxy.User@Example.com"}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_email_shared_by_two_accounts_matches_nobody(self):
+        self._configure()
+        User.objects.create_user(
+            username="twin",
+            password="unused-password",
+            email="proxy.user@example.com",
+            user_level=10,
+        )
+        response = self._post(
+            **{"HTTP_X_FORWARDED_USER": "proxy.user@example.com"}
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_only_the_configured_header_is_read(self):
+        self._configure(header="X-Auth-Request-User")
+        response = self._post(**{"HTTP_X_FORWARDED_USER": "proxyuser"})
+        self.assertEqual(response.status_code, 401)
+
+        response = self._post(**{"HTTP_X_AUTH_REQUEST_USER": "proxyuser"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_returned_tokens_authenticate_api_calls(self):
+        self._configure()
+        access = self._post(**{"HTTP_X_FORWARDED_USER": "proxyuser"}).json()["access"]
+
+        authed = APIClient()
+        authed.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+        me = authed.get("/api/accounts/users/me/")
+        self.assertEqual(me.status_code, 200)
+        self.assertEqual(me.json()["username"], "proxyuser")

--- a/core/migrations/0028_default_reverse_proxy_auth_settings.py
+++ b/core/migrations/0028_default_reverse_proxy_auth_settings.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+def preload_reverse_proxy_auth_settings(apps, schema_editor):
+    CoreSettings = apps.get_model("core", "CoreSettings")
+    CoreSettings.objects.get_or_create(
+        key="reverse_proxy_auth",
+        defaults={
+            "name": "Reverse Proxy Auth",
+            "value": {"enabled": False, "header": ""},
+        },
+    )
+
+
+def remove_reverse_proxy_auth_settings(apps, schema_editor):
+    CoreSettings = apps.get_model("core", "CoreSettings")
+    CoreSettings.objects.filter(key="reverse_proxy_auth").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0027_vlc_play_and_exit"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            preload_reverse_proxy_auth_settings,
+            remove_reverse_proxy_auth_settings,
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -251,6 +251,7 @@ NETWORK_ACCESS_KEY = "network_access"
 SYSTEM_SETTINGS_KEY = "system_settings"
 EPG_SETTINGS_KEY = "epg_settings"
 USER_LIMITS_SETTINGS_KEY = "user_limit_settings"
+REVERSE_PROXY_AUTH_KEY = "reverse_proxy_auth"
 
 # Redis cache for CoreSettings JSON groups. Primary invalidation is post_save /
 # post_delete; TTL is a safety net if a writer bypasses signals.
@@ -759,6 +760,15 @@ class CoreSettings(models.Model):
     def get_network_access_settings(cls):
         """CIDR allowlists per endpoint type (UI, STREAMS, XC_API, M3U_EPG, ...)."""
         return cls._get_group(NETWORK_ACCESS_KEY, {})
+
+    # Reverse Proxy Auth
+    @classmethod
+    def get_reverse_proxy_auth_settings(cls):
+        """Header-based sign-in handed off by a trusted reverse proxy."""
+        return cls._get_group(REVERSE_PROXY_AUTH_KEY, {
+            "enabled": False,
+            "header": "",
+        })
 
     # System Settings
     @classmethod

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -3,7 +3,8 @@ import json
 import ipaddress
 
 from rest_framework import serializers
-from .models import CoreSettings, UserAgent, StreamProfile, OutputProfile, DVR_SETTINGS_KEY, NETWORK_ACCESS_KEY, SYSTEM_SETTINGS_KEY
+from dispatcharr.utils import validate_proxy_auth_header
+from .models import CoreSettings, UserAgent, StreamProfile, OutputProfile, DVR_SETTINGS_KEY, NETWORK_ACCESS_KEY, SYSTEM_SETTINGS_KEY, REVERSE_PROXY_AUTH_KEY
 
 
 def _clamp_int(value, default, lo, hi):
@@ -88,6 +89,26 @@ class CoreSettingsSerializer(serializers.ModelSerializer):
                     value["log_keep"] = _clamp_int(value["log_keep"], 5, 1, 50)
                 if "log_persist" in value:
                     value["log_persist"] = value["log_persist"] is not False
+
+        if instance.key == REVERSE_PROXY_AUTH_KEY:
+            value = validated_data.get("value") or {}
+            header = (value.get("header") or "").strip()
+            if value.get("enabled") and not header:
+                raise serializers.ValidationError(
+                    {"message": "A header name is required to enable reverse proxy auth."}
+                )
+            if header and not validate_proxy_auth_header(header):
+                raise serializers.ValidationError(
+                    {
+                        "message": (
+                            "Invalid header name. Use letters, digits and dashes "
+                            "only (for example X-Forwarded-User)."
+                        ),
+                        "value": header,
+                    }
+                )
+            value["header"] = header
+            value["enabled"] = bool(value.get("enabled"))
 
         # Sanitize series_rules when DVR settings are saved through the
         # generic settings API (e.g. Settings page round-trip) to prevent

--- a/dispatcharr/utils.py
+++ b/dispatcharr/utils.py
@@ -2,6 +2,7 @@
 import ipaddress
 import logging
 import os
+import re
 
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
@@ -137,6 +138,44 @@ def get_client_ip(request):
             return str(hop_ip)
 
     return str(peer)
+
+
+_PROXY_AUTH_HEADER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,63}$")
+
+
+def validate_proxy_auth_header(header):
+    """Whether a header name is safe to read a proxy-asserted identity from."""
+    return bool(_PROXY_AUTH_HEADER_RE.match((header or "").strip()))
+
+
+def proxy_auth_identity(request):
+    """Username or email asserted for this request by a trusted reverse proxy.
+
+    Returns None unless reverse proxy auth is enabled with a valid header name
+    and the connecting peer is a trusted proxy: the header is client-suppliable,
+    so honoring it from an untrusted peer would let anyone sign in as any user.
+    """
+    config = CoreSettings.get_reverse_proxy_auth_settings()
+    if not config.get("enabled"):
+        return None
+
+    header = (config.get("header") or "").strip()
+    if not validate_proxy_auth_header(header):
+        return None
+
+    peer = _normalize_ip(request.META.get("REMOTE_ADDR") or "")
+    if not _ip_in_trusted(peer):
+        logger.warning(
+            "Ignoring %s from untrusted peer %s; add it to %s to enable "
+            "reverse proxy auth from that host",
+            header,
+            peer,
+            TRUSTED_PROXIES_ENV,
+        )
+        return None
+
+    meta_key = "HTTP_" + header.upper().replace("-", "_")
+    return (request.META.get(meta_key) or "").strip() or None
 
 
 def setup_ip_allowed(request):

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -190,6 +190,18 @@ export default class API {
     }
   }
 
+  static async proxyLogin() {
+    try {
+      const response = await request(`${host}/api/accounts/auth/proxy-login/`, {
+        auth: false,
+        method: 'POST',
+      });
+      return response?.access ? response : null;
+    } catch {
+      return null;
+    }
+  }
+
   static async refreshToken(refresh) {
     try {
       return await request(`${host}/api/accounts/token/refresh/`, {

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -470,7 +470,7 @@ const Sidebar = ({ collapsed, toggleDrawer, drawerWidth, miniDrawerWidth }) => {
                   </UnstyledButton>
                 </Group>
                 <ActionIcon variant="transparent" color="white" size="xs">
-                  <LogOut onClick={logout} />
+                  <LogOut onClick={() => logout({ explicit: true })} />
                 </ActionIcon>
               </Group>
             )}

--- a/frontend/src/components/forms/settings/ReverseProxyAuthForm.jsx
+++ b/frontend/src/components/forms/settings/ReverseProxyAuthForm.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { useForm } from '@mantine/form';
+import { Alert, Button, Flex, Stack, Switch, TextInput } from '@mantine/core';
+import useSettingsStore from '../../../store/settings.jsx';
+import {
+  createSetting,
+  updateSetting,
+} from '../../../utils/pages/SettingsUtils.js';
+
+const SETTING_KEY = 'reverse_proxy_auth';
+const HEADER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]{0,63}$/;
+
+const ReverseProxyAuthForm = React.memo(({ active }) => {
+  const settings = useSettingsStore((s) => s.settings);
+  const fetchSettings = useSettingsStore((s) => s.fetchSettings);
+
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const form = useForm({
+    mode: 'controlled',
+    initialValues: { enabled: false, header: '' },
+    validate: {
+      header: (value, values) => {
+        const header = (value || '').trim();
+        if (values.enabled && !header) {
+          return 'A header name is required to enable reverse proxy auth.';
+        }
+        if (header && !HEADER_PATTERN.test(header)) {
+          return 'Use letters, digits and dashes only (for example X-Forwarded-User).';
+        }
+        return null;
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (!active) {
+      setSaved(false);
+      setError(null);
+    }
+  }, [active]);
+
+  useEffect(() => {
+    const value = settings[SETTING_KEY]?.value || {};
+    form.setValues({
+      enabled: Boolean(value.enabled),
+      header: value.header || '',
+    });
+  }, [settings]);
+
+  const onSubmit = async () => {
+    setSaved(false);
+    setError(null);
+    setSaving(true);
+
+    const values = form.getValues();
+    const value = {
+      enabled: Boolean(values.enabled),
+      header: (values.header || '').trim(),
+    };
+
+    try {
+      const existing = settings[SETTING_KEY];
+      if (existing?.id) {
+        await updateSetting({ ...existing, value });
+      } else {
+        await createSetting({
+          key: SETTING_KEY,
+          name: 'Reverse Proxy Auth',
+          value,
+        });
+      }
+      await fetchSettings();
+      setSaved(true);
+    } catch (e) {
+      setError(
+        e?.body?.message || 'Failed to save reverse proxy auth settings.'
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Stack gap="md">
+      {saved && (
+        <Alert variant="light" color="green" title="Saved Successfully" />
+      )}
+      {error && (
+        <Alert variant="light" color="red" title="Save Failed">
+          {error}
+        </Alert>
+      )}
+      <Alert variant="light" color="yellow" title="Trust your proxy first">
+        Anything that can reach Dispatcharr directly can send this header. It is
+        only honored when the request arrives from a trusted proxy — private and
+        loopback ranges by default, or the list in DISPATCHARR_TRUSTED_PROXIES.
+        Make sure your proxy strips the header from inbound requests and sets it
+        itself.
+      </Alert>
+      <Switch
+        label="Enable Reverse Proxy Authentication"
+        description="Sign users in from an identity header set by an authenticating proxy such as Cloudflare Access, oauth2-proxy, or Authelia, instead of showing the login form."
+        {...form.getInputProps('enabled', { type: 'checkbox' })}
+        id="reverse_proxy_auth_enabled"
+      />
+      <TextInput
+        label="Identity Header"
+        description="Header carrying the authenticated username. An email address is also accepted when it matches exactly one account. Examples: X-Forwarded-User, X-Auth-Request-User, Cf-Access-Authenticated-User-Email."
+        placeholder="X-Forwarded-User"
+        {...form.getInputProps('header')}
+        id="reverse_proxy_auth_header"
+      />
+      <Flex mih={50} gap="xs" justify="flex-end" align="flex-end">
+        <Button
+          onClick={form.onSubmit(onSubmit)}
+          disabled={saving}
+          variant="default"
+        >
+          Save
+        </Button>
+      </Flex>
+    </Stack>
+  );
+});
+
+export default ReverseProxyAuthForm;

--- a/frontend/src/components/forms/settings/__tests__/ReverseProxyAuthForm.test.jsx
+++ b/frontend/src/components/forms/settings/__tests__/ReverseProxyAuthForm.test.jsx
@@ -1,0 +1,238 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Store mocks ────────────────────────────────────────────────────────────────
+vi.mock('../../../../store/settings.jsx', () => ({ default: vi.fn() }));
+
+// ── Utility mocks ──────────────────────────────────────────────────────────────
+vi.mock('../../../../utils/pages/SettingsUtils.js', () => ({
+  createSetting: vi.fn(),
+  updateSetting: vi.fn(),
+}));
+
+// ── Mantine form ───────────────────────────────────────────────────────────────
+vi.mock('@mantine/form', () => ({
+  useForm: vi.fn(),
+}));
+
+// ── Mantine core ───────────────────────────────────────────────────────────────
+vi.mock('@mantine/core', () => ({
+  Alert: ({ title, children }) => (
+    <div data-testid="alert">
+      <strong>{title}</strong>
+      {children ? <div>{children}</div> : null}
+    </div>
+  ),
+  Button: ({ children, onClick, disabled }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  Flex: ({ children }) => <div>{children}</div>,
+  Stack: ({ children }) => <div>{children}</div>,
+  Switch: ({ label, description, id }) => (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <p>{description}</p>
+      <input data-testid={id} id={id} type="checkbox" onChange={() => {}} />
+    </div>
+  ),
+  TextInput: ({ label, description, id, placeholder }) => (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <p>{description}</p>
+      <input data-testid={id} id={id} placeholder={placeholder} />
+    </div>
+  ),
+}));
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Imports after mocks
+// ──────────────────────────────────────────────────────────────────────────────
+import ReverseProxyAuthForm from '../ReverseProxyAuthForm';
+import useSettingsStore from '../../../../store/settings.jsx';
+import {
+  createSetting,
+  updateSetting,
+} from '../../../../utils/pages/SettingsUtils.js';
+import { useForm } from '@mantine/form';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+const setupMocks = ({ settings = {}, formValues = {} } = {}) => {
+  const values = { enabled: false, header: '', ...formValues };
+
+  const formMock = {
+    values,
+    getValues: vi.fn().mockReturnValue(values),
+    setValues: vi.fn(),
+    getInputProps: vi.fn((field, opts) =>
+      opts?.type === 'checkbox'
+        ? { checked: values[field] ?? false, onChange: vi.fn() }
+        : { value: values[field] ?? '', onChange: vi.fn() }
+    ),
+    onSubmit: vi.fn((handler) => handler),
+  };
+
+  const fetchSettings = vi.fn().mockResolvedValue(undefined);
+
+  vi.mocked(useForm).mockReturnValue(formMock);
+  vi.mocked(useSettingsStore).mockImplementation((sel) =>
+    sel({ settings, fetchSettings })
+  );
+
+  return { formMock, fetchSettings };
+};
+
+const EXISTING_SETTING = {
+  reverse_proxy_auth: {
+    id: 7,
+    key: 'reverse_proxy_auth',
+    name: 'Reverse Proxy Auth',
+    value: { enabled: true, header: 'X-Forwarded-User' },
+  },
+};
+
+describe('ReverseProxyAuthForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders the enable switch and header input', () => {
+      setupMocks();
+      render(<ReverseProxyAuthForm active={true} />);
+
+      expect(
+        screen.getByTestId('reverse_proxy_auth_enabled')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('reverse_proxy_auth_header')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Save')).toBeInTheDocument();
+    });
+
+    it('warns that the header is only trusted from a trusted proxy', () => {
+      setupMocks();
+      render(<ReverseProxyAuthForm active={true} />);
+
+      expect(screen.getByText('Trust your proxy first')).toBeInTheDocument();
+    });
+
+    it('seeds the form from the stored setting', () => {
+      const { formMock } = setupMocks({ settings: EXISTING_SETTING });
+      render(<ReverseProxyAuthForm active={true} />);
+
+      expect(formMock.setValues).toHaveBeenCalledWith({
+        enabled: true,
+        header: 'X-Forwarded-User',
+      });
+    });
+
+    it('falls back to disabled with no header when the setting is missing', () => {
+      const { formMock } = setupMocks();
+      render(<ReverseProxyAuthForm active={true} />);
+
+      expect(formMock.setValues).toHaveBeenCalledWith({
+        enabled: false,
+        header: '',
+      });
+    });
+  });
+
+  describe('validation', () => {
+    const getValidator = () => {
+      setupMocks();
+      render(<ReverseProxyAuthForm active={true} />);
+      return vi.mocked(useForm).mock.calls[0][0].validate.header;
+    };
+
+    it('requires a header name when enabling', () => {
+      expect(getValidator()('', { enabled: true })).toMatch(/required/i);
+    });
+
+    it('allows an empty header while disabled', () => {
+      expect(getValidator()('', { enabled: false })).toBeNull();
+    });
+
+    it('accepts a conventional header name', () => {
+      expect(getValidator()('X-Forwarded-User', { enabled: true })).toBeNull();
+    });
+
+    it('rejects a header name containing an underscore', () => {
+      expect(getValidator()('Remote_User', { enabled: true })).toMatch(
+        /letters, digits and dashes/i
+      );
+    });
+  });
+
+  describe('saving', () => {
+    it('updates the existing setting with a trimmed header', async () => {
+      setupMocks({
+        settings: EXISTING_SETTING,
+        formValues: { enabled: true, header: '  X-Auth-Request-User  ' },
+      });
+      vi.mocked(updateSetting).mockResolvedValue({});
+
+      render(<ReverseProxyAuthForm active={true} />);
+      fireEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        expect(updateSetting).toHaveBeenCalledWith({
+          ...EXISTING_SETTING.reverse_proxy_auth,
+          value: { enabled: true, header: 'X-Auth-Request-User' },
+        });
+      });
+      expect(createSetting).not.toHaveBeenCalled();
+    });
+
+    it('creates the setting when no row exists yet', async () => {
+      setupMocks({ formValues: { enabled: true, header: 'X-Forwarded-User' } });
+      vi.mocked(createSetting).mockResolvedValue({});
+
+      render(<ReverseProxyAuthForm active={true} />);
+      fireEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        expect(createSetting).toHaveBeenCalledWith({
+          key: 'reverse_proxy_auth',
+          name: 'Reverse Proxy Auth',
+          value: { enabled: true, header: 'X-Forwarded-User' },
+        });
+      });
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it('refreshes settings after a successful save', async () => {
+      const { fetchSettings } = setupMocks({
+        settings: EXISTING_SETTING,
+        formValues: { enabled: true, header: 'X-Forwarded-User' },
+      });
+      vi.mocked(updateSetting).mockResolvedValue({});
+
+      render(<ReverseProxyAuthForm active={true} />);
+      fireEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => expect(fetchSettings).toHaveBeenCalled());
+      expect(screen.getByText('Saved Successfully')).toBeInTheDocument();
+    });
+
+    it('surfaces the error message returned by the backend', async () => {
+      setupMocks({
+        settings: EXISTING_SETTING,
+        formValues: { enabled: true, header: 'X-Forwarded-User' },
+      });
+      const failure = new Error('rejected');
+      failure.body = { message: 'Invalid header name.' };
+      vi.mocked(updateSetting).mockRejectedValue(failure);
+
+      render(<ReverseProxyAuthForm active={true} />);
+      fireEvent.click(screen.getByText('Save'));
+
+      await waitFor(() =>
+        expect(screen.getByText('Invalid header name.')).toBeInTheDocument()
+      );
+    });
+  });
+});

--- a/frontend/src/config/settingsNav.js
+++ b/frontend/src/config/settingsNav.js
@@ -3,6 +3,7 @@ import {
   ArrowLeftRight,
   DatabaseBackup,
   FileOutput,
+  KeyRound,
   Menu,
   Monitor,
   Network,
@@ -25,6 +26,7 @@ const UserAgentsTable = lazy(() => import('../components/tables/UserAgentsTable.
 const NetworkAccessForm = lazy(() => import('../components/forms/settings/NetworkAccessForm.jsx'));
 const SystemSettingsForm = lazy(() => import('../components/forms/settings/SystemSettingsForm.jsx'));
 const UserLimitsForm = lazy(() => import('../components/forms/settings/UserLimitsForm.jsx'));
+const ReverseProxyAuthForm = lazy(() => import('../components/forms/settings/ReverseProxyAuthForm.jsx'));
 const BackupManager = lazy(() => import('../components/backups/BackupManager.jsx'));
 
 // Component lives on each section so it can never drift out of sync with the
@@ -74,6 +76,7 @@ export const SETTINGS_GROUPS = [
     adminOnly: true,
     sections: [
       { id: 'system-settings', label: 'System Settings', icon: Settings2, Component: SystemSettingsForm },
+      { id: 'reverse-proxy-auth', label: 'Reverse Proxy Auth', icon: KeyRound, Component: ReverseProxyAuthForm },
       { id: 'user-limits', label: 'User Limits', icon: Users, Component: UserLimitsForm },
     ],
   },

--- a/frontend/src/store/__tests__/auth.test.jsx
+++ b/frontend/src/store/__tests__/auth.test.jsx
@@ -685,4 +685,133 @@ describe('useAuthStore', () => {
       expect(fetchChannelIdsSpy).toHaveBeenCalled();
     });
   });
+
+  describe('proxyLogin', () => {
+    beforeEach(() => {
+      useAuthStore.setState({ proxyAuthOptOut: false });
+    });
+
+    it('should store the tokens returned for a proxy-asserted identity', async () => {
+      const mockToken = createMockToken();
+      API.proxyLogin.mockResolvedValue({
+        access: mockToken,
+        refresh: 'proxy-refresh-token',
+      });
+
+      const { result } = renderHook(() => useAuthStore());
+
+      let signedIn;
+      await act(async () => {
+        signedIn = await result.current.proxyLogin();
+      });
+
+      expect(signedIn).toBe(true);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'accessToken',
+        mockToken
+      );
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'refreshToken',
+        'proxy-refresh-token'
+      );
+    });
+
+    it('should report failure when the proxy asserted nothing', async () => {
+      API.proxyLogin.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useAuthStore());
+
+      let signedIn;
+      await act(async () => {
+        signedIn = await result.current.proxyLogin();
+      });
+
+      expect(signedIn).toBe(false);
+    });
+
+    it('should sign in again once the page reloads after an explicit logout', async () => {
+      API.logout.mockResolvedValue();
+      API.proxyLogin.mockResolvedValue({
+        access: createMockToken(),
+        refresh: 'proxy-refresh-token',
+      });
+
+      const { result } = renderHook(() => useAuthStore());
+
+      await act(async () => {
+        await result.current.logout({ explicit: true });
+      });
+
+      // A reload rebuilds the store, which is what clears the opt-out.
+      useAuthStore.setState({ proxyAuthOptOut: false });
+
+      let signedIn;
+      await act(async () => {
+        signedIn = await result.current.proxyLogin();
+      });
+
+      expect(signedIn).toBe(true);
+    });
+
+    it('should not sign the user back in after an explicit logout', async () => {
+      API.logout.mockResolvedValue();
+      API.proxyLogin.mockResolvedValue({
+        access: createMockToken(),
+        refresh: 'proxy-refresh-token',
+      });
+
+      const { result } = renderHook(() => useAuthStore());
+
+      await act(async () => {
+        await result.current.logout({ explicit: true });
+      });
+
+      let signedIn;
+      await act(async () => {
+        signedIn = await result.current.proxyLogin();
+      });
+
+      expect(signedIn).toBe(false);
+      expect(API.proxyLogin).not.toHaveBeenCalled();
+    });
+
+    it('should still sign in after a session-expiry logout', async () => {
+      API.logout.mockResolvedValue();
+      API.proxyLogin.mockResolvedValue({
+        access: createMockToken(),
+        refresh: 'proxy-refresh-token',
+      });
+
+      const { result } = renderHook(() => useAuthStore());
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      let signedIn;
+      await act(async () => {
+        signedIn = await result.current.proxyLogin();
+      });
+
+      expect(signedIn).toBe(true);
+    });
+
+    it('should be attempted by initializeAuth when no refresh token exists', async () => {
+      localStorageMock.getItem.mockReturnValue(null);
+      API.proxyLogin.mockResolvedValue({
+        access: createMockToken(),
+        refresh: 'proxy-refresh-token',
+      });
+
+      const { result } = renderHook(() => useAuthStore());
+
+      let initialized;
+      await act(async () => {
+        initialized = await result.current.initializeAuth();
+      });
+
+      expect(initialized).toBe(true);
+      expect(API.proxyLogin).toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/store/auth.jsx
+++ b/frontend/src/store/auth.jsx
@@ -24,11 +24,24 @@ const isTokenExpired = (expirationTime) => {
   return now >= expirationTime;
 };
 
+const storeTokens = (set, response) => {
+  const expiration = decodeToken(response.access);
+  set({
+    accessToken: response.access,
+    refreshToken: response.refresh,
+    tokenExpiration: expiration,
+  });
+  localStorage.setItem('accessToken', response.access);
+  localStorage.setItem('refreshToken', response.refresh);
+  localStorage.setItem('tokenExpiration', expiration);
+};
+
 const useAuthStore = create((set, get) => ({
   isAuthenticated: false,
   isInitialized: false,
   isInitializing: false,
   isCheckingAuth: true,
+  proxyAuthOptOut: false,
   user: {
     username: '',
     email: '',
@@ -180,22 +193,28 @@ const useAuthStore = create((set, get) => ({
     try {
       const response = await API.login(username, password);
       if (response.access) {
-        const expiration = decodeToken(response.access);
-        set({
-          accessToken: response.access,
-          refreshToken: response.refresh,
-          tokenExpiration: expiration, // 1 hour from now
-        });
-        // Store in localStorage
-        localStorage.setItem('accessToken', response.access);
-        localStorage.setItem('refreshToken', response.refresh);
-        localStorage.setItem('tokenExpiration', expiration);
+        set({ proxyAuthOptOut: false });
+        storeTokens(set, response);
 
         // Don't start background loading here - let it happen after app initialization
       }
     } catch (error) {
       console.error('Login failed:', error);
     }
+  },
+
+  proxyLogin: async () => {
+    if (get().proxyAuthOptOut) {
+      return false;
+    }
+
+    const response = await API.proxyLogin();
+    if (!response) {
+      return false;
+    }
+
+    storeTokens(set, response);
+    return true;
   },
 
   // Action to refresh the token
@@ -223,8 +242,13 @@ const useAuthStore = create((set, get) => ({
     }
   },
 
-  // Action to logout
-  logout: async () => {
+  // Opting out lasts until the page is reloaded: an explicit logout should show
+  // the login form, but a later visit signs in through the proxy again.
+  logout: async ({ explicit = false } = {}) => {
+    if (explicit) {
+      set({ proxyAuthOptOut: true });
+    }
+
     // Call backend logout endpoint to log the event
     try {
       await API.logout();
@@ -258,7 +282,8 @@ const useAuthStore = create((set, get) => ({
       }
     }
 
-    return false;
+    set({ isCheckingAuth: true });
+    return await get().proxyLogin();
   },
 }));
 


### PR DESCRIPTION
## Description

Adds an opt-in "Reverse Proxy Auth" setting under Settings -> System that signs a user in from an identity header asserted by an authenticating reverse proxy, so instances already sitting behind Cloudflare Access, oauth2-proxy, Authelia or similar do not present a second login form.

The header is only honored when an admin has enabled the setting AND the connecting peer is a trusted proxy (DISPATCHARR_TRUSTED_PROXIES, which already defaults to private and loopback ranges), because the header is otherwise client-suppliable. Identities resolve to a username first, then to an email matching exactly one account, so proxies that assert an email work without renaming accounts.

POST /api/accounts/auth/proxy-login/ exchanges the header for the same JWT pair as password login and returns 401 whenever proxy auth is unavailable, so the web UI probes it on load and silently falls back to the password form. initializeAuth retries it when a refresh token has expired, which otherwise leaves the SPA stranded until a manual reload. An explicit logout opts out until the page is reloaded so the logout button still does something visible.

## Related Issue
Closes https://github.com/Dispatcharr/Dispatcharr/issues/1644

## How was it tested?

### Backend — `apps/accounts/tests/test_reverse_proxy_auth.py` (11 new tests)

| Test | Asserts |
| --- | --- |
| `test_disabled_by_default_even_with_the_header_present` | 401 — the feature is inert until an admin enables it |
| `test_enabled_trusted_peer_returns_tokens` | 200 with `access` + `refresh` |
| `test_header_from_untrusted_peer_is_ignored` | 401 when `REMOTE_ADDR` is outside the trusted set |
| `test_explicitly_trusted_peer_is_honored` | 200 once that peer is added to `DISPATCHARR_TRUSTED_PROXIES` |
| `test_missing_header_does_not_sign_anyone_in` | 401 when the header is absent |
| `test_unknown_identity_is_rejected` | 401 for an identity with no account |
| `test_inactive_user_is_rejected` | 401 for `is_active=False` |
| `test_identity_matches_email_for_proxies_that_assert_one` | case-insensitive email match |
| `test_email_shared_by_two_accounts_matches_nobody` | 401 — an ambiguous email never resolves |
| `test_only_the_configured_header_is_read` | a different header is ignored; the configured one works |
| `test_returned_tokens_authenticate_api_calls` | the issued access token authenticates `GET /api/accounts/users/me/` |

### Frontend — 18 new tests

`store/__tests__/auth.test.jsx` (6): tokens stored for a proxy-asserted identity · failure reported when the proxy asserts nothing · no sign-in after an explicit logout · sign-in again once the page reloads · still signs in after a session-expiry logout · attempted by `initializeAuth` when no refresh token exists.

`components/forms/settings/__tests__/ReverseProxyAuthForm.test.jsx` (12):

- **Rendering:** enable switch and header input present; the trusted-proxy warning is shown; the form seeds from the stored setting; falls back to disabled/empty when the setting row is missing.
- **Validation:** a header is required when enabling; empty is allowed while disabled; a conventional name is accepted; a name containing an underscore is rejected.
- **Saving:** updates an existing row with a trimmed header; creates the row when none exists; refreshes settings and shows the success banner; surfaces the backend's error message on failure.

### Manually, on a live instance behind an authenticating proxy
Enabled the setting and confirmed the browser lands straight in the UI with no login form; a request without the header returns 401; a spoofed header from an untrusted peer is rejected and logs `Ignoring <header> from untrusted peer`; and after narrowing `DISPATCHARR_TRUSTED_PROXIES` to the single proxy address, sign-in still works while a spoof from any other container is refused.

## UI Changes
<img width="400" height="760" alt="image" src="https://github.com/user-attachments/assets/b6da134e-91d8-4415-bb5c-c933a6bd0c6c" />
<img width="1869" height="710" alt="image" src="https://github.com/user-attachments/assets/09cdf2b1-107c-4636-894c-517b3c62e20b" />


## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [x] Backend: migrations are included if any models were changed
- [x] Backend: new API endpoints appear correctly in the OpenAPI schema
- [x] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [x] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change
