### PR TITLE
docs: explain DISPATCHARR_PORT for asymmetric host port remaps without a reverse proxy

### DIFF
--- a/docker/docker-compose.aio.yml
+++ b/docker/docker-compose.aio.yml
@@ -15,16 +15,10 @@ services:
       - REDIS_HOST=localhost
       - CELERY_BROKER_URL=redis://localhost:6379/0
       - DISPATCHARR_LOG_LEVEL=info
-      # Port the app listens on internally (Optional, default: 9191). Only needed
-      # if you're mapping a DIFFERENT host port above (e.g. "80:80" or "8080:8080")
-      # AND have NO reverse proxy in front of Dispatcharr. Without a reverse proxy,
-      # generated URLs (logos, M3U/EPG, VOD posters, catch-up) fall back to the
-      # port the app sees itself on, which is 9191 unless you set this to match
-      # your host-side port. If you do have a reverse proxy in front (Traefik,
-      # nginx, Caddy, etc.), it already forwards the real host/port and this is
-      # not needed. Must be set to the SAME value on both sides of the ports:
-      # mapping above (e.g. DISPATCHARR_PORT=8080 with "8080:8080").
+      # Port nginx listens on (default 9191). Must match the container port in
+      # ports: above (e.g. DISPATCHARR_PORT=8080 with "8080:8080").
       #- DISPATCHARR_PORT=9191
+
       # Redis idle-client timeout in seconds, and per-process redis-py /
       # django-redis pool cap (Optional, defaults: 300 / 50)
       #- REDIS_IDLE_TIMEOUT=300

--- a/docker/docker-compose.aio.yml
+++ b/docker/docker-compose.aio.yml
@@ -15,6 +15,16 @@ services:
       - REDIS_HOST=localhost
       - CELERY_BROKER_URL=redis://localhost:6379/0
       - DISPATCHARR_LOG_LEVEL=info
+      # Port the app listens on internally (Optional, default: 9191). Only needed
+      # if you're mapping a DIFFERENT host port above (e.g. "80:80" or "8080:8080")
+      # AND have NO reverse proxy in front of Dispatcharr. Without a reverse proxy,
+      # generated URLs (logos, M3U/EPG, VOD posters, catch-up) fall back to the
+      # port the app sees itself on, which is 9191 unless you set this to match
+      # your host-side port. If you do have a reverse proxy in front (Traefik,
+      # nginx, Caddy, etc.), it already forwards the real host/port and this is
+      # not needed. Must be set to the SAME value on both sides of the ports:
+      # mapping above (e.g. DISPATCHARR_PORT=8080 with "8080:8080").
+      #- DISPATCHARR_PORT=9191
       # Redis idle-client timeout in seconds, and per-process redis-py /
       # django-redis pool cap (Optional, defaults: 300 / 50)
       #- REDIS_IDLE_TIMEOUT=300


### PR DESCRIPTION
## Description

Adds a comment explaining `DISPATCHARR_PORT` to `docker/docker-compose.aio.yml`, next to the `ports:` mapping. Follow-up to #1653: that PR added a new setting to solve the same problem this env var already solves, it just wasn't documented anywhere an AIO user would see it (only mentioned in the modular compose file, and even there framed purely as a Celery-to-web detail, not as something that also fixes generated URLs when there's no reverse proxy).

No code changes, docs only.

## Related Issue

Closes #1654.

## How was it tested?

Verified the behavior it documents is real, on a throwaway container built from the current `dev` image: with `DISPATCHARR_PORT` unset and an asymmetric host mapping (`80:9191`), `get.php` bakes the internal `:9191` into every generated URL, dead on arrival since nothing listens on 9191 externally. With `DISPATCHARR_PORT=80` and a matching `80:80` mapping, generated URLs are correct with no port at all (HTTP default). Also checked `DISPATCHARR_PORT=7575` with a matching `7575:7575` mapping, correctly bakes in `:7575`, so this isn't limited to well-known ports.

`docker/docker-compose.aio.yml` was validated as parseable YAML after the change.

## Checklist

Please check every item before marking this PR as ready for review. Unchecked items will be flagged during review.

- [x] I have read the [CONTRIBUTING.md](../blob/dev/CONTRIBUTING.md) in full
- [x] I agree to the [Contributor License Agreement](../blob/dev/CONTRIBUTING.md#contributor-license-agreement)
- [x] I understand — line by line — every change in this PR and can explain it if asked
- [x] This PR targets the `dev` branch
- [ ] Backend: migrations are included if any models were changed
- [ ] Backend: new API endpoints appear correctly in the OpenAPI schema
- [ ] Frontend: ESLint and Prettier pass cleanly (`npm run lint`, `npm run format`)
- [ ] Tests are included for new functionality
- [x] Existing tests still pass
- [x] No `console.log`, `print()`, debug statements, or commented-out code is left in the diff
- [x] I have not reformatted or refactored code outside the scope of this change

Docs-only change: no models, no API endpoints, no frontend code, and no new functionality needing tests, so the four unchecked items above don't apply here.
